### PR TITLE
Add ability to serialize Distributions and RegressionDatasets.

### DIFF
--- a/albatross/core/distribution.h
+++ b/albatross/core/distribution.h
@@ -54,9 +54,9 @@ template <typename CovarianceType> struct Distribution {
       : mean(mean_), covariance(covariance_){};
 };
 
+using DiagonalMatrixXd = Eigen::DiagonalMatrix<double, Eigen::Dynamic>;
 using DenseDistribution = Distribution<Eigen::MatrixXd>;
-using DiagonalDistribution =
-    Distribution<Eigen::DiagonalMatrix<double, Eigen::Dynamic>>;
+using DiagonalDistribution = Distribution<DiagonalMatrixXd>;
 
 template <typename CovarianceType, typename SizeType>
 Distribution<CovarianceType> subset(const std::vector<SizeType> &indices,
@@ -69,6 +69,7 @@ Distribution<CovarianceType> subset(const std::vector<SizeType> &indices,
     return Distribution<CovarianceType>(mean);
   }
 }
+
 } // namespace albatross
 
 #endif

--- a/albatross/core/distribution.h
+++ b/albatross/core/distribution.h
@@ -13,6 +13,9 @@
 #ifndef ALBATROSS_CORE_DISTRIBUTION_H
 #define ALBATROSS_CORE_DISTRIBUTION_H
 
+#include "cereal/cereal.hpp"
+#include "core/traits.h"
+#include "eigen/serializable_diagonal_matrix.h"
 #include "indexing.h"
 #include <Eigen/Core>
 #include <iostream>
@@ -52,9 +55,38 @@ template <typename CovarianceType> struct Distribution {
   Distribution(const Eigen::VectorXd &mean_) : mean(mean_), covariance(){};
   Distribution(const Eigen::VectorXd &mean_, const CovarianceType &covariance_)
       : mean(mean_), covariance(covariance_){};
+
+  /*
+   * If the CovarianceType is serializable, add a serialize method.
+   */
+  template <class Archive>
+  typename std::enable_if<
+      valid_in_out_serializer<CovarianceType, Archive>::value, void>::type
+  serialize(Archive &archive) {
+    archive(cereal::make_nvp("mean", mean));
+    archive(cereal::make_nvp("covariance", covariance));
+  }
+
+  /*
+   * If you try to serialize a Distribution for which the covariance
+   * type is not serializable you'll get an error.
+   */
+  template <class Archive>
+  typename std::enable_if<
+      !valid_in_out_serializer<CovarianceType, Archive>::value, void>::type
+  save(Archive &archive) {
+    static_assert(delay_static_assert<Archive>::value,
+                  "In order to serialize a Distribution the corresponding "
+                  "CovarianceType must be serializable.");
+  }
+
+  bool operator==(const Distribution &other) const {
+    return (mean == other.mean && covariance == other.covariance);
+  }
 };
 
-using DiagonalMatrixXd = Eigen::DiagonalMatrix<double, Eigen::Dynamic>;
+using DiagonalMatrixXd =
+    Eigen::SerializableDiagonalMatrix<double, Eigen::Dynamic>;
 using DenseDistribution = Distribution<Eigen::MatrixXd>;
 using DiagonalDistribution = Distribution<DiagonalMatrixXd>;
 

--- a/albatross/eigen/serializable_diagonal_matrix.h
+++ b/albatross/eigen/serializable_diagonal_matrix.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_EIGEN_SERIALIZABLE_DIAGONAL_MATRIX_H
+#define ALBATROSS_EIGEN_SERIALIZABLE_DIAGONAL_MATRIX_H
+
+/*
+ * The Eigen::DiagonalMatrix doesn't provide the public methods
+ * required to reliably serialize the `m_diagonal` private
+ * member.  In order to make the DiagonalMatrix serializable
+ * we instead inherit from it, giving private access to the
+ * diagonal elements which in turn allows us to serialize it.
+ */
+
+#include "Eigen/Cholesky"
+#include "Eigen/Dense"
+#include "cereal/cereal.hpp"
+#include <math.h>
+
+namespace Eigen {
+
+template <typename _Scalar, int SizeAtCompileTime>
+class SerializableDiagonalMatrix
+    : public Eigen::DiagonalMatrix<_Scalar, SizeAtCompileTime> {
+  using BaseClass = Eigen::DiagonalMatrix<_Scalar, SizeAtCompileTime>;
+
+public:
+  SerializableDiagonalMatrix() : BaseClass(){};
+
+  SerializableDiagonalMatrix(const BaseClass &other)
+      // Can we get around copying here?
+      : BaseClass(other){};
+
+  template <typename OtherDerived>
+  inline SerializableDiagonalMatrix(const DiagonalBase<OtherDerived> &other)
+      : BaseClass(other){};
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::make_nvp("diagonal", this->m_diagonal));
+  }
+
+  bool operator==(const BaseClass &other) const {
+    return (this->m_diagonal == other.diagonal());
+  }
+};
+
+} // namesapce Eigen
+
+#endif

--- a/albatross/eigen/serializable_diagonal_matrix.h
+++ b/albatross/eigen/serializable_diagonal_matrix.h
@@ -36,10 +36,6 @@ class SerializableDiagonalMatrix
 public:
   SerializableDiagonalMatrix() : BaseClass(){};
 
-  SerializableDiagonalMatrix(const BaseClass &other)
-      // Can we get around copying here?
-      : BaseClass(other){};
-
   template <typename OtherDerived>
   inline SerializableDiagonalMatrix(const DiagonalBase<OtherDerived> &other)
       : BaseClass(other){};

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -99,6 +99,39 @@ struct EigenMatrixXd : public SerializableType<Eigen::MatrixXd> {
   }
 };
 
+struct FullDenseDistribution : public SerializableType<DenseDistribution> {
+  DenseDistribution create() const override {
+    Eigen::MatrixXd cov(3, 3);
+    cov << 1., 2., 3., 4., 5., 6., 7, 8, 9;
+    Eigen::VectorXd mean = Eigen::VectorXd::Ones(3);
+    return DenseDistribution(mean, cov);
+  }
+};
+
+struct MeanOnlyDenseDistribution : public SerializableType<DenseDistribution> {
+  DenseDistribution create() const override {
+    Eigen::MatrixXd mean = Eigen::VectorXd::Ones(3);
+    return DenseDistribution(mean);
+  }
+};
+
+struct FullDiagonalDistribution
+    : public SerializableType<DiagonalDistribution> {
+  DiagonalDistribution create() const override {
+    Eigen::VectorXd diag = Eigen::VectorXd::Ones(3);
+    Eigen::VectorXd mean = Eigen::VectorXd::Ones(3);
+    return DiagonalDistribution(mean, diag.asDiagonal());
+  }
+};
+
+struct MeanOnlyDiagonalDistribution
+    : public SerializableType<DiagonalDistribution> {
+  DiagonalDistribution create() const override {
+    Eigen::MatrixXd mean = Eigen::VectorXd::Ones(3);
+    return DiagonalDistribution(mean);
+  }
+};
+
 struct LDLT : public SerializableType<Eigen::SerializableLDLT> {
   Eigen::Index n = 3;
 
@@ -281,10 +314,12 @@ struct PolymorphicSerializeTest : public ::testing::Test {
 typedef ::testing::Types<
     LDLT, SerializableType<Eigen::Matrix3d>, SerializableType<Eigen::Matrix2i>,
     EmptyEigenVectorXd, EigenVectorXd, EmptyEigenMatrixXd, EigenMatrixXd,
-    ParameterStoreType, SerializableType<MockModel>, UnfitSerializableModel,
-    FitSerializableModel, FitDirectModel, UnfitDirectModel,
-    UnfitRegressionModel, FitLinearRegressionModel,
-    FitLinearSerializablePointer, UnfitGaussianProcess, FitGaussianProcess>
+    FullDenseDistribution, MeanOnlyDenseDistribution, FullDiagonalDistribution,
+    MeanOnlyDiagonalDistribution, ParameterStoreType,
+    SerializableType<MockModel>, UnfitSerializableModel, FitSerializableModel,
+    FitDirectModel, UnfitDirectModel, UnfitRegressionModel,
+    FitLinearRegressionModel, FitLinearSerializablePointer,
+    UnfitGaussianProcess, FitGaussianProcess>
     ToTest;
 
 TYPED_TEST_CASE(PolymorphicSerializeTest, ToTest);


### PR DESCRIPTION
This gives you the ability to serialize a `RegressionDataset` provided the `FeatureType` is also serializable.  This can come in handy when it's costly to parse data and convert it into the required `features` and `targets`.  For example, you can now you can do something like:

```
// Parse data and cache it.
std::vector<RegressionDataset<MyFeature>> datasets = parse_lots_of_data();
{
  std::ofstream ofs(cache_path);
  cereal::BinaryOutputArchive archive(ofs);
  archive(datasets);
}
```
Allowing you to read them in much faster next time,
```
// Read the cached datasets.
std::vector<RegressionDataset<MyFeature>> datasets;
{
  std::ifstream ifs(cache_path);
  cereal::BinaryInputArchive archive(ofs);
  archive(datasets);
}
```