### PR TITLE
Model Adapter Params

### DIFF
--- a/albatross/core/model_adapter.h
+++ b/albatross/core/model_adapter.h
@@ -96,7 +96,9 @@ public:
 
   bool has_been_fit() const override { return sub_model_.has_been_fit(); }
 
-  ParameterStore get_params() const override { return sub_model_.get_params(); }
+  ParameterStore get_params() const override {
+    return map_join(this->params_, sub_model_.get_params());
+  }
 
   template <class Archive> void save(Archive &archive) const {
     archive(cereal::make_nvp(
@@ -112,7 +114,12 @@ public:
 
   void unchecked_set_param(const std::string &name,
                            const double value) override {
-    sub_model_.set_param(name, value);
+
+    if (map_contains(this->params_, name)) {
+      this->params_[name] = value;
+    } else {
+      sub_model_.set_param(name, value);
+    }
   }
 
   fit_type_if_serializable<SubModelType> get_fit() const {

--- a/albatross/core/parameter_handling_mixin.h
+++ b/albatross/core/parameter_handling_mixin.h
@@ -51,7 +51,7 @@ inline std::string pretty_params(const ParameterStore &params) {
 /*
  * This mixin class is intended to be included an any class which
  * depends on some set of parameters which we want to programatically
- * change for things such as optimization routines / seralization.
+ * change for things such as optimization routines / serialization.
  */
 class ParameterHandlingMixin {
 public:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,6 @@ test_parameter_handling_mixin.cc
 test_models.cc
 test_core_distribution.cc
 test_tune.cc
-test_scaling_function.cc
 )
 
 add_dependencies(albatross_unit_tests

--- a/tests/test_model_adapter.cc
+++ b/tests/test_model_adapter.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "covariance_functions/covariance_functions.h"
+#include "evaluate.h"
+#include "models/gp.h"
+#include "test_utils.h"
+#include <cereal/archives/json.hpp>
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+using SqrExp = CovarianceFunction<SquaredExponential<EuclideanDistance>>;
+
+using TestBaseModel = GaussianProcessRegression<Eigen::VectorXd, SqrExp>;
+
+using TestAdaptedModelBase = AdaptedRegressionModel<double, TestBaseModel>;
+
+class TestAdaptedModel : public TestAdaptedModelBase {
+public:
+  TestAdaptedModel() { this->params_["center"] = 0.; };
+
+  std::string get_name() const override { return "test_adapted"; };
+
+  const Eigen::VectorXd convert_feature(const double &x) const {
+    Eigen::VectorXd converted(2);
+    converted << 1., (x - this->params_.at("center"));
+    return converted;
+  }
+
+  /*
+   * save/load methods are inherited from the SerializableRegressionModel,
+   * but by defining them here and explicitly showing the inheritence
+   * through the use of `base_class` we can make use of cereal's
+   * polymorphic serialization.
+   */
+  template <class Archive> void save(Archive &archive) const {
+    archive(cereal::make_nvp("test_adapted",
+                             cereal::base_class<TestAdaptedModelBase>(this)));
+  }
+
+  template <class Archive> void load(Archive &archive) {
+    archive(cereal::make_nvp("test_adapted",
+                             cereal::base_class<TestAdaptedModelBase>(this)));
+  }
+};
+}
+
+void test_get_set(albatross::RegressionModel<double> &model,
+                  const std::string &key) {
+  // Make sure a key exists, then modify it and make sure it
+  // takes on the new value.
+  const auto orig = model.get_params().at(key);
+  model.set_param(key, orig + 1.);
+  EXPECT_EQ(model.get_params().at(key), orig + 1.);
+}
+
+TEST(test_model_adapter, test_get_set_params) {
+  // An adapted model should contain both higher level parameters,
+  // and the sub model parameters.
+  auto model = albatross::TestAdaptedModel();
+  auto sqr_exp_params = albatross::SqrExp().get_params();
+  auto params = model.get_params();
+  // Make sure all the sub model params are in the adapted params
+  for (const auto &pair : sqr_exp_params) {
+    test_get_set(model, pair.first);
+  }
+  // And the higher level parameter.
+  test_get_set(model, "center");
+};


### PR DESCRIPTION
This changes lets an `AdaptedModel` take on higher level parameters.  This is useful for situations where converting from feature `X` to feature `Y` might change depending on some model parameter.

An example of this is given in the new added test,

```
class TestAdaptedModel : public TestAdaptedModelBase {
public:
  TestAdaptedModel() { this->params_["center"] = 0.; };

  const Eigen::VectorXd convert_feature(const double &x) const {
    Eigen::VectorXd converted(2);
    converted << 1., (x - this->params_.at("center"));
    return converted;
  }
```