### PR TITLE
Fast Leave One Out Crossvalidation for GPs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ CACHE INTERNAL ""
 set(albatross_HEADERS
     albatross/tune.h
     albatross/evaluate.h
+    albatross/crossvalidation.h
+    albatross/tuning_metrics.h
     albatross/map_utils.h
     albatross/core/keys.h
     albatross/core/model.h

--- a/albatross/core/model_adapter.h
+++ b/albatross/core/model_adapter.h
@@ -19,15 +19,6 @@
 
 namespace albatross {
 
-template <typename X, typename T>
-using enable_if_serializable =
-    std::enable_if<is_serializable_regression_model<X>::value, T>;
-
-template <typename X>
-using fit_type_if_serializable =
-    typename enable_if_serializable<X,
-                                    typename fit_type_or_void<X>::type>::type;
-
 /*
  * This helper function takes a model which is being adapted (SubModelType)
  * and decides which base class to extend by inspecting whether or not the
@@ -122,7 +113,7 @@ public:
     }
   }
 
-  fit_type_if_serializable<SubModelType> get_fit() const {
+  fit_type_if_serializable<SubModelType> get_fit() const override {
     return sub_model_.get_fit();
   }
 

--- a/albatross/core/serialize.h
+++ b/albatross/core/serialize.h
@@ -53,7 +53,7 @@ public:
     archive(cereal::make_nvp("model_fit", this->model_fit_));
   }
 
-  ModelFit get_fit() const { return model_fit_; }
+  virtual ModelFit get_fit() const { return model_fit_; }
 
 protected:
   void fit_(const std::vector<FeatureType> &features,

--- a/albatross/core/traits.h
+++ b/albatross/core/traits.h
@@ -65,6 +65,23 @@ template <typename T> class fit_type_or_void {
 public:
   typedef decltype(test<T>(0)) type;
 };
+
+/*
+ * Helper function for enable_if and is_serializable_regression_model
+ */
+template <typename X, typename T>
+using enable_if_serializable =
+    std::enable_if<is_serializable_regression_model<X>::value, T>;
+
+/*
+ * Will result in substitution failure if X is not serializable and
+ * otherwise resolves to X::FitType.
+ */
+template <typename X>
+using fit_type_if_serializable =
+    typename enable_if_serializable<X,
+                                    typename fit_type_or_void<X>::type>::type;
+
 } // namespace albatross
 
 #endif

--- a/albatross/crossvalidation.h
+++ b/albatross/crossvalidation.h
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CROSSVALIDATION_H
+#define ALBATROSS_CROSSVALIDATION_H
+
+#include "core/model.h"
+#include <functional>
+#include <map>
+#include <memory>
+
+namespace albatross {
+
+/*
+ * An evaluation metric is a function that takes a prediction distribution and
+ * corresponding targets and returns a single real value that summarizes
+ * the quality of the prediction.
+ */
+using EvaluationMetric = std::function<double(
+    const PredictDistribution &prediction, const TargetDistribution &targets)>;
+
+inline FoldIndices get_train_indices(const FoldIndices &test_indices,
+                                     const int n) {
+  const s32 k = static_cast<s32>(test_indices.size());
+  // The train indices are all the indices that are not test indices.
+  FoldIndices train_indices(n - k);
+  s32 train_cnt = 0;
+  for (s32 j = 0; j < n; j++) {
+    if (std::find(test_indices.begin(), test_indices.end(), j) ==
+        test_indices.end()) {
+      train_indices[train_cnt] = j;
+      train_cnt++;
+    }
+  }
+  return train_indices;
+}
+
+/*
+ * Each flavor of cross validation can be described by a set of
+ * FoldIndices, which store which indices should be used for the
+ * test cases.  This function takes a map from FoldName to
+ * FoldIndices and a dataset and creates the resulting folds.
+ */
+template <typename FeatureType>
+static inline std::vector<RegressionFold<FeatureType>>
+folds_from_fold_indexer(const RegressionDataset<FeatureType> &dataset,
+                        const FoldIndexer &groups) {
+  // For a dataset with n features, we'll have n folds.
+  const s32 n = static_cast<s32>(dataset.features.size());
+  std::vector<RegressionFold<FeatureType>> folds;
+  // For each fold, partition into train and test sets.
+  for (const auto &pair : groups) {
+    // These get exposed inside the returned RegressionFold and because
+    // we'd like to prevent modification of the output from this function
+    // from changing the input FoldIndexer we perform a copy here.
+    const FoldName group_name(pair.first);
+    const FoldIndices test_indices(pair.second);
+    const auto train_indices = get_train_indices(test_indices, n);
+
+    std::vector<FeatureType> train_features =
+        subset(train_indices, dataset.features);
+    TargetDistribution train_targets = subset(train_indices, dataset.targets);
+
+    std::vector<FeatureType> test_features =
+        subset(test_indices, dataset.features);
+    TargetDistribution test_targets = subset(test_indices, dataset.targets);
+
+    assert(train_features.size() == train_targets.size());
+    assert(test_features.size() == test_targets.size());
+    assert(test_targets.size() + train_targets.size() == n);
+
+    const RegressionDataset<FeatureType> train_split(train_features,
+                                                     train_targets);
+    const RegressionDataset<FeatureType> test_split(test_features,
+                                                    test_targets);
+    folds.push_back(RegressionFold<FeatureType>(train_split, test_split,
+                                                group_name, test_indices));
+  }
+  return folds;
+}
+
+template <typename FeatureType>
+static inline FoldIndexer
+leave_one_out_indexer(const RegressionDataset<FeatureType> &dataset) {
+  FoldIndexer groups;
+  for (s32 i = 0; i < static_cast<s32>(dataset.features.size()); i++) {
+    FoldName group_name = std::to_string(i);
+    groups[group_name] = {i};
+  }
+  return groups;
+}
+
+/*
+ * Splits a dataset into cross validation folds where each fold contains all but
+ * one predictor/target pair.
+ */
+template <typename FeatureType>
+static inline FoldIndexer leave_one_group_out_indexer(
+    const RegressionDataset<FeatureType> &dataset,
+    const std::function<FoldName(const FeatureType &)> &get_group_name) {
+  FoldIndexer groups;
+  for (s32 i = 0; i < static_cast<s32>(dataset.features.size()); i++) {
+    const std::string k =
+        get_group_name(dataset.features[static_cast<std::size_t>(i)]);
+    // Get the existing indices if we've already encountered this group_name
+    // otherwise initialize a new one.
+    FoldIndices indices;
+    if (groups.find(k) == groups.end()) {
+      indices = FoldIndices();
+    } else {
+      indices = groups[k];
+    }
+    // Add the current index.
+    indices.push_back(i);
+    groups[k] = indices;
+  }
+  return groups;
+}
+
+/*
+ * Generates cross validation folds which represent leave one out
+ * cross validation.
+ */
+template <typename FeatureType>
+static inline std::vector<RegressionFold<FeatureType>>
+leave_one_out(const RegressionDataset<FeatureType> &dataset) {
+  return folds_from_fold_indexer<FeatureType>(
+      dataset, leave_one_out_indexer<FeatureType>(dataset));
+}
+
+/*
+ * Uses a `get_group_name` function to bucket each FeatureType into
+ * a group, then holds out one group at a time.
+ */
+template <typename FeatureType>
+static inline std::vector<RegressionFold<FeatureType>> leave_one_group_out(
+    const RegressionDataset<FeatureType> &dataset,
+    const std::function<FoldName(const FeatureType &)> &get_group_name) {
+  const FoldIndexer indexer =
+      leave_one_group_out_indexer<FeatureType>(dataset, get_group_name);
+  return folds_from_fold_indexer<FeatureType>(dataset, indexer);
+}
+
+/*
+ * Computes a PredictDistribution for each fold in set of cross validation
+ * folds.  The resulting vector of PredictDistributions can then be used
+ * for things like computing an EvaluationMetric for each fold, or assembling
+ * all the predictions into a single cross validated PredictionDistribution.
+ */
+template <typename FeatureType>
+static inline std::vector<PredictDistribution> cross_validated_predictions(
+    const std::vector<RegressionFold<FeatureType>> &folds,
+    RegressionModel<FeatureType> *model) {
+  // Iteratively make predictions and assemble the output vector
+  std::vector<PredictDistribution> predictions;
+  for (std::size_t i = 0; i < folds.size(); i++) {
+    predictions.push_back(model->fit_and_predict(
+        folds[i].train_dataset.features, folds[i].train_dataset.targets,
+        folds[i].test_dataset.features));
+  }
+  return predictions;
+}
+
+/*
+ * Iterates over previously computed predictions for each fold and
+ * returns a vector of scores for each fold.
+ */
+template <class FeatureType>
+static inline Eigen::VectorXd
+compute_scores(const EvaluationMetric &metric,
+               const std::vector<RegressionFold<FeatureType>> &folds,
+               const std::vector<PredictDistribution> &predictions) {
+  // Create a vector of metrics, one for each fold.
+  Eigen::VectorXd metrics(static_cast<s32>(folds.size()));
+  // Loop over each fold, making predictions then evaluating them
+  // to create the final output.
+  for (std::size_t i = 0; i < folds.size(); i++) {
+    metrics[static_cast<s32>(i)] =
+        metric(predictions[i], folds[i].test_dataset.targets);
+  }
+  return metrics;
+}
+
+/*
+ * Iterates over each fold in a cross validation set and fits/predicts and
+ * scores the fold, returning a vector of scores for each fold.
+ */
+template <class FeatureType>
+static inline Eigen::VectorXd
+cross_validated_scores(const EvaluationMetric &metric,
+                       const std::vector<RegressionFold<FeatureType>> &folds,
+                       RegressionModel<FeatureType> *model) {
+  // Create a vector of predictions.
+  std::vector<PredictDistribution> predictions =
+      cross_validated_predictions<FeatureType>(folds, model);
+  return compute_scores(metric, folds, predictions);
+}
+
+/*
+ * Returns a single cross validated prediction distribution
+ * for some cross validation folds, taking into account the
+ * fact that each fold may contain reordered data.
+ *
+ * Note that the prediction covariance is not propagated
+ * which is a result of having made predictions one fold at
+ * a time, so the full dense prediction covariance is
+ * unknown.
+ */
+template <typename FeatureType>
+static inline PredictDistribution
+cross_validated_predict(const std::vector<RegressionFold<FeatureType>> &folds,
+                        RegressionModel<FeatureType> *model) {
+  // Get the cross validated predictions, note however that
+  // depending on the type of folds, these predictions may
+  // be shuffled.
+  const std::vector<PredictDistribution> predictions =
+      cross_validated_predictions<FeatureType>(folds, model);
+  // Create a new prediction mean that will eventually contain
+  // the ordered concatenation of each fold's predictions.
+  s32 n = 0;
+  for (const auto &pred : predictions) {
+    n += static_cast<s32>(pred.mean.size());
+  }
+  Eigen::VectorXd mean(n);
+  // Put all the predicted means back in order.
+  for (s32 j = 0; j < static_cast<s32>(predictions.size()); j++) {
+    const auto pred = predictions[j];
+    const auto fold = folds[j];
+    for (s32 i = 0; i < static_cast<s32>(pred.mean.size()); i++) {
+      mean[static_cast<s32>(fold.test_indices[static_cast<std::size_t>(i)])] =
+          pred.mean[i];
+    }
+  }
+  return PredictDistribution(mean);
+}
+
+} // namespace albatross
+
+#endif

--- a/albatross/crossvalidation.h
+++ b/albatross/crossvalidation.h
@@ -210,7 +210,7 @@ cross_validated_scores(const EvaluationMetric &metric,
  * for some cross validation folds, taking into account the
  * fact that each fold may contain reordered data.
  *
- * Note that the prediction covariance is not propagated
+ * Note that the prediction covariance is not returned
  * which is a result of having made predictions one fold at
  * a time, so the full dense prediction covariance is
  * unknown.

--- a/albatross/evaluate.h
+++ b/albatross/evaluate.h
@@ -14,6 +14,7 @@
 #define ALBATROSS_EVALUATE_H
 
 #include "core/model.h"
+#include "crossvalidation.h"
 #include <Eigen/Cholesky>
 #include <Eigen/Dense>
 #include <functional>
@@ -24,38 +25,24 @@
 namespace albatross {
 
 /*
- * An evaluation metric is a function that takes a prediction distribution and
- * corresponding targets and returns a single real value that summarizes
- * the quality of the prediction.
- */
-using EvaluationMetric = std::function<double(
-    const PredictDistribution &prediction, const TargetDistribution &targets)>;
-
-/*
  * Computes the negative log likelihood under the assumption that the predcitve
  * distribution is multivariate normal.
  */
 static inline double
-negative_log_likelihood(const PredictDistribution &prediction,
-                        const TargetDistribution &truth) {
-
-  const auto mean = prediction.mean;
-  Eigen::MatrixXd covariance(prediction.covariance);
-
-  if (truth.has_covariance()) {
-    covariance += truth.covariance;
-  }
-
+negative_log_likelihood(const Eigen::VectorXd &mean,
+                        const Eigen::MatrixXd &covariance) {
   auto llt = covariance.llt();
   auto cholesky = llt.matrixL();
   double det = cholesky.determinant();
   double log_det = log(det);
-  Eigen::VectorXd normalized_residuals(truth.size());
-  normalized_residuals = cholesky.solve(mean - truth.mean);
+  Eigen::VectorXd normalized_residuals(mean.size());
+  normalized_residuals = cholesky.solve(mean);
   double residuals = normalized_residuals.dot(normalized_residuals);
   return 0.5 *
-         (log_det + residuals + static_cast<double>(truth.size()) * 2 * M_PI);
+         (log_det + residuals + static_cast<double>(mean.size()) * 2 * M_PI);
 }
+
+namespace evaluation_metrics {
 
 static inline double
 root_mean_square_error(const PredictDistribution &prediction,
@@ -78,221 +65,22 @@ static inline double standard_deviation(const PredictDistribution &prediction,
   return std::sqrt(error.dot(error) / (n_elements - 1));
 }
 
-inline FoldIndices get_train_indices(const FoldIndices &test_indices,
-                                     const int n) {
-  const s32 k = static_cast<s32>(test_indices.size());
-  // The train indices are all the indices that are not test indices.
-  FoldIndices train_indices(n - k);
-  s32 train_cnt = 0;
-  for (s32 j = 0; j < n; j++) {
-    if (std::find(test_indices.begin(), test_indices.end(), j) ==
-        test_indices.end()) {
-      train_indices[train_cnt] = j;
-      train_cnt++;
-    }
-  }
-  return train_indices;
-}
-
 /*
- * Each flavor of cross validation can be described by a set of
- * FoldIndices, which store which indices should be used for the
- * test cases.  This function takes a map from FoldName to
- * FoldIndices and a dataset and creates the resulting folds.
+ * Computes the negative log likelihood under the assumption that the predictive
+ * distribution is multivariate normal.
  */
-template <typename FeatureType>
-static inline std::vector<RegressionFold<FeatureType>>
-folds_from_fold_indexer(const RegressionDataset<FeatureType> &dataset,
-                        const FoldIndexer &groups) {
-  // For a dataset with n features, we'll have n folds.
-  const s32 n = static_cast<s32>(dataset.features.size());
-  std::vector<RegressionFold<FeatureType>> folds;
-  // For each fold, partition into train and test sets.
-  for (const auto &pair : groups) {
-    // These get exposed inside the returned RegressionFold and because
-    // we'd like to prevent modification of the output from this function
-    // from changing the input FoldIndexer we perform a copy here.
-    const FoldName group_name(pair.first);
-    const FoldIndices test_indices(pair.second);
-    const auto train_indices = get_train_indices(test_indices, n);
-
-    std::vector<FeatureType> train_features =
-        subset(train_indices, dataset.features);
-    TargetDistribution train_targets = subset(train_indices, dataset.targets);
-
-    std::vector<FeatureType> test_features =
-        subset(test_indices, dataset.features);
-    TargetDistribution test_targets = subset(test_indices, dataset.targets);
-
-    assert(train_features.size() == train_targets.size());
-    assert(test_features.size() == test_targets.size());
-    assert(test_targets.size() + train_targets.size() == n);
-
-    const RegressionDataset<FeatureType> train_split(train_features,
-                                                     train_targets);
-    const RegressionDataset<FeatureType> test_split(test_features,
-                                                    test_targets);
-    folds.push_back(RegressionFold<FeatureType>(train_split, test_split,
-                                                group_name, test_indices));
+static inline double
+negative_log_likelihood(const PredictDistribution &prediction,
+                        const TargetDistribution &truth) {
+  const Eigen::VectorXd mean = prediction.mean - truth.mean;
+  Eigen::MatrixXd covariance(prediction.covariance);
+  if (truth.has_covariance()) {
+    covariance += truth.covariance;
   }
-  return folds;
+  return albatross::negative_log_likelihood(mean, covariance);
 }
 
-template <typename FeatureType>
-static inline FoldIndexer
-leave_one_out_indexer(const RegressionDataset<FeatureType> &dataset) {
-  FoldIndexer groups;
-  for (s32 i = 0; i < static_cast<s32>(dataset.features.size()); i++) {
-    FoldName group_name = std::to_string(i);
-    groups[group_name] = {i};
-  }
-  return groups;
-}
-
-/*
- * Splits a dataset into cross validation folds where each fold contains all but
- * one predictor/target pair.
- */
-template <typename FeatureType>
-static inline FoldIndexer leave_one_group_out_indexer(
-    const RegressionDataset<FeatureType> &dataset,
-    const std::function<FoldName(const FeatureType &)> &get_group_name) {
-  FoldIndexer groups;
-  for (s32 i = 0; i < static_cast<s32>(dataset.features.size()); i++) {
-    const std::string k =
-        get_group_name(dataset.features[static_cast<std::size_t>(i)]);
-    // Get the existing indices if we've already encountered this group_name
-    // otherwise initialize a new one.
-    FoldIndices indices;
-    if (groups.find(k) == groups.end()) {
-      indices = FoldIndices();
-    } else {
-      indices = groups[k];
-    }
-    // Add the current index.
-    indices.push_back(i);
-    groups[k] = indices;
-  }
-  return groups;
-}
-
-/*
- * Generates cross validation folds which represent leave one out
- * cross validation.
- */
-template <typename FeatureType>
-static inline std::vector<RegressionFold<FeatureType>>
-leave_one_out(const RegressionDataset<FeatureType> &dataset) {
-  return folds_from_fold_indexer<FeatureType>(
-      dataset, leave_one_out_indexer<FeatureType>(dataset));
-}
-
-/*
- * Uses a `get_group_name` function to bucket each FeatureType into
- * a group, then holds out one group at a time.
- */
-template <typename FeatureType>
-static inline std::vector<RegressionFold<FeatureType>> leave_one_group_out(
-    const RegressionDataset<FeatureType> &dataset,
-    const std::function<FoldName(const FeatureType &)> &get_group_name) {
-  const FoldIndexer indexer =
-      leave_one_group_out_indexer<FeatureType>(dataset, get_group_name);
-  return folds_from_fold_indexer<FeatureType>(dataset, indexer);
-}
-
-/*
- * Computes a PredictDistribution for each fold in set of cross validation
- * folds.  The resulting vector of PredictDistributions can then be used
- * for things like computing an EvaluationMetric for each fold, or assembling
- * all the predictions into a single cross validated PredictionDistribution.
- */
-template <typename FeatureType>
-static inline std::vector<PredictDistribution> cross_validated_predictions(
-    const std::vector<RegressionFold<FeatureType>> &folds,
-    RegressionModel<FeatureType> *model) {
-  // Iteratively make predictions and assemble the output vector
-  std::vector<PredictDistribution> predictions;
-  for (std::size_t i = 0; i < folds.size(); i++) {
-    predictions.push_back(model->fit_and_predict(
-        folds[i].train_dataset.features, folds[i].train_dataset.targets,
-        folds[i].test_dataset.features));
-  }
-  return predictions;
-}
-
-/*
- * Iterates over previously computed predictions for each fold and
- * returns a vector of scores for each fold.
- */
-template <class FeatureType>
-static inline Eigen::VectorXd
-compute_scores(const std::vector<RegressionFold<FeatureType>> &folds,
-               const EvaluationMetric &metric,
-               const std::vector<PredictDistribution> &predictions) {
-  // Create a vector of metrics, one for each fold.
-  Eigen::VectorXd metrics(static_cast<s32>(folds.size()));
-  // Loop over each fold, making predictions then evaluating them
-  // to create the final output.
-  for (std::size_t i = 0; i < folds.size(); i++) {
-    metrics[static_cast<s32>(i)] =
-        metric(predictions[i], folds[i].test_dataset.targets);
-  }
-  return metrics;
-}
-
-/*
- * Iterates over each fold in a cross validation set and fits/predicts and
- * scores the fold, returning a vector of scores for each fold.
- */
-template <class FeatureType>
-static inline Eigen::VectorXd
-cross_validated_scores(const EvaluationMetric &metric,
-                       const std::vector<RegressionFold<FeatureType>> &folds,
-                       RegressionModel<FeatureType> *model) {
-  // Create a vector of predictions.
-  std::vector<PredictDistribution> predictions =
-      cross_validated_predictions<FeatureType>(folds, model);
-  return compute_scores(folds, metric, predictions);
-}
-
-/*
- * Returns a single cross validated prediction distribution
- * for some cross validation folds, taking into account the
- * fact that each fold may contain reordered data.
- *
- * Note that the prediction covariance is not propagated
- * which is a result of having made predictions one fold at
- * a time, so the full dense prediction covariance is
- * unknown.
- */
-template <typename FeatureType>
-static inline PredictDistribution
-cross_validated_predict(const std::vector<RegressionFold<FeatureType>> &folds,
-                        RegressionModel<FeatureType> *model) {
-  // Get the cross validated predictions, note however that
-  // depending on the type of folds, these predictions may
-  // be shuffled.
-  const std::vector<PredictDistribution> predictions =
-      cross_validated_predictions<FeatureType>(folds, model);
-  // Create a new prediction mean that will eventually contain
-  // the ordered concatenation of each fold's predictions.
-  s32 n = 0;
-  for (const auto &pred : predictions) {
-    n += static_cast<s32>(pred.mean.size());
-  }
-  Eigen::VectorXd mean(n);
-  // Put all the predicted means back in order.
-  for (s32 j = 0; j < static_cast<s32>(predictions.size()); j++) {
-    const auto pred = predictions[j];
-    const auto fold = folds[j];
-    for (s32 i = 0; i < static_cast<s32>(pred.mean.size()); i++) {
-      mean[static_cast<s32>(fold.test_indices[static_cast<std::size_t>(i)])] =
-          pred.mean[i];
-    }
-  }
-  return PredictDistribution(mean);
-}
-
+} // namespace evaluation_metrics
 } // namespace albatross
 
 #endif

--- a/albatross/models/gp.h
+++ b/albatross/models/gp.h
@@ -13,6 +13,7 @@
 #ifndef ALBATROSS_GP_GP_H
 #define ALBATROSS_GP_GP_H
 
+#include "evaluate.h"
 #include "stdio.h"
 #include <functional>
 #include <memory>
@@ -159,6 +160,43 @@ private:
   CovarianceFunction covariance_function_;
   std::string model_name_;
 };
+
+/*
+ * The leave one out cross validated predictions for a Gaussian Process
+ * can be efficiently computed by dropping a row and column from the
+ * covariance and obtaining the prediction for the dropped index.  This
+ * results in,
+ *
+ * mean[i] = y[i] - cov^{-1} y)/cov^{-1}[i, i]
+ * variance[i] = 1. / cov^{-1}[i, i]
+ *
+ * See section 5.4.2 Rasmussen Gaussian Processes
+ */
+static inline Distribution<DiagonalMatrixXd>
+fast_gp_loo_predictions(const Eigen::VectorXd &targets,
+                        const Eigen::MatrixXd &train_covariance) {
+  Eigen::VectorXd information = train_covariance.ldlt().solve(targets);
+  Eigen::MatrixXd inverse = train_covariance.inverse();
+
+  Eigen::VectorXd loo_mean(targets);
+  Eigen::VectorXd loo_variance(targets.size());
+  for (Eigen::Index i = 0; i < targets.size(); i++) {
+    loo_mean[i] -= information[i] / inverse(i, i);
+    loo_variance[i] = 1. / inverse(i, i);
+  }
+  return Distribution<DiagonalMatrixXd>(loo_mean, loo_variance.asDiagonal());
+}
+
+template <typename FeatureType>
+static inline Distribution<DiagonalMatrixXd>
+fast_gp_loo_cross_validated_predict(
+    const RegressionDataset<FeatureType> &dataset,
+    SerializableGaussianProcess<FeatureType> *model) {
+  model->fit(dataset);
+  const auto model_fit = model->get_fit();
+  return fast_gp_loo_predictions(dataset.targets.mean,
+                                 model_fit.train_covariance);
+}
 
 template <typename FeatureType, typename CovFunc>
 GaussianProcessRegression<FeatureType, CovFunc>

--- a/albatross/tune.h
+++ b/albatross/tune.h
@@ -14,7 +14,9 @@
 #define ALBATROSS_TUNE_H
 
 #include "core/model.h"
+#include "evaluate.h"
 #include "nlopt.hpp"
+#include "tuning_metrics.h"
 #include <map>
 #include <vector>
 
@@ -40,25 +42,6 @@ inverse_parameters(const std::vector<ParameterValue> &x) {
   std::transform(x.begin(), x.end(), inverted.begin(), double_exp);
 
   return inverted;
-}
-
-template <class FeatureType>
-using TuningMetric = std::function<double(
-    const RegressionDataset<FeatureType> &, RegressionModel<FeatureType> *)>;
-
-using TuningMetricAggregator =
-    std::function<double(const std::vector<double> &metrics)>;
-
-/*
- * Returns the mean of metrics computed across multiple datasets.
- */
-inline double mean_aggregator(const std::vector<double> &metrics) {
-  double mean = 0.;
-  for (const auto &metric : metrics) {
-    mean += metric;
-  }
-  mean /= static_cast<double>(metrics.size());
-  return mean;
 }
 
 template <class FeatureType> struct TuneModelConfg {

--- a/albatross/tuning_metrics.h
+++ b/albatross/tuning_metrics.h
@@ -27,12 +27,14 @@ using TuningMetric = std::function<double(
     const RegressionDataset<FeatureType> &, RegressionModel<FeatureType> *)>;
 
 /*
- * Use caution with this metric!  It assumes that the RegressionModel<T>
- * is actually a SerializableRegressionModel<T, GaussianProcessFit<T>>
+ * Use caution with this metric!  You'll have to manually ensure that
+ * the template parameters are correct for the specific model you wish
+ * to tune as internally it assumes that the RegressionModel<T>
+ * is actually a SerializableRegressionModel<X, GaussianProcessFit<Y>>
  * and if that is not the case at run time a segfault will surely follow.
  *
  * BUT if you do in fact know your regression model is a GP this will
- * result in an order of magnitude faster tuning.
+ * result in n^3 versus n^4 complexity.
  */
 template <typename FeatureType, typename SubFeatureType = FeatureType>
 inline double gp_fast_loo_nll(const RegressionDataset<FeatureType> &dataset,

--- a/albatross/tuning_metrics.h
+++ b/albatross/tuning_metrics.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_TUNING_METRICS_H
+#define ALBATROSS_TUNING_METRICS_H
+
+#include "core/model.h"
+#include "core/serialize.h"
+#include "evaluate.h"
+#include "models/gp.h"
+#include <map>
+#include <vector>
+
+namespace albatross {
+
+template <typename FeatureType>
+using TuningMetric = std::function<double(
+    const RegressionDataset<FeatureType> &, RegressionModel<FeatureType> *)>;
+
+/*
+ * Use caution with this metric!  It assumes that the RegressionModel<T>
+ * is actually a SerializableRegressionModel<T, GaussianProcessFit<T>>
+ * and if that is not the case at run time a segfault will surely follow.
+ *
+ * BUT if you do in fact know your regression model is a GP this will
+ * result in an order of magnitude faster tuning.
+ */
+template <typename FeatureType, typename SubFeatureType = FeatureType>
+inline double gp_fast_loo_nll(const RegressionDataset<FeatureType> &dataset,
+                              RegressionModel<FeatureType> *model) {
+  using SerializableGP =
+      SerializableRegressionModel<FeatureType,
+                                  GaussianProcessFit<SubFeatureType>>;
+  SerializableGP *gp_model = static_cast<SerializableGP *>(model);
+  const auto predictions =
+      fast_gp_loo_cross_validated_predict(dataset, gp_model);
+  const auto deviations = dataset.targets.mean - predictions.mean;
+  return negative_log_likelihood(deviations, predictions.covariance);
+}
+
+inline double loo_nll(const albatross::RegressionDataset<double> &dataset,
+                      albatross::RegressionModel<double> *model) {
+  auto loo_folds = albatross::leave_one_out(dataset);
+  return albatross::cross_validated_scores(
+             albatross::evaluation_metrics::negative_log_likelihood, loo_folds,
+             model)
+      .sum();
+}
+
+inline double loo_rmse(const albatross::RegressionDataset<double> &dataset,
+                       albatross::RegressionModel<double> *model) {
+  auto loo_folds = albatross::leave_one_out(dataset);
+  return albatross::cross_validated_scores(
+             albatross::evaluation_metrics::root_mean_square_error, loo_folds,
+             model)
+      .mean();
+}
+
+using TuningMetricAggregator =
+    std::function<double(const std::vector<double> &metrics)>;
+
+/*
+ * Returns the mean of metrics computed across multiple datasets.
+ */
+inline double mean_aggregator(const std::vector<double> &metrics) {
+  double mean = 0.;
+  for (const auto &metric : metrics) {
+    mean += metric;
+  }
+  mean /= static_cast<double>(metrics.size());
+  return mean;
+}
+
+} // namespace albatross
+#endif

--- a/examples/sinc_example.cc
+++ b/examples/sinc_example.cc
@@ -23,8 +23,9 @@ DEFINE_string(n, "10", "number of training points to use.");
 double loo_nll(const albatross::RegressionDataset<double> &dataset,
                albatross::RegressionModel<double> *model) {
   auto loo_folds = albatross::leave_one_out(dataset);
-  return albatross::cross_validated_scores(albatross::negative_log_likelihood,
-                                           loo_folds, model)
+  return albatross::cross_validated_scores(
+             albatross::evaluation_metrics::negative_log_likelihood, loo_folds,
+             model)
       .mean();
 }
 

--- a/examples/tune_example.cc
+++ b/examples/tune_example.cc
@@ -11,7 +11,6 @@
  */
 
 #include "tune.h"
-#include "evaluate.h"
 #include "example_utils.h"
 #include "gflags/gflags.h"
 #include <functional>
@@ -19,16 +18,6 @@
 DEFINE_string(input, "", "path to csv containing input data.");
 DEFINE_string(output, "", "path where predictions will be written in csv.");
 DEFINE_string(n, "10", "number of training points to use.");
-
-double loo_nll(const albatross::RegressionDataset<double> &dataset,
-               albatross::RegressionModel<double> *model) {
-  std::cout << "create folds" << std::endl;
-  auto loo_folds = albatross::leave_one_out(dataset);
-  std::cout << "cross validate" << std::endl;
-  return albatross::cross_validated_scores(albatross::evaluation_metrics::negative_log_likelihood,
-                                           loo_folds, model)
-      .mean();
-}
 
 int main(int argc, char *argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
@@ -80,7 +69,7 @@ int main(int argc, char *argv[]) {
    * maximize the likelihood (or minimize the negative log likelihood).
    */
   std::cout << "Tuning the model." << std::endl;
-  TuningMetric<double> metric = loo_nll;
+  TuningMetric<double> metric = albatross::gp_fast_loo_nll<double>;
 
   TuneModelConfg<double> config(model_creator, data, metric);
   auto params = tune_regression_model<double>(config);

--- a/examples/tune_example.cc
+++ b/examples/tune_example.cc
@@ -25,7 +25,7 @@ double loo_nll(const albatross::RegressionDataset<double> &dataset,
   std::cout << "create folds" << std::endl;
   auto loo_folds = albatross::leave_one_out(dataset);
   std::cout << "cross validate" << std::endl;
-  return albatross::cross_validated_scores(albatross::negative_log_likelihood,
+  return albatross::cross_validated_scores(albatross::evaluation_metrics::negative_log_likelihood,
                                            loo_folds, model)
       .mean();
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ test_parameter_handling_mixin.cc
 test_models.cc
 test_core_distribution.cc
 test_tune.cc
+test_tuning_metrics.cc
 )
 
 add_dependencies(albatross_unit_tests

--- a/tests/test_evaluate.cc
+++ b/tests/test_evaluate.cc
@@ -23,6 +23,33 @@ namespace albatross {
 
 using albatross::evaluation_metrics::root_mean_square_error;
 
+/* Make sure the multivariate negative log likelihood
+ * matches python.
+ *
+ * import numpy as np
+ * from scipy import stats
+ *
+ * x = np.array([-1, 0., 1])
+ * cov = np.array([[1., 0.9, 0.8],
+ *                 [0.9, 1., 0.9],
+ *                 [0.8, 0.9, 1.]])
+ * stats.multivariate_normal.logpdf(x, np.zeros(x.size), cov)
+ * -6.0946974293510134
+ *
+ */
+TEST(test_evaluate, test_negative_log_likelihood) {
+  Eigen::VectorXd x(3);
+  x << -1., 0., 1.;
+  Eigen::MatrixXd cov(3, 3);
+  cov << 1., 0.9, 0.8, 0.9, 1., 0.9, 0.8, 0.9, 1.;
+
+  const auto nll = albatross::negative_log_likelihood(x, cov);
+  EXPECT_NEAR(nll, -6.0946974293510134, 1e-6);
+
+  const auto ldlt_nll = albatross::negative_log_likelihood(x, cov.ldlt());
+  EXPECT_NEAR(nll, ldlt_nll, 1e-6);
+}
+
 TEST_F(LinearRegressionTest, test_leave_one_out) {
   PredictDistribution preds = model_ptr_->fit_and_predict(
       dataset_.features, dataset_.targets, dataset_.features);

--- a/tests/test_evaluate.cc
+++ b/tests/test_evaluate.cc
@@ -21,6 +21,8 @@
 
 namespace albatross {
 
+using albatross::evaluation_metrics::root_mean_square_error;
+
 TEST_F(LinearRegressionTest, test_leave_one_out) {
   PredictDistribution preds = model_ptr_->fit_and_predict(
       dataset_.features, dataset_.targets, dataset_.features);

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -80,13 +80,12 @@ TEST(test_models, test_with_target_distribution) {
   auto folds = leave_one_out(dataset);
   auto model = MakeGaussianProcess().create();
   auto scores = cross_validated_scores(
-      evaluation_metrics::negative_log_likelihood, folds, model.get());
-
+      evaluation_metrics::root_mean_square_error, folds, model.get());
   RegressionDataset<double> dataset_without_variance(dataset.features,
                                                      dataset.targets.mean);
   auto folds_without_variance = leave_one_out(dataset_without_variance);
   auto scores_without_variance =
-      cross_validated_scores(evaluation_metrics::negative_log_likelihood,
+      cross_validated_scores(evaluation_metrics::root_mean_square_error,
                              folds_without_variance, model.get());
 
   EXPECT_LE(scores.mean(), scores_without_variance.mean());

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -59,8 +59,8 @@ TYPED_TEST(RegressionModelTester, performs_reasonably_on_linear_data) {
   auto dataset = make_toy_linear_data();
   auto folds = leave_one_out(dataset);
   auto model = this->creator.create();
-  auto cv_scores =
-      cross_validated_scores(root_mean_square_error, folds, model.get());
+  auto cv_scores = cross_validated_scores(
+      evaluation_metrics::root_mean_square_error, folds, model.get());
   // Here we make sure the cross validated mean absolute error is reasonable.
   // Note that because we are running leave one out cross validation, the
   // RMSE for each fold is just the absolute value of the error.
@@ -79,14 +79,15 @@ TEST(test_models, test_with_target_distribution) {
 
   auto folds = leave_one_out(dataset);
   auto model = MakeGaussianProcess().create();
-  auto scores =
-      cross_validated_scores(negative_log_likelihood, folds, model.get());
+  auto scores = cross_validated_scores(
+      evaluation_metrics::negative_log_likelihood, folds, model.get());
 
   RegressionDataset<double> dataset_without_variance(dataset.features,
                                                      dataset.targets.mean);
   auto folds_without_variance = leave_one_out(dataset_without_variance);
-  auto scores_without_variance = cross_validated_scores(
-      negative_log_likelihood, folds_without_variance, model.get());
+  auto scores_without_variance =
+      cross_validated_scores(evaluation_metrics::negative_log_likelihood,
+                             folds_without_variance, model.get());
 
   EXPECT_LE(scores.mean(), scores_without_variance.mean());
 }

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -22,7 +22,7 @@ namespace albatross {
 TEST(test_tune, test_single_dataset) {
   auto dataset = make_toy_linear_data();
 
-  auto model_creator = one_dimensional_gaussian_process;
+  auto model_creator = toy_gaussian_process;
 
   TuningMetric<double> metric = loo_nll;
   std::ostringstream output_stream;
@@ -36,7 +36,7 @@ TEST(test_tune, test_multiple_datasets) {
   auto another_dataset = make_toy_linear_data(1., 5., 0.1);
   std::vector<RegressionDataset<double>> datasets = {one_dataset,
                                                      another_dataset};
-  auto model_creator = one_dimensional_gaussian_process;
+  auto model_creator = toy_gaussian_process;
   TuningMetric<double> metric = loo_nll;
   std::ostringstream output_stream;
   TuneModelConfg<double> config(model_creator, datasets, metric,

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -22,8 +22,9 @@ namespace albatross {
 double loo_nll(const albatross::RegressionDataset<double> &dataset,
                albatross::RegressionModel<double> *model) {
   auto loo_folds = albatross::leave_one_out(dataset);
-  return albatross::cross_validated_scores(albatross::negative_log_likelihood,
-                                           loo_folds, model)
+  return albatross::cross_validated_scores(
+             albatross::evaluation_metrics::negative_log_likelihood, loo_folds,
+             model)
       .mean();
 }
 

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -19,28 +19,10 @@
 
 namespace albatross {
 
-double loo_nll(const albatross::RegressionDataset<double> &dataset,
-               albatross::RegressionModel<double> *model) {
-  auto loo_folds = albatross::leave_one_out(dataset);
-  return albatross::cross_validated_scores(
-             albatross::evaluation_metrics::negative_log_likelihood, loo_folds,
-             model)
-      .mean();
-}
-
-std::unique_ptr<RegressionModel<double>> create_model() {
-  using SqrExp = SquaredExponential<ScalarDistance>;
-  using Noise = IndependentNoise<double>;
-  CovarianceFunction<SqrExp> squared_exponential = {SqrExp(100., 100.)};
-  CovarianceFunction<Noise> noise = {Noise(0.1)};
-  auto covariance = squared_exponential + noise;
-  return gp_pointer_from_covariance<double>(covariance);
-}
-
 TEST(test_tune, test_single_dataset) {
   auto dataset = make_toy_linear_data();
 
-  auto model_creator = create_model;
+  auto model_creator = one_dimensional_gaussian_process;
 
   TuningMetric<double> metric = loo_nll;
   std::ostringstream output_stream;
@@ -54,12 +36,12 @@ TEST(test_tune, test_multiple_datasets) {
   auto another_dataset = make_toy_linear_data(1., 5., 0.1);
   std::vector<RegressionDataset<double>> datasets = {one_dataset,
                                                      another_dataset};
-  auto model_creator = create_model;
+  auto model_creator = one_dimensional_gaussian_process;
   TuningMetric<double> metric = loo_nll;
   std::ostringstream output_stream;
   TuneModelConfg<double> config(model_creator, datasets, metric,
                                 albatross::mean_aggregator, output_stream);
-  std::cout << output_stream.str() << std::endl;
   auto params = tune_regression_model(config);
 }
+
 } // namespace albatross

--- a/tests/test_tuning_metrics.cc
+++ b/tests/test_tuning_metrics.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "covariance_functions/covariance_functions.h"
+#include "evaluate.h"
+#include "models/gp.h"
+#include "test_utils.h"
+#include "tune.h"
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+TEST(test_tuning_metrics, test_fast_loo_equals_slow) {
+  auto dataset = make_toy_linear_data();
+
+  auto model_creator = one_dimensional_gaussian_process;
+  auto model = model_creator();
+
+  double fast_loo_nll = gp_fast_loo_nll(dataset, model.get());
+
+  double slow_loo_nll = loo_nll(dataset, model.get());
+
+  EXPECT_NEAR(fast_loo_nll, slow_loo_nll, 1e-6);
+}
+
+/*
+ * Here we setup a typed test to make it easy to add new
+ * tuning metrics and make sure they run fine.
+ */
+
+using DoubleTuningMetric = double(const RegressionDataset<double> &,
+                                  RegressionModel<double> *);
+
+template <DoubleTuningMetric Metric_> struct TestMetric {
+  TuningMetric<double> function = Metric_;
+};
+
+template <typename TestMetric>
+class TuningMetricTester : public ::testing::Test {
+public:
+  TestMetric test_metric;
+};
+
+/*
+ * Add any new tuning metrics here:
+ */
+typedef ::testing::Types<TestMetric<loo_nll>, TestMetric<loo_rmse>,
+                         TestMetric<gp_fast_loo_nll<double>>>
+    MetricsToTest;
+
+TYPED_TEST_CASE(TuningMetricTester, MetricsToTest);
+
+TYPED_TEST(TuningMetricTester, test_sanity) {
+  const auto dataset = make_toy_linear_data();
+  const auto model_creator = one_dimensional_gaussian_process;
+  const auto model = model_creator();
+  const auto metric = this->test_metric.function(dataset, model.get());
+  EXPECT_FALSE(std::isnan(metric));
+}
+
+} // namespace albatross

--- a/tests/test_tuning_metrics.cc
+++ b/tests/test_tuning_metrics.cc
@@ -22,7 +22,7 @@ namespace albatross {
 TEST(test_tuning_metrics, test_fast_loo_equals_slow) {
   auto dataset = make_toy_linear_data();
 
-  auto model_creator = one_dimensional_gaussian_process;
+  auto model_creator = toy_gaussian_process;
   auto model = model_creator();
 
   double fast_loo_nll = gp_fast_loo_nll(dataset, model.get());
@@ -61,10 +61,20 @@ TYPED_TEST_CASE(TuningMetricTester, MetricsToTest);
 
 TYPED_TEST(TuningMetricTester, test_sanity) {
   const auto dataset = make_toy_linear_data();
-  const auto model_creator = one_dimensional_gaussian_process;
+  const auto model_creator = toy_gaussian_process;
   const auto model = model_creator();
   const auto metric = this->test_metric.function(dataset, model.get());
   EXPECT_FALSE(std::isnan(metric));
+}
+
+TEST(test_tuning_metrics, test_fast_loo_works_on_adapted_model) {
+  auto dataset = make_adapted_toy_linear_data();
+
+  auto model_creator = adapted_toy_gaussian_process;
+  auto model = model_creator();
+
+  double fast_loo_nll =
+      gp_fast_loo_nll<AdaptedFeature, double>(dataset, model.get());
 }
 
 } // namespace albatross

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -205,6 +205,17 @@ public:
   std::unique_ptr<LinearRegression> model_ptr_;
   RegressionDataset<double> dataset_;
 };
+
+static inline std::unique_ptr<RegressionModel<double>>
+one_dimensional_gaussian_process() {
+  using SqrExp = SquaredExponential<ScalarDistance>;
+  using Noise = IndependentNoise<double>;
+  CovarianceFunction<SqrExp> squared_exponential = {SqrExp(100., 100.)};
+  CovarianceFunction<Noise> noise = {Noise(0.1)};
+  auto covariance = squared_exponential + noise;
+  return gp_pointer_from_covariance<double>(covariance);
+}
+
 } // namespace albatross
 
 #endif


### PR DESCRIPTION
This changes implements the linear algebra trick mentioned in 5.4.2 of Rasmussen Gaussian Processes for Machine Learning, in which the LOO cross validated predictions can be computed by what amounts to iteratively dropping rows and columns.

Includes:

- Cross validation utilities have been moved to their own file `crossvalidation.h`.
- A variety of forms for computing the negative log likelihood of some data from a normal distributions.
- Tests to make sure the negative log likelihoods are consistent.
- A templated test for tuning metrics to make it easy to test new metrics.