### PR TITLE
Add tools for inspecting state.

### DIFF
--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -152,7 +152,6 @@ class RegressionModel : public ParameterHandlingMixin {
   virtual PredictionDistribution predict_(
       const std::vector<Predictor> &predictors) const = 0;
 
- private:
   bool has_been_fit_ = false;
 };
 

--- a/albatross/covariance_functions/covariance_base.h
+++ b/albatross/covariance_functions/covariance_base.h
@@ -7,17 +7,45 @@
 
 namespace albatross {
 
-template <class Predictor>
+/*
+ * This struct determines whether or not a class has a method defined for,
+ *   `operator() (First &first, Second &second, ...)`
+ * The result of the inspection gets stored in the member `value`.
+ */
+template <typename T, typename... Args>
+class has_call_operator
+{
+    template <typename C,
+              typename = decltype( std::declval<C>()(std::declval<Args>()...))>
+    static std::true_type test(int);
+    template <typename C>
+    static std::false_type test(...);
+
+public:
+    static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+
+/*
+ * An abstract class (though no purely abstract due to templating)
+ * which holds anything all Covariance terms should have in common.
+ */
 class CovarianceBase : public ParameterHandlingMixin {
  public:
   CovarianceBase() : ParameterHandlingMixin(){};
   virtual ~CovarianceBase(){};
 
-  virtual double operator()(const Predictor &x, const Predictor &y) const = 0;
+  template<typename First, typename Second>
+  double operator()(const First &first, const Second &second) const;
 };
 
-template <class X, class Y, class Predictor>
-class CombinationOfCovariances : public CovarianceBase<Predictor> {
+/*
+ * As we start composing Covariance objects we want to keep track of
+ * their parameters and names in a friendly way.  This class deals with
+ * any of those operations that are shared for all composition operations.
+ */
+template <class X, class Y>
+class CombinationOfCovariances : public CovarianceBase {
  public:
   CombinationOfCovariances(X &x, Y &y) : x_(x), y_(y){};
   virtual ~CombinationOfCovariances(){};
@@ -45,34 +73,132 @@ class CombinationOfCovariances : public CovarianceBase<Predictor> {
   }
 
  protected:
+
   X x_;
   Y y_;
 };
 
-template <class X, class Y, class Predictor>
-class SumOfCovariance : public CombinationOfCovariances<X, Y, Predictor> {
+
+template <class X, class Y>
+class SumOfCovariance : public CombinationOfCovariances<X, Y> {
  public:
   SumOfCovariance(X &x, Y &y)
-      : CombinationOfCovariances<X, Y, Predictor>(x, y){};
+      : CombinationOfCovariances<X, Y>(x, y){};
 
   std::string get_operation_symbol() const { return "+"; }
 
-  double operator()(const Predictor &x, const Predictor &y) const override {
-    return this->x_(x, y) + this->y_(x, y);
+  /*
+   * If both X and Y have a valid call method for the types First and Second
+   * this will return the sum of the two.
+   */
+  template <typename First,
+            typename Second,
+            typename std::enable_if<(has_call_operator<X, First&, Second&>::value &&
+                                     has_call_operator<Y, First&, Second&>::value),
+                                    int>::type = 0>
+  double operator() (First &first, Second &second) const {
+    return this->x_(first, second) + this->y_(first, second);
   }
+
+  /*
+   * If only X has a valid call method we ignore Y.
+   */
+  template <typename First,
+            typename Second,
+            typename std::enable_if<(has_call_operator<X, First&, Second&>::value &&
+                                     !has_call_operator<Y, First&, Second&>::value),
+                                    int>::type = 0>
+  double operator() (First &first, Second &second) const {
+    std::cout << "sum[x]" << std::endl;
+    return this->x_(first, second);
+  }
+
+  /*
+   * If only Y has a valid call method we ignore X.
+   */
+  template <typename First,
+            typename Second,
+            typename std::enable_if<(!has_call_operator<X, First&, Second&>::value &&
+                                     has_call_operator<Y, First&, Second&>::value),
+                                    int>::type = 0>
+  double operator() (First &first, Second &second) const {
+    std::cout << "sum[y]" << std::endl;
+    return this->y_(first, second);
+  }
+
+  /*
+   * If neither have a valid call method we assume zero correlation.
+   */
+  template <typename First,
+            typename Second,
+            typename std::enable_if<(!has_call_operator<X, First&, Second&>::value &&
+                                     !has_call_operator<Y, First&, Second&>::value),
+                                    int>::type = 0>
+  double operator() (First &first, Second &second) const {
+    std::cout << "sum[]" << std::endl;
+    return 0.;
+  }
+
+
 };
 
-template <class X, class Y, class Predictor>
-class ProductOfCovariance : public CombinationOfCovariances<X, Y, Predictor> {
+template <class X, class Y>
+class ProductOfCovariance : public CombinationOfCovariances<X, Y> {
  public:
   ProductOfCovariance(X &x, Y &y)
-      : CombinationOfCovariances<X, Y, Predictor>(x, y){};
+      : CombinationOfCovariances<X, Y>(x, y){};
 
   std::string get_operation_symbol() const { return "*"; }
 
-  double operator()(const Predictor &x, const Predictor &y) const override {
-    return this->x_(x, y) * this->y_(x, y);
+  /*
+   * If both X and Y have a valid call method for the types First and Second
+   * this will return the sum of the two.
+   */
+  template <typename First,
+            typename Second,
+            typename std::enable_if<(has_call_operator<X, First&, Second&>::value &&
+                                     has_call_operator<Y, First&, Second&>::value),
+                                    int>::type = 0>
+  double operator() (First &first, Second &second) const {
+    return this->x_(first, second) * this->y_(first, second);
   }
+
+  /*
+   * If only X has a valid call method we ignore Y.
+   */
+  template <typename First,
+            typename Second,
+            typename std::enable_if<(has_call_operator<X, First&, Second&>::value &&
+                                     !has_call_operator<Y, First&, Second&>::value),
+                                    int>::type = 0>
+  double operator() (First &first, Second &second) const {
+    return this->x_(first, second);
+  }
+
+  /*
+   * If only Y has a valid call method we ignore X.
+   */
+  template <typename First,
+            typename Second,
+            typename std::enable_if<(!has_call_operator<X, First&, Second&>::value &&
+                                     has_call_operator<Y, First&, Second&>::value),
+                                    int>::type = 0>
+  double operator() (First &first, Second &second) const {
+    return this->y_(first, second);
+  }
+
+  /*
+   * If neither have a valid call method we assume zero correlation.
+   */
+  template <typename First,
+            typename Second,
+            typename std::enable_if<(!has_call_operator<X, First&, Second&>::value &&
+                                     !has_call_operator<Y, First&, Second&>::value),
+                                    int>::type = 0>
+  double operator() (First &first, Second &second) const {
+    return 0.;
+  }
+
 };
 
 }  // albatross

--- a/albatross/covariance_functions/distance_metrics.h
+++ b/albatross/covariance_functions/distance_metrics.h
@@ -2,16 +2,14 @@
 #define GP_DISTANCE_H
 
 #include "core/parameter_handler.h"
+#include <Eigen/Core>
 
 namespace albatross {
 
-template <class Predictor>
 class DistanceMetric : public ParameterHandlingMixin {
  public:
   DistanceMetric(){};
   virtual ~DistanceMetric(){};
-
-  virtual double operator()(const Predictor &x, const Predictor &y) const = 0;
 
   //  virtual double gradient(const Predictor &x, const Predictor &y,
   //                          const Eigen::VectorXd &grad) = 0;
@@ -27,28 +25,26 @@ class DistanceMetric : public ParameterHandlingMixin {
  protected:
 };
 
-template <class Predictor>
-class EuclideanDistance : public DistanceMetric<Predictor> {
+class EuclideanDistance : public DistanceMetric {
  public:
   EuclideanDistance(){};
   ~EuclideanDistance(){};
 
   std::string get_name() const override { return "euclidean"; };
 
-  double operator()(const Predictor &x, const Predictor &y) const {
+  double operator()(const Eigen::VectorXd &x, const Eigen::VectorXd &y) const {
     return (x - y).norm();
   }
 };
 
-template <class Predictor>
-class RadialDistance : public DistanceMetric<Predictor> {
+class RadialDistance : public DistanceMetric {
  public:
   RadialDistance(){};
   ~RadialDistance(){};
 
   std::string get_name() const override { return "radial"; };
 
-  double operator()(const Predictor &x, const Predictor &y) const {
+  double operator()(const Eigen::VectorXd &x, const Eigen::VectorXd &y) const {
     return fabs(x.norm() - y.norm());
   }
 };

--- a/albatross/covariance_functions/noise.h
+++ b/albatross/covariance_functions/noise.h
@@ -5,8 +5,8 @@
 
 namespace albatross {
 
-template <class Predictor>
-class IndependentNoise : public CovarianceBase<Predictor> {
+template <typename Observed>
+class IndependentNoise : public CovarianceBase {
  public:
   IndependentNoise(double sigma_noise = 0.1) {
     this->params_["sigma_independent_noise"] = sigma_noise;
@@ -17,9 +17,10 @@ class IndependentNoise : public CovarianceBase<Predictor> {
   std::string get_name() const { return "independent_noise"; }
 
   /*
-   * This will create a scaled identity matrix.
+   * This will create a scaled identity matrix, but only between
+   * two different observations defined by the Observed type.
    */
-  double operator()(const Predictor &x, const Predictor &y) const override {
+  double operator()(const Observed &x, const Observed &y) const {
     if (x == y) {
       double sigma_noise = this->params_.at("sigma_independent_noise");
       return sigma_noise * sigma_noise;

--- a/albatross/covariance_functions/polynomials.h
+++ b/albatross/covariance_functions/polynomials.h
@@ -17,8 +17,9 @@
 
 namespace albatross {
 
-template <class Predictor>
-class ConstantMean : public CovarianceBase<Predictor> {
+struct MeanTerm {};
+
+class ConstantMean : public CovarianceBase {
  public:
   ConstantMean(double sigma_mean = 10.) {
     this->params_["sigma_constant_mean"] = sigma_mean;
@@ -28,17 +29,25 @@ class ConstantMean : public CovarianceBase<Predictor> {
 
   std::string get_name() const { return "constant_mean"; }
 
+  template <typename Predictor>
+  std::vector<MeanTerm> get_state_space_representation(std::vector<Predictor> &x) {
+    std::vector<MeanTerm> terms = {MeanTerm()};
+    return terms;
+  }
+
   /*
    * This will create a covariance matrix that looks like,
    *     sigma_mean^2 * ones(m, n)
    * which is saying all observations are perfectly correlated,
    * so you can move one if you move the rest the same amount.
    */
-  double operator()(const Predictor &x __attribute__((unused)),
-                    const Predictor &y __attribute__((unused))) const {
+  template <typename First, typename Second>
+  double operator()(const First &x __attribute__((unused)),
+                    const Second &y __attribute__((unused))) const {
     double sigma_mean = this->params_.at("sigma_constant_mean");
     return sigma_mean * sigma_mean;
   }
+
 };
 
 }

--- a/albatross/covariance_functions/radial.h
+++ b/albatross/covariance_functions/radial.h
@@ -25,8 +25,8 @@ namespace albatross {
  * is then used by the implementing function to determine how
  * correlated the two elements are as a function of their distance.
  */
-template <class Predictor, class DistanceMetricImpl>
-class RadialCovariance : public CovarianceBase<Predictor> {
+template <class DistanceMetricImpl>
+class RadialCovariance : public CovarianceBase {
  public:
   RadialCovariance() : distance_metric_(){};
 
@@ -53,9 +53,9 @@ class RadialCovariance : public CovarianceBase<Predictor> {
  * SquaredExponential distance
  *  - c(d) = -exp((d/length_scale)^2)
  */
-template <class Predictor, class DistanceMetricImpl>
+template <class DistanceMetricImpl>
 class SquaredExponential
-    : public RadialCovariance<Predictor, DistanceMetricImpl> {
+    : public RadialCovariance<DistanceMetricImpl> {
  public:
   SquaredExponential(double length_scale = 100000.,
                      double sigma_squared_exponential = 10.) {
@@ -71,6 +71,7 @@ class SquaredExponential
     return oss.str();
   }
 
+  template <typename Predictor>
   double operator()(const Predictor &x, const Predictor &y) const {
     double distance = this->distance_metric_(x, y);
     double length_scale = this->params_.at("length_scale");

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,10 +16,13 @@ add_dependencies(run_temperature_example
     temperature_example
 )
 
-
 add_executable(linear_example
     EXCLUDE_FROM_ALL
     linear.cc
+)
+
+add_dependencies(linear_example
+    albatross
 )
 
 target_link_libraries(linear_example m gflags yaml-cpp pthread)
@@ -37,6 +40,10 @@ add_dependencies(run_linear_example
 add_executable(inspection_example
     EXCLUDE_FROM_ALL
     inspection.cc
+)
+
+add_dependencies(inspection_example
+    albatross
 )
 
 target_link_libraries(inspection_example m gflags yaml-cpp pthread)

--- a/examples/inspection.cc
+++ b/examples/inspection.cc
@@ -1,0 +1,188 @@
+#include <random>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <Eigen/Core>
+#include "csv.h"
+#include "gflags/gflags.h"
+
+#include "gp/gp.h"
+#include "core/model.h"
+#include "covariance_functions/covariance_functions.h"
+
+DEFINE_string(input, "", "path to csv containing input data.");
+DEFINE_string(output, "", "path where predictions will be written in csv.");
+DEFINE_string(n, "50", "number of training points to use.");
+
+namespace albatross {
+
+class SlopeTerm : public CovarianceBase {
+ public:
+  SlopeTerm(double sigma_slope = 0.1) {
+    this->params_["sigma_slope"] = sigma_slope;
+  };
+
+  ~SlopeTerm(){};
+
+  std::string get_name() const { return "slope_term"; }
+
+  double operator()(const double &x,
+                    const double &y) const {
+    double sigma_slope = this->params_.at("sigma_slope");
+    return sigma_slope * sigma_slope * x * y;
+  }
+
+};
+
+class ScalarDistance : public DistanceMetric {
+ public:
+
+  std::string get_name() const { return "scalar_distance"; }
+
+  double operator()(const double &x,
+                    const double &y) const {
+    return fabs(x - y);
+  }
+};
+
+template <typename CovFunc>
+GaussianProcessRegression<CovFunc, double> gp_from_covariance(
+    CovFunc covariance_function) {
+  return GaussianProcessRegression<CovFunc, double>(covariance_function);
+};
+
+
+}
+
+
+std::vector<double> random_points_on_line(const int n,
+                                          const double low,
+                                          const double high) {
+  std::default_random_engine generator;
+  std::uniform_real_distribution<double> distribution(low, high);
+
+  std::vector<double> xs;
+  for (int i = 0; i < n; i++) {
+    xs.push_back(distribution(generator));
+  }
+  return xs;
+};
+
+
+std::vector<double> uniform_points_on_line(const int n,
+                                           const double low,
+                                           const double high) {
+  std::default_random_engine generator;
+  std::uniform_real_distribution<double> distribution(low, high);
+
+  std::vector<double> xs;
+  for (int i = 0; i < n; i++) {
+    double ratio = (double) i / (double) (n - 1);
+    xs.push_back(low + ratio * (high - low));
+  }
+  return xs;
+};
+
+
+double truth(double x) {
+  double a = sqrt(2.);
+  double b = 3.14159;
+  return x * a + b;
+}
+
+
+albatross::RegressionDataset<double> create_train_data(const int n,
+                       const double low,
+                       const double high,
+                       const double measurement_noise) {
+  auto xs = random_points_on_line(n, low, high);
+
+  std::default_random_engine generator;
+  std::normal_distribution<double> noise_distribution(0., measurement_noise);
+
+  Eigen::VectorXd ys(n);
+
+  for (int i = 0; i < n; i++) {
+    double noise = noise_distribution(generator);
+    ys[i] = (truth(xs[i]) + noise);
+  }
+
+  return albatross::RegressionDataset<double>(xs, ys);
+}
+
+
+albatross::RegressionDataset<double> read_linear_input(std::string file_path) {
+  std::vector<double> xs;
+  std::vector<double> ys;
+
+  io::CSVReader<2> file_in(file_path);
+
+  file_in.read_header(io::ignore_extra_column, "x", "y");
+  double x, y;
+  bool more_to_parse = true;
+  while (more_to_parse) {
+    more_to_parse = file_in.read_row(x, y);
+
+    xs.push_back(x);
+    ys.push_back(y);
+  }
+  Eigen::Map<Eigen::VectorXd> eigen_ys(&ys[0],
+                                           static_cast<int>(ys.size()));
+  return albatross::RegressionDataset<double>(xs, eigen_ys);
+}
+
+inline bool file_exists (const std::string& name) {
+    std::ifstream f(name.c_str());
+    return f.good();
+}
+
+int main(int argc, char *argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  int n = std::stoi(FLAGS_n);
+  const double low = -3.;
+  const double high = 13.;
+  const double meas_noise = 1.;
+
+  /*
+   * Either read the input data from file, or if it doesn't exist
+   * generate new input data and write it to file.
+   */
+  if (file_exists(FLAGS_input)) {
+    std::cout << "reading data from : " << FLAGS_input << std::endl;
+  } else {
+    std::cout << "creating training data and writing it to : " << FLAGS_input << std::endl;
+    auto data = create_train_data(n, low, high, meas_noise);
+    std::ofstream train;
+    train.open(FLAGS_input);
+    train << "x,y" << std::endl;
+    for (int i = 0; i < static_cast<int>(data.predictors.size()); i++) {
+      train << data.predictors[i] << ", " << data.targets[i] << std::endl;
+    }
+  }
+  auto data = read_linear_input(FLAGS_input);
+
+  using namespace albatross;
+  using Mean = ConstantMean;
+  using Slope = SlopeTerm;
+  using Noise = IndependentNoise<double>;
+
+  auto mean_term = Mean(10.);
+  CovarianceFunction<Mean> mean = {mean_term};
+  CovarianceFunction<Slope> slope = {Slope(10.)};
+  CovarianceFunction<Noise> noise = {Noise(meas_noise)};
+
+  auto linear_model = mean + slope + noise;
+
+  std::cout << "Using Model:" << std::endl;
+  std::cout << linear_model.to_string() << std::endl;
+
+  auto model = gp_from_covariance(linear_model);
+
+  model.fit(data);
+
+  const auto mean_terms = mean_term.get_state_space_representation(data.predictors);
+
+  auto state = model.inspect(mean_terms);
+  std::cout << state.mean << " +/- " << state.covariance << std::endl;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,19 +1,23 @@
 
 set(CMAKE_CXX_FLAGS "-Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitialized -Wpointer-arith -Wcast-align -Wformat=2 -Wredundant-decls ${CMAKE_CXX_FLAGS}")
 
-add_executable(test_albatross
+add_executable(albatross_unit_tests
 EXCLUDE_FROM_ALL
 test_covariance_functions.cc
 )
 
-target_link_libraries(test_albatross m gtest gtest_main pthread gflags yaml-cpp)
+add_dependencies(albatross_unit_tests
+    albatross
+)
+
+target_link_libraries(albatross_unit_tests m gtest gtest_main pthread gflags yaml-cpp)
 
 add_custom_target(
-run_test_albatross ALL
-COMMAND test_albatross
+run_albatross_unit_tests ALL
+COMMAND albatross_unit_tests
 COMMENT "Running unit tests"
 )
 
-add_dependencies(run_test_albatross
-test_albatross
+add_dependencies(run_albatross_unit_tests
+albatross_unit_tests
 )

--- a/tests/test_covariance_functions.cc
+++ b/tests/test_covariance_functions.cc
@@ -17,17 +17,17 @@ std::vector<Eigen::Vector3d> points_on_a_line(const int n) {
   return xs;
 }
 
-TEST(test_gp_covariance_functions, test_build_covariance) {
+TEST(test_covariance_functions, test_build_covariance) {
   using Predictor = Eigen::Vector3d;
-  using Mean = ConstantMean<Predictor>;
-  using Noise = IndependentNoise<Predictor>;
-  using SqExp = SquaredExponential<Predictor, EuclideanDistance<Predictor>>;
-  using RadialSqExp = SquaredExponential<Predictor, RadialDistance<Predictor>>;
+  using Mean = ConstantMean;
+  using Noise = IndependentNoise;
+  using SqExp = SquaredExponential<EuclideanDistance>;
+  using RadialSqExp = SquaredExponential<RadialDistance>;
 
-  CovarianceFunction<SqExp, Predictor> sqexp = {SqExp()};
-  CovarianceFunction<Mean, Predictor> mean = {Mean()};
-  CovarianceFunction<Noise, Predictor> noise = {Noise()};
-  CovarianceFunction<RadialSqExp, Predictor> radial_sqexp = {RadialSqExp()};
+  CovarianceFunction<SqExp> sqexp = {SqExp()};
+  CovarianceFunction<Mean> mean = {Mean()};
+  CovarianceFunction<Noise> noise = {Noise()};
+  CovarianceFunction<RadialSqExp> radial_sqexp = {RadialSqExp()};
 
   // Add and multiply covariance functions together and make sure they are
   // still capable of producing a covariance matrix.
@@ -40,27 +40,23 @@ TEST(test_gp_covariance_functions, test_build_covariance) {
   std::cout << covariance_function.to_string() << std::endl;
 }
 
-TEST(test_gp_covariance_functions, test_build_covariance) {
+TEST(test_covariance_functions, test_other_predictor) {
   using Predictor = Eigen::Vector3d;
-  using Mean = ConstantMean<Predictor>;
-  using Noise = IndependentNoise<Predictor>;
-  using SqExp = SquaredExponential<Predictor, EuclideanDistance<Predictor>>;
-  using RadialSqExp = SquaredExponential<Predictor, RadialDistance<Predictor>>;
+  using Mean = ConstantMean;
+  using Noise = IndependentNoise;
 
-  CovarianceFunction<SqExp, Predictor> sqexp = {SqExp()};
-  CovarianceFunction<Mean, Predictor> mean = {Mean()};
-  CovarianceFunction<Noise, Predictor> noise = {Noise()};
-  CovarianceFunction<RadialSqExp, Predictor> radial_sqexp = {RadialSqExp()};
+  auto mean_term = Mean();
+  CovarianceFunction<Mean> mean = {mean_term};
+  CovarianceFunction<Noise> noise = {Noise()};
 
-  // Add and multiply covariance functions together and make sure they are
-  // still capable of producing a covariance matrix.
-  auto product = sqexp * radial_sqexp;
-  auto covariance_function = mean + product + noise;
+
+  auto cov = mean + noise;
+  std::cout << cov.to_string() << std::endl;
 
   auto xs = points_on_a_line(5);
-  Eigen::MatrixXd C = symmetric_covariance(covariance_function, xs);
+  auto terms = mean_term.get_state_space_representation(xs);
+  Eigen::MatrixXd C = asymmetric_covariance(cov, terms, xs);
   std::cout << C << std::endl;
-  std::cout << covariance_function.to_string() << std::endl;
 }
 
 }


### PR DESCRIPTION
Still a WIP, but got a functional version working.

Looking for feedback (particularly from you @kmdade !)

The general idea is to provide us a way to inspect the state space representation of some term in a covariance function.  For example, if we were to start with some model,

```
  using Mean = ConstantMean;
  using Slope = SlopeTerm;
  using Noise = IndependentNoise<double>;

  auto mean_term = Mean(10.);
  CovarianceFunction<Mean> mean = {mean_term};
  CovarianceFunction<Slope> slope = {Slope(10.)};
  CovarianceFunction<Noise> noise = {Noise(meas_noise)};

  auto linear_model = mean + slope + noise;
  auto model = gp_from_covariance(linear_model);
  model.fit(data);
```
We can use the model to `fit` and `predict` the function value (or observations), but what if we're curious about what the equivalent state space model would have been estimating for a mean?  We can now do this,
```
  // Query the mean covariance term for its state space representation which
  // in this case is simply a length one vector which represents the scalar mean that
  // is being estimated.
  const auto mean_terms = mean_term.get_state_space_representation(data.predictors);
  //  Then we ask the (already fit) model what its estimate of the mean would be
  auto state = model.inspect(mean_terms);
  // In this test example the mean was fixed at `pi`, we estimated:
  std::cout << state.mean << " +/- " << state.covariance << std::endl; // 3.20826 +/- 0.132747
```
So far the only term capable of inspection is the `ConstantMean`.  To add inspectability to a covariance term you need to define three functions,
```
std::vector<StateSpaceRepr> get_state_space_representation(std::vector<Predictor> predictors);
```
which looks at all the predictors and decides which state variables would have been required (perhaps a clock per station observed for example),
```
double operator() (StateSpaceRepr &first, Predictor &second);
```
which defines the covariance between each state variable and each observation (this should build `P H^T` in kalman filters).
and,
```
double operator() (StateSpaceRepr &first, StateSpaceRepr &second);
```
which defines the covariance between each state variable.  This is the prior on the state space variables (or `P` in kalman filters).