### PR TITLE
Add ability to tune a model using multiple datasets.

### DIFF
--- a/albatross/tune.h
+++ b/albatross/tune.h
@@ -20,36 +20,71 @@
 
 namespace albatross {
 
-std::vector<ParameterValue>
+inline std::vector<ParameterValue>
 transform_parameters(const std::vector<ParameterValue> &x) {
   std::vector<ParameterValue> transformed(x.size());
   std::transform(x.begin(), x.end(), transformed.begin(), log);
   return transformed;
 }
 
-std::vector<ParameterValue>
+inline std::vector<ParameterValue>
 inverse_parameters(const std::vector<ParameterValue> &x) {
   std::vector<ParameterValue> inverted(x.size());
   std::transform(x.begin(), x.end(), inverted.begin(), exp);
   return inverted;
 }
 
-template <class Predictor>
-using TuningMetric = std::function<double(const RegressionDataset<Predictor> &,
-                                          RegressionModel<Predictor> *)>;
+template <class FeatureType>
+using TuningMetric = std::function<double(
+    const RegressionDataset<FeatureType> &, RegressionModel<FeatureType> *)>;
 
-template <class Predictor> struct TuneModelConfg {
-  RegressionModelCreator<Predictor> model_creator;
-  RegressionDataset<Predictor> dataset;
-  TuningMetric<Predictor> metric;
+using TuningMetricAggregator =
+    std::function<double(const std::vector<double> &metrics)>;
 
-  TuneModelConfg(const RegressionModelCreator<Predictor> &model_creator_,
-                 const RegressionDataset<Predictor> &dataset_,
-                 const TuningMetric<Predictor> &metric_)
-      : model_creator(model_creator_), dataset(dataset_), metric(metric_){};
+/*
+ * Returns the mean of metrics computed across multiple datasets.
+ */
+inline double mean_aggregator(const std::vector<double> &metrics) {
+  double mean = 0.;
+  for (const auto &metric : metrics) {
+    mean += metric;
+  }
+  mean /= static_cast<double>(metrics.size());
+  return mean;
+}
+
+template <class FeatureType> struct TuneModelConfg {
+  RegressionModelCreator<FeatureType> model_creator;
+  std::vector<RegressionDataset<FeatureType>> datasets;
+  TuningMetric<FeatureType> metric;
+  TuningMetricAggregator aggregator;
+  std::ostream &output_stream;
+
+  TuneModelConfg(const RegressionModelCreator<FeatureType> &model_creator_,
+                 const RegressionDataset<FeatureType> &dataset_,
+                 const TuningMetric<FeatureType> &metric_,
+                 const TuningMetricAggregator &aggregator_ = mean_aggregator,
+                 std::ostream &output_stream_ = std::cout)
+      : model_creator(model_creator_), datasets({dataset_}), metric(metric_),
+        aggregator(aggregator_), output_stream(output_stream_){};
+
+  TuneModelConfg(const RegressionModelCreator<FeatureType> &model_creator_,
+                 const std::vector<RegressionDataset<FeatureType>> &datasets_,
+                 const TuningMetric<FeatureType> &metric_,
+                 const TuningMetricAggregator &aggregator_ = mean_aggregator,
+                 std::ostream &output_stream_ = std::cout)
+      : model_creator(model_creator_), datasets(datasets_), metric(metric_),
+        aggregator(aggregator_), output_stream(output_stream_){};
 };
 
-template <class Predictor>
+/*
+ * This function API is defined by nlopt, when an optimization algorithm
+ * requires the gradient nlopt expects that the grad argument gets
+ * modified inside this function.  The TuneModelConfig which holds
+ * any information about which functions to call etc, needs to be passed
+ * in through a void pointer.
+ */
+template <class FeatureType>
 double objective_function(const std::vector<double> &x,
                           std::vector<double> &grad, void *void_tune_config) {
   if (!grad.empty()) {
@@ -57,31 +92,31 @@ double objective_function(const std::vector<double> &x,
                                 "a gradient but one isn't available.");
   }
 
-  const TuneModelConfg<Predictor> config =
-      *static_cast<TuneModelConfg<Predictor> *>(void_tune_config);
+  const TuneModelConfg<FeatureType> config =
+      *static_cast<TuneModelConfg<FeatureType> *>(void_tune_config);
 
   const auto model = config.model_creator();
 
   model->set_params_from_vector(inverse_parameters(x));
 
-  const double metric = config.metric(config.dataset, model.get());
+  std::vector<double> metrics;
+  for (std::size_t i = 0; i < config.datasets.size(); i++) {
+    metrics.push_back(config.metric(config.datasets[i], model.get()));
+  }
+  double metric = config.aggregator(metrics);
 
-  std::cout << "-------------------" << std::endl;
-  std::cout << model->pretty_string() << std::endl;
-  std::cout << "objective: " << metric << std::endl;
-  std::cout << "-------------------" << std::endl;
+  config.output_stream << "-------------------" << std::endl;
+  config.output_stream << model->pretty_string() << std::endl;
+  config.output_stream << "objective: " << metric << std::endl;
+  config.output_stream << "-------------------" << std::endl;
   return metric;
 }
 
-template <class Predictor>
+template <class FeatureType>
 ParameterStore
-tune_regression_model(const RegressionModelCreator<Predictor> &model_creator,
-                      const RegressionDataset<Predictor> &dataset,
-                      const TuningMetric<Predictor> &metric) {
-  const auto example_model = model_creator();
+tune_regression_model(const TuneModelConfg<FeatureType> &config) {
 
-  TuneModelConfg<Predictor> config(model_creator, dataset, metric);
-
+  const auto example_model = config.model_creator();
   auto x = transform_parameters(example_model->get_params_as_vector());
 
   assert(x.size());
@@ -89,7 +124,7 @@ tune_regression_model(const RegressionModelCreator<Predictor> &model_creator,
   // The various algorithms in nlopt are coded by the first two characters.
   // In this case LN stands for local, gradient free.
   nlopt::opt opt(nlopt::LN_PRAXIS, (unsigned)x.size());
-  opt.set_min_objective(objective_function<Predictor>, (void *)&config);
+  opt.set_min_objective(objective_function<FeatureType>, (void *)&config);
   opt.set_ftol_abs(1e-8);
   opt.set_ftol_rel(1e-6);
   // the sensitivity to parameters varies greatly between parameters so
@@ -101,10 +136,10 @@ tune_regression_model(const RegressionModelCreator<Predictor> &model_creator,
 
   // Tell the user what the final parameters were.
   example_model->set_params_from_vector(inverse_parameters(x));
-  std::cout << "==================" << std::endl;
-  std::cout << "TUNED MODEL PARAMS" << std::endl;
-  std::cout << "==================" << std::endl;
-  std::cout << example_model->pretty_string() << std::endl;
+  config.output_stream << "==================" << std::endl;
+  config.output_stream << "TUNED MODEL PARAMS" << std::endl;
+  config.output_stream << "==================" << std::endl;
+  config.output_stream << example_model->pretty_string() << std::endl;
 
   return example_model->get_params();
 }

--- a/examples/tune_example.cc
+++ b/examples/tune_example.cc
@@ -81,5 +81,7 @@ int main(int argc, char *argv[]) {
    */
   std::cout << "Tuning the model." << std::endl;
   TuningMetric<double> metric = loo_nll;
-  auto params = tune_regression_model<double>(model_creator, data, metric);
+
+  TuneModelConfg<double> config(model_creator, data, metric);
+  auto params = tune_regression_model<double>(config);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,13 +13,15 @@ test_serialize.cc
 test_parameter_handling_mixin.cc
 test_models.cc
 test_core_distribution.cc
+test_tune.cc
 )
 
 add_dependencies(albatross_unit_tests
     albatross
+    clang-format-all
 )
 
-target_link_libraries(albatross_unit_tests m gtest gtest_main pthread gflags)
+target_link_libraries(albatross_unit_tests m gtest gtest_main pthread gflags nlopt)
 
 add_custom_target(
 run_albatross_unit_tests ALL

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "covariance_functions/covariance_functions.h"
+#include "evaluate.h"
+#include "models/gp.h"
+#include "test_utils.h"
+#include "tune.h"
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+double loo_nll(const albatross::RegressionDataset<double> &dataset,
+               albatross::RegressionModel<double> *model) {
+  auto loo_folds = albatross::leave_one_out(dataset);
+  return albatross::cross_validated_scores(albatross::negative_log_likelihood,
+                                           loo_folds, model)
+      .mean();
+}
+
+std::unique_ptr<RegressionModel<double>> create_model() {
+  using SqrExp = SquaredExponential<ScalarDistance>;
+  using Noise = IndependentNoise<double>;
+  CovarianceFunction<SqrExp> squared_exponential = {SqrExp(100., 100.)};
+  CovarianceFunction<Noise> noise = {Noise(0.1)};
+  auto covariance = squared_exponential + noise;
+  return gp_pointer_from_covariance<double>(covariance);
+}
+
+TEST(test_tune, test_single_dataset) {
+  auto dataset = make_toy_linear_data();
+
+  auto model_creator = create_model;
+
+  TuningMetric<double> metric = loo_nll;
+  std::ostringstream output_stream;
+  TuneModelConfg<double> config(model_creator, dataset, metric,
+                                albatross::mean_aggregator, output_stream);
+  auto params = tune_regression_model(config);
+}
+
+TEST(test_tune, test_multiple_datasets) {
+  auto one_dataset = make_toy_linear_data(2., 4., 0.2);
+  auto another_dataset = make_toy_linear_data(1., 5., 0.1);
+  std::vector<RegressionDataset<double>> datasets = {one_dataset,
+                                                     another_dataset};
+  auto model_creator = create_model;
+  TuningMetric<double> metric = loo_nll;
+  std::ostringstream output_stream;
+  TuneModelConfg<double> config(model_creator, datasets, metric,
+                                albatross::mean_aggregator, output_stream);
+  std::cout << "output" << std::endl;
+  std::cout << output_stream.str() << std::endl;
+  auto params = tune_regression_model(config);
+}
+}


### PR DESCRIPTION
This provides a way to run parameter optimization on a model by aggregating tuning metrics across multiple datasets.

In pseudocode, it lets us minimize a metric along the lines of:
```
double multiple_dataset_metric() {
  vector<double> metric_per_dataset;
  for (dataset : vector_of_datasets) {
    one_metric = compute_metric_for_single_dataset(dataset)
    metric_per_dataset.push_back(one_metric)
  }
  return compute_mean_of_all_metrics(metric_per_dataset);
}
```
where before we were only capable of minimizing:
```
compute_metric_for_single_dataset(dataset)
```