### PR TITLE
Allow adapted models to be serialized.

### DIFF
--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -220,7 +220,6 @@ class RegressionModel : public ParameterHandlingMixin {
   virtual PredictionDistribution predict_(
       const std::vector<FeatureType> &features) const = 0;
 
-
   bool has_been_fit_;
 };
 

--- a/albatross/core/serialize.h
+++ b/albatross/core/serialize.h
@@ -24,6 +24,7 @@ template <typename FeatureType, typename ModelFit>
 class SerializableRegressionModel : public RegressionModel<FeatureType> {
 
  public:
+  using FitType = ModelFit;
   SerializableRegressionModel() : model_fit_() {};
   virtual ~SerializableRegressionModel() {};
 
@@ -56,7 +57,6 @@ class SerializableRegressionModel : public RegressionModel<FeatureType> {
   }
 
  protected:
-
   void fit_(const std::vector<FeatureType> &features,
                     const Eigen::VectorXd &targets) {
     model_fit_ = serializable_fit_(features, targets);

--- a/albatross/core/traits.h
+++ b/albatross/core/traits.h
@@ -16,7 +16,7 @@
 namespace albatross {
 
 /*
- * This struct determines whether or not a class has a method defined for,
+ * This determines whether or not a class has a method defined for,
  *   `operator() (X x, Y y, Z z, ...)`
  * The result of the inspection gets stored in the member `value`.
  */
@@ -31,6 +31,24 @@ class has_call_operator
 
 public:
     static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+/*
+ * This traits helper class defines `::type` to be `T::FitType`
+ * if a type with that name has been defined for T and will
+ * otherwise be `void`.
+ */
+template <typename T>
+class fit_type_or_void
+{
+    template <typename C,
+              typename = typename C::FitType>
+    static typename C::FitType test(int);
+    template <typename C>
+    static void test(...);
+
+public:
+    typedef decltype(test<T>(0)) type;
 };
 
 }

--- a/albatross/core/traits.h
+++ b/albatross/core/traits.h
@@ -34,7 +34,11 @@ public:
 };
 
 
-template <typename T, typename... Args>
+/*
+ * Inspects T to see if it has a class level type called FitType,
+ * the result is returned in ::value.
+ */
+template <typename T>
 class has_fit_type
 {
   template <typename C,
@@ -46,6 +50,14 @@ class has_fit_type
 public:
     static constexpr bool value = decltype(test<T>(0))::value;
 };
+
+/*
+ * One way to tell the difference between a RegressionModel
+ * and a SerializableRegressionModel is by inspecting for a
+ * FitType.
+ */
+template <typename T>
+using is_serializable_regression_model = has_fit_type<T>;
 
 /*
  * This traits helper class defines `::type` to be `T::FitType`
@@ -64,6 +76,7 @@ class fit_type_or_void
 public:
     typedef decltype(test<T>(0)) type;
 };
+
 
 }
 

--- a/albatross/core/traits.h
+++ b/albatross/core/traits.h
@@ -33,6 +33,20 @@ public:
     static constexpr bool value = decltype(test<T>(0))::value;
 };
 
+
+template <typename T, typename... Args>
+class has_fit_type
+{
+  template <typename C,
+            typename = typename C::FitType>
+    static std::true_type test(int);
+    template <typename C>
+    static std::false_type test(...);
+
+public:
+    static constexpr bool value = decltype(test<T>(0))::value;
+};
+
 /*
  * This traits helper class defines `::type` to be `T::FitType`
  * if a type with that name has been defined for T and will

--- a/albatross/models/gp.h
+++ b/albatross/models/gp.h
@@ -67,6 +67,9 @@ class GaussianProcessRegression : public SerializableGaussianProcess<FeatureType
   GaussianProcessRegression(CovarianceFunction& covariance_function,
                             const std::string &model_name)
       : covariance_function_(covariance_function), model_name_(model_name) {};
+  GaussianProcessRegression(const std::string &model_name)
+      : covariance_function_(), model_name_(model_name) {};
+
   ~GaussianProcessRegression(){};
 
   std::string get_name() const override {
@@ -76,11 +79,13 @@ class GaussianProcessRegression : public SerializableGaussianProcess<FeatureType
   template <typename Archive>
   void save(Archive & archive) const {
     archive(cereal::base_class<SerializableRegressionModel<FeatureType, GaussianProcessFit<FeatureType>>>(this));
+    archive(model_name_);
   }
 
   template <typename Archive>
   void load(Archive & archive) {
     archive(cereal::base_class<SerializableRegressionModel<FeatureType, GaussianProcessFit<FeatureType>>>(this));
+    archive(model_name_);
   }
 
   template <typename OtherFeatureType>

--- a/albatross/models/least_squares.h
+++ b/albatross/models/least_squares.h
@@ -25,6 +25,16 @@ namespace albatross {
 
 struct LeastSquaresFit {
   Eigen::VectorXd coefs;
+
+  bool operator == (const LeastSquaresFit &other) const {
+    return coefs == other.coefs;
+  }
+
+  template <typename Archive>
+  void serialize(Archive &archive) {
+    archive(coefs);
+  }
+
 };
 
 /*
@@ -41,17 +51,6 @@ class LeastSquaresRegression : public SerializableRegressionModel<Eigen::VectorX
   LeastSquaresRegression() {};
   std::string get_name() const override { return "least_squares"; };
 
- protected:
-
-  /*
-   * This lets you customize the least squares approach if need be,
-   * default uses the QR decomposition.
-   */
-  virtual Eigen::VectorXd least_squares_solver(const Eigen::MatrixXd &A,
-                                               const Eigen::VectorXd &b) const {
-    return A.colPivHouseholderQr().solve(b);
-  }
-
   LeastSquaresFit serializable_fit_(const std::vector<Eigen::VectorXd> &features,
                                      const Eigen::VectorXd &targets) const override {
     // Build the design matrix
@@ -66,7 +65,9 @@ class LeastSquaresRegression : public SerializableRegressionModel<Eigen::VectorX
     return model_fit;
   }
 
-  PredictionDistribution predict_(const std::vector<Eigen::VectorXd> &features) const {
+ protected:
+
+  PredictionDistribution predict_(const std::vector<Eigen::VectorXd> &features) const override {
     int n = static_cast<s32>(features.size());
     Eigen::VectorXd predictions(n);
     for (s32 i = 0; i < n; i++) {
@@ -75,9 +76,21 @@ class LeastSquaresRegression : public SerializableRegressionModel<Eigen::VectorX
 
     return PredictionDistribution(predictions);
   }
+
+  /*
+   * This lets you customize the least squares approach if need be,
+   * default uses the QR decomposition.
+   */
+  virtual Eigen::VectorXd least_squares_solver(const Eigen::MatrixXd &A,
+                                               const Eigen::VectorXd &b) const {
+    return A.colPivHouseholderQr().solve(b);
+  }
+
 };
 
-
+using LinearRegressionBase = AdaptedRegressionModel<double,
+    LeastSquaresRegression,
+    SerializableRegressionModel<double, LeastSquaresFit>>;
 /*
  * Creates a least squares problem by building a design matrix that looks like:
  *
@@ -85,8 +98,10 @@ class LeastSquaresRegression : public SerializableRegressionModel<Eigen::VectorX
  *
  * Setup like this the resulting fit will represent an offset and slope.
  */
-class LinearRegression : public AdaptedRegressionModel<double, LeastSquaresRegression> {
+class LinearRegression : public LinearRegressionBase {
 
+ public:
+  LinearRegression() {};
   std::string get_name() const override { return "linear_regression"; };
 
   const Eigen::VectorXd convert_feature(const double& x) const {
@@ -95,8 +110,30 @@ class LinearRegression : public AdaptedRegressionModel<double, LeastSquaresRegre
     return converted;
   }
 
+  /*
+   * save/load methods are inherited from the SerializableRegressionModel,
+   * but by defining them here and explicitly showing the inheritence
+   * through the use of `base_class` we can make use of cereal's
+   * polymorphic serialization.
+   */
+  template<class Archive>
+  void save(Archive & archive) const
+  {
+    archive(cereal::make_nvp("linear_regression",
+                             cereal::base_class<LinearRegressionBase>(this)));
+  }
+
+  template<class Archive>
+  void load(Archive & archive)
+  {
+    archive(cereal::make_nvp("linear_regression",
+                             cereal::base_class<LinearRegressionBase>(this)));
+  }
+
 };
 
 }
+
+CEREAL_REGISTER_TYPE(albatross::LinearRegression);
 
 #endif

--- a/albatross/models/least_squares.h
+++ b/albatross/models/least_squares.h
@@ -99,8 +99,7 @@ class LeastSquaresRegression : public SerializableRegressionModel<Eigen::VectorX
  * an offset and slope.
  */
 using LinearRegressionBase = AdaptedRegressionModel<double,
-    LeastSquaresRegression,
-    SerializableRegressionModel<double, LeastSquaresFit>>;
+                                                    LeastSquaresRegression>;
 
 class LinearRegression : public LinearRegressionBase {
 

--- a/albatross/models/least_squares.h
+++ b/albatross/models/least_squares.h
@@ -88,16 +88,20 @@ class LeastSquaresRegression : public SerializableRegressionModel<Eigen::VectorX
 
 };
 
-using LinearRegressionBase = AdaptedRegressionModel<double,
-    LeastSquaresRegression,
-    SerializableRegressionModel<double, LeastSquaresFit>>;
+
 /*
- * Creates a least squares problem by building a design matrix that looks like:
+ * Creates a least squares problem by building a design matrix where the
+ * i^th row looks like:
  *
  *   A_i = [1 x]
  *
- * Setup like this the resulting fit will represent an offset and slope.
+ * Setup like this the resulting least squares solve will represent
+ * an offset and slope.
  */
+using LinearRegressionBase = AdaptedRegressionModel<double,
+    LeastSquaresRegression,
+    SerializableRegressionModel<double, LeastSquaresFit>>;
+
 class LinearRegression : public LinearRegressionBase {
 
  public:

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -28,7 +28,7 @@ using SqrExp = SquaredExponential<ScalarDistance>;
 using Noise = IndependentNoise<double>;
 using SqrExpAndNoise = SumOfCovarianceTerms<SqrExp, Noise>;
 using CovFunc = CovarianceFunction<SqrExpAndNoise>;
-using SquaredExpoentialGaussianProcess = GaussianProcessRegression<double, CovFunc>;
+using SquaredExponentialGaussianProcess = GaussianProcessRegression<double, CovFunc>;
 
 /*
  * Make sure we can serialize a model and recover the parameters.
@@ -205,10 +205,10 @@ class FitLinearSerializablePointer : public ModelRepresentation<SerializableLeas
    };
 };
 
-class UnfitGaussianProcess : public ModelRepresentation<std::unique_ptr<SquaredExpoentialGaussianProcess>> {
+class UnfitGaussianProcess : public ModelRepresentation<std::unique_ptr<SquaredExponentialGaussianProcess>> {
 public:
   RepresentationType create() const override {
-    auto gp = std::make_unique<SquaredExpoentialGaussianProcess>();
+    auto gp = std::make_unique<SquaredExponentialGaussianProcess>("custom_name");
     gp->set_param("length_scale", log(2.));
     return gp;
   }
@@ -220,12 +220,12 @@ public:
 };
 
 
-class FitGaussianProcess : public ModelRepresentation<std::unique_ptr<SquaredExpoentialGaussianProcess>> {
+class FitGaussianProcess : public ModelRepresentation<std::unique_ptr<SquaredExponentialGaussianProcess>> {
 public:
   RepresentationType create() const override {
 
     auto dataset = make_toy_linear_data();
-    auto gp = std::make_unique<SquaredExpoentialGaussianProcess>();
+    auto gp = std::make_unique<SquaredExponentialGaussianProcess>("custom_name");
     gp->set_param("length_scale", log(2.));
     gp->fit(dataset);
     return gp;


### PR DESCRIPTION
 Give AdaptedRegressionModel the ability to extend anything that is derived from RegressionModel.  In particular this lets AdaptedRegressionModel wrap a SerializableRegressionModel and proives the appropriate cereal::base_class paths which allow polymorphic serialization.
    
This required using traits to conditionally add required pure virtual functions when an AdaptedRegressionModel extends a SerializableRegressionModel.