### PR TITLE
Serializable LDLT Decomposition.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ cache:
 matrix:
   fast_finish: true
   include:
-  - compiler: gcc
+  - compiler: gcc-6
     addons:
       apt:
         sources:
           - ubuntu-toolchain-r-test
         packages:
-          - g++-5
+          - g++-6
           - libc++-dev
           - libc++abi-dev
           - clang-3.8
@@ -28,8 +28,8 @@ matrix:
           - clang-tidy-3.8
           - libnlopt-dev
     env:
-      - C_COMPILER=gcc-5 CXX_COMPILER=g++-5 COVERAGE=''
-  - compiler: clang
+      - C_COMPILER=gcc-6 CXX_COMPILER=g++-6 COVERAGE=''
+  - compiler: clang-3.8
     addons:
       apt:
         sources:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(albatross_HEADERS
     albatross/core/serialize.h
     albatross/core/parameter_handling_mixin.h    
     albatross/cereal/eigen.h
+    albatross/eigen/serializable_ldlt.h
     albatross/models/gp.h
     albatross/models/least_squares.h
     albatross/covariance_functions/covariance_term.h

--- a/albatross/eigen/serializable_ldlt.h
+++ b/albatross/eigen/serializable_ldlt.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_EIGEN_SERIALIZABLE_LDLT_H
+#define ALBATROSS_EIGEN_SERIALIZABLE_LDLT_H
+
+#include "Eigen/Cholesky"
+#include "Eigen/Dense"
+#include "cereal/cereal.hpp"
+#include <math.h>
+
+namespace Eigen {
+
+template <class Archive, typename _Scalar, int _Rows, int _Cols>
+inline void save_lower_triangle(Archive &archive,
+                                const Eigen::Matrix<_Scalar, _Rows, _Cols> &v) {
+  cereal::size_type rows = static_cast<cereal::size_type>(v.rows());
+  cereal::size_type storage_size = (rows * rows + rows) / 2;
+  archive(cereal::make_size_tag(storage_size));
+  for (cereal::size_type i = 0; i < rows; i++) {
+    for (cereal::size_type j = 0; j <= i; j++) {
+      archive(v(i, j));
+    }
+  }
+}
+
+template <class Archive, typename _Scalar, int _Rows, int _Cols>
+inline void load_lower_triangle(Archive &archive,
+                                Eigen::Matrix<_Scalar, _Rows, _Cols> &v) {
+  cereal::size_type storage_size;
+  archive(cereal::make_size_tag(storage_size));
+  // We assume the matrix is square and compute the number of rows from the
+  // storage size.
+  double drows = (std::sqrt(static_cast<double>(storage_size * 8 + 1)) - 1) / 2;
+  cereal::size_type rows = static_cast<cereal::size_type>(drows);
+  v.resize(rows, rows);
+  for (cereal::size_type i = 0; i < rows; i++) {
+    for (cereal::size_type j = 0; j <= i; j++) {
+      archive(v(i, j));
+    }
+  }
+}
+
+template <typename MatrixType = MatrixXd>
+class SerializableLDLT : public LDLT<MatrixType, Lower> {
+public:
+  SerializableLDLT() : LDLT<MatrixType, Lower>(){};
+
+  SerializableLDLT(const LDLT<MatrixType, Lower> &ldlt)
+      : LDLT<MatrixType, Lower>(ldlt){};
+
+  template <typename Archive> void save(Archive &archive) const {
+    save_lower_triangle(archive, this->m_matrix);
+    archive(this->m_transpositions, this->m_isInitialized);
+  }
+
+  template <typename Archive> void load(Archive &archive) {
+    load_lower_triangle(archive, this->m_matrix);
+    archive(this->m_transpositions, this->m_isInitialized);
+  }
+
+  bool operator==(const SerializableLDLT &rhs) const {
+    // Make sure the two lower triangles are the same and that
+    // any permutations are identical.
+    auto this_lower =
+        MatrixXd(MatrixXd(this->matrixLDLT()).triangularView<Eigen::Lower>());
+    auto rhs_lower =
+        MatrixXd(MatrixXd(rhs.matrixLDLT()).triangularView<Eigen::Lower>());
+    return (this_lower == rhs_lower &&
+            this->transpositionsP().indices() ==
+                rhs.transpositionsP().indices());
+  }
+};
+
+} // namesapce Eigen
+
+#endif

--- a/albatross/models/gp.h
+++ b/albatross/models/gp.h
@@ -21,6 +21,7 @@
 #include "cereal/eigen.h"
 #include "core/model.h"
 #include "core/serialize.h"
+#include "eigen/serializable_ldlt.h"
 
 namespace albatross {
 

--- a/albatross/models/gp.h
+++ b/albatross/models/gp.h
@@ -179,14 +179,12 @@ fast_gp_loo_cross_validated_predict(
   assert(targets.size() == train_covariance_ldlt.rows());
   assert(train_covariance_ldlt.rows() == train_covariance_ldlt.cols());
   Eigen::VectorXd information = train_covariance_ldlt.solve(targets);
-  const auto inverse = train_covariance_ldlt.solve(
-      Eigen::MatrixXd::Identity(targets.size(), targets.size()));
-
+  const auto inverse_diag = train_covariance_ldlt.inverse_diagonal();
   Eigen::VectorXd loo_mean(targets);
   Eigen::VectorXd loo_variance(targets.size());
   for (Eigen::Index i = 0; i < targets.size(); i++) {
-    loo_mean[i] -= information[i] / inverse(i, i);
-    loo_variance[i] = 1. / inverse(i, i);
+    loo_mean[i] -= information[i] / inverse_diag(i);
+    loo_variance[i] = 1. / inverse_diag(i);
   }
   return Distribution<DiagonalMatrixXd>(loo_mean, loo_variance.asDiagonal());
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ test_models.cc
 test_core_distribution.cc
 test_tune.cc
 test_tuning_metrics.cc
+test_serializable_ldlt.cc
 )
 
 add_dependencies(albatross_unit_tests

--- a/tests/test_serializable_ldlt.cc
+++ b/tests/test_serializable_ldlt.cc
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <gtest/gtest.h>
+
+#include "eigen/serializable_ldlt.h"
+
+namespace albatross {
+
+/*
+ * This test makes sure that we can make predictions of what
+ * the attenuation of a signal would be at some unobserved location.
+ */
+TEST(test_scaling_functions, test_predicts) {
+  auto part = Eigen::MatrixXd::Random(n, n);
+  auto cov = part * part.transpose();
+  auto ldlt = cov.ldlt();
+  auto information = Eigen::VectorXd::Ones(n);
+
+}
+
+} // namespace albatross

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -99,12 +99,15 @@ struct EigenMatrixXd : public SerializableType<Eigen::MatrixXd> {
   }
 };
 
-struct LDLT
-    : public SerializableType<Eigen::SerializableLDLT<Eigen::MatrixXd>> {
+struct LDLT : public SerializableType<Eigen::SerializableLDLT> {
   Eigen::Index n = 3;
 
   RepresentationType create() const override {
-    auto part = Eigen::MatrixXd::Random(n, n);
+    // This looks weird, but without forcing this to a Eigen::MatrixXd
+    // type every time `part` is accessed it'll have new random values!
+    // so part.tranpose() will not be the transpose of `part` but the
+    // transpose of some new random matrix.  Seems like a bug to me.
+    const auto part = Eigen::MatrixXd(Eigen::MatrixXd::Random(n, n));
     auto cov = part * part.transpose();
     auto ldlt = cov.ldlt();
     auto information = Eigen::VectorXd::Ones(n);

--- a/tests/test_tuning_metrics.cc
+++ b/tests/test_tuning_metrics.cc
@@ -20,7 +20,7 @@
 namespace albatross {
 
 TEST(test_tuning_metrics, test_fast_loo_equals_slow) {
-  auto dataset = make_toy_linear_data();
+  auto dataset = make_toy_linear_data(5., 1., 0.1, 4);
 
   auto model_creator = toy_gaussian_process;
   auto model = model_creator();
@@ -60,7 +60,8 @@ typedef ::testing::Types<TestMetric<loo_nll>, TestMetric<loo_rmse>,
 TYPED_TEST_CASE(TuningMetricTester, MetricsToTest);
 
 TYPED_TEST(TuningMetricTester, test_sanity) {
-  const auto dataset = make_toy_linear_data();
+  const auto dataset = make_toy_linear_data(5., 1., 0.1, 4);
+  ;
   const auto model_creator = toy_gaussian_process;
   const auto model = model_creator();
   const auto metric = this->test_metric.function(dataset, model.get());

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -150,13 +150,12 @@ expect_parameter_vector_equal(const std::vector<ParameterValue> &x,
 
 static inline auto make_toy_linear_data(const double a = 5.,
                                         const double b = 1.,
-                                        const double sigma = 0.1) {
+                                        const double sigma = 0.1,
+                                        const s32 n = 10) {
   std::random_device rd{};
   std::mt19937 gen{rd()};
   gen.seed(3);
   std::normal_distribution<> d{0., sigma};
-
-  s32 n = 10;
   std::vector<double> features;
   Eigen::VectorXd targets(n);
 


### PR DESCRIPTION
Adds an extention of Eigen's LDLT which is serializable and only serializes the lower triangular portion.

Changes include:
- Generalization of the existing Matrix serialization routines to allow different scalar types.  What were previously separate serializations routines for `Matrix3d` and `MatrixXd` are now handled in a single case which also allows for different internal types.
- Addition of the `SerializableLDLT` class which wraps `LDLT<MatrixXd>`.
- Use of `SerilizableLDLT` in `GaussianProcessFit`.
- Extended `test_serilalize` to test more than just the models.