### PR TITLE
Covariance matrix directly from CovarianceTerm.

### DIFF
--- a/albatross/covariance_functions/covariance_functions.h
+++ b/albatross/covariance_functions/covariance_functions.h
@@ -22,6 +22,7 @@
 namespace albatross {
 
 template <typename Term> struct CovarianceFunction {
+  using TermType = Term;
   Term term;
 
   CovarianceFunction() : term(){};
@@ -113,6 +114,17 @@ Eigen::MatrixXd symmetric_covariance(const CovarianceFunction<Covariance> &f,
 }
 
 /*
+ * Convenience function that turns a covariance term into a function
+ * before computing a covariance matrix.
+ */
+template <typename CovarianceTerm, typename Feature>
+Eigen::MatrixXd symmetric_covariance(const CovarianceTerm &term,
+                                     const std::vector<Feature> &xs) {
+  CovarianceFunction<CovarianceTerm> func(term);
+  return symmetric_covariance(func, xs);
+}
+
+/*
  * Computes the covariance matrix between some predictors (x) and
  * a separate distinct set (y).  x and y can be of the same type,
  * which is common when making predictions at new locations, or x may
@@ -137,6 +149,18 @@ Eigen::MatrixXd asymmetric_covariance(const CovarianceFunction<Covariance> &f,
     }
   }
   return C;
+}
+
+/*
+ * Convenience function that turns a covariance term into a function
+ * before computing a covariance matrix.
+ */
+template <typename CovarianceTerm, typename OtherFeature, typename Feature>
+Eigen::MatrixXd asymmetric_covariance(const CovarianceTerm &term,
+                                      const std::vector<OtherFeature> &xs,
+                                      const std::vector<Feature> &ys) {
+  CovarianceFunction<CovarianceTerm> func(term);
+  return asymmetric_covariance(func, xs, ys);
 }
 } // namespace albatross
 

--- a/tests/test_covariance_functions.cc
+++ b/tests/test_covariance_functions.cc
@@ -74,9 +74,18 @@ TYPED_TEST_CASE(TestVectorCovarianceFunctions,
 TYPED_TEST(TestVectorCovarianceFunctions, WorksWithEigen) {
 
   typename TestFixture::CovFunc covariance_function;
-
   auto xs = points_on_a_line(5);
   Eigen::MatrixXd C = symmetric_covariance(covariance_function, xs);
+  assert(C.rows() == xs.size());
+  assert(C.cols() == xs.size());
+  // Make sure C is positive definite.
+  auto inverse = C.inverse();
+}
+
+TYPED_TEST(TestVectorCovarianceFunctions, WorksDirectlyOnCovarianceterms) {
+  typename TestFixture::CovFunc covariance_function;
+  auto xs = points_on_a_line(5);
+  Eigen::MatrixXd C = symmetric_covariance(covariance_function.term, xs);
   assert(C.rows() == xs.size());
   assert(C.cols() == xs.size());
   // Make sure C is positive definite.


### PR DESCRIPTION
Add a wrapper around covariance matrix functions to allow them to be called directly with a CovarianceTerm.