### PR TITLE
Allow faster predict methods.

### DIFF
--- a/albatross/core/distribution.h
+++ b/albatross/core/distribution.h
@@ -85,9 +85,17 @@ template <typename CovarianceType> struct Distribution {
   }
 };
 
+// A JointDistribution has a dense covariance matrix, which
+// contains the covariance between each variable and all others.
+using JointDistribution = Distribution<Eigen::MatrixXd>;
+
+// We use a wrapper around DiagonalMatrix in order to make
+// the resulting distribution serializable
 using DiagonalMatrixXd =
     Eigen::SerializableDiagonalMatrix<double, Eigen::Dynamic>;
-using JointDistribution = Distribution<Eigen::MatrixXd>;
+// A MarginalDistribution has only a digaonal covariance
+// matrix, so in turn only describes the variance of each
+// variable independent of all others.
 using MarginalDistribution = Distribution<DiagonalMatrixXd>;
 
 template <typename CovarianceType, typename SizeType>

--- a/albatross/core/distribution.h
+++ b/albatross/core/distribution.h
@@ -87,8 +87,8 @@ template <typename CovarianceType> struct Distribution {
 
 using DiagonalMatrixXd =
     Eigen::SerializableDiagonalMatrix<double, Eigen::Dynamic>;
-using DenseDistribution = Distribution<Eigen::MatrixXd>;
-using DiagonalDistribution = Distribution<DiagonalMatrixXd>;
+using JointDistribution = Distribution<Eigen::MatrixXd>;
+using MarginalDistribution = Distribution<DiagonalMatrixXd>;
 
 template <typename CovarianceType, typename SizeType>
 Distribution<CovarianceType> subset(const std::vector<SizeType> &indices,

--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -168,6 +168,27 @@ public:
     return predict(features);
   }
 
+  DiagonalDistribution
+  predict_marginal(const std::vector<FeatureType> &features) const {
+    assert(has_been_fit());
+    DiagonalDistribution preds = predict_marginal_(features);
+    assert(static_cast<s32>(preds.mean.size()) ==
+           static_cast<s32>(features.size()));
+    return preds;
+  }
+
+  Eigen::VectorXd predict_mean(const std::vector<FeatureType> &features) const {
+    assert(has_been_fit());
+    Eigen::VectorXd preds = predict_mean_(features);
+    assert(static_cast<s32>(preds.size()) == static_cast<s32>(features.size()));
+    return preds;
+  }
+
+  double predict_mean(const FeatureType &feature) const {
+    std::vector<FeatureType> features = {feature};
+    return predict_mean(features)[0];
+  }
+
   /*
    * Computes predictions for the test features given set of training
    * features and targets. In the general case this is simply a call to fit,
@@ -232,6 +253,24 @@ protected:
 
   virtual PredictDistribution
   predict_(const std::vector<FeatureType> &features) const = 0;
+
+  virtual DiagonalDistribution
+  predict_marginal_(const std::vector<FeatureType> &features) const {
+    std::cout << "WARNING: A marginal prediction is being made, but in a "
+                 "horribly inefficient way.";
+    const auto full_distribution = predict_(features);
+    return DiagonalDistribution(
+        full_distribution.mean,
+        full_distribution.covariance.diagonal().asDiagonal());
+  }
+
+  virtual Eigen::VectorXd
+  predict_mean_(const std::vector<FeatureType> &features) const {
+    std::cout << "WARNING: A mean prediction is being made, but in a horribly "
+                 "inefficient way.";
+    const auto full_distribution = predict_(features);
+    return full_distribution.mean;
+  }
 
   bool has_been_fit_;
 };

--- a/albatross/core/model_adapter.h
+++ b/albatross/core/model_adapter.h
@@ -142,6 +142,16 @@ protected:
     return sub_model_.predict(convert_features(features));
   }
 
+  virtual DiagonalDistribution
+  predict_marginal_(const std::vector<FeatureType> &features) const override {
+    return sub_model_.predict_marginal(convert_features(features));
+  }
+
+  virtual Eigen::VectorXd
+  predict_mean_(const std::vector<FeatureType> &features) const override {
+    return sub_model_.predict_mean(convert_features(features));
+  }
+
   const std::vector<SubFeature>
   convert_features(const std::vector<FeatureType> &parent_features) const {
     std::vector<SubFeature> converted;

--- a/albatross/core/model_adapter.h
+++ b/albatross/core/model_adapter.h
@@ -119,7 +119,7 @@ public:
 
 protected:
   void fit_(const std::vector<FeatureType> &features,
-            const TargetDistribution &targets) override {
+            const MarginalDistribution &targets) override {
     this->sub_model_.fit(convert_features(features), targets);
   }
 
@@ -130,19 +130,19 @@ protected:
    */
   fit_type_if_serializable<RegressionModelImplementation>
   serializable_fit_(const std::vector<FeatureType> &features,
-                    const TargetDistribution &targets) const override {
+                    const MarginalDistribution &targets) const override {
     assert(false &&
            "serializable_fit_ for an adapted model should never be called");
     typename fit_type_or_void<RegressionModelImplementation>::type dummy;
     return dummy;
   }
 
-  PredictDistribution
+  JointDistribution
   predict_(const std::vector<FeatureType> &features) const override {
     return sub_model_.predict(convert_features(features));
   }
 
-  virtual DiagonalDistribution
+  virtual MarginalDistribution
   predict_marginal_(const std::vector<FeatureType> &features) const override {
     return sub_model_.predict_marginal(convert_features(features));
   }

--- a/albatross/core/serialize.h
+++ b/albatross/core/serialize.h
@@ -89,13 +89,13 @@ public:
 
 protected:
   void fit_(const std::vector<FeatureType> &features,
-            const TargetDistribution &targets) {
+            const MarginalDistribution &targets) {
     model_fit_ = serializable_fit_(features, targets);
   }
 
   virtual ModelFit
   serializable_fit_(const std::vector<FeatureType> &features,
-                    const TargetDistribution &targets) const = 0;
+                    const MarginalDistribution &targets) const = 0;
 
   ModelFit model_fit_;
 };

--- a/albatross/evaluate.h
+++ b/albatross/evaluate.h
@@ -106,8 +106,8 @@ negative_log_likelihood(const Eigen::VectorXd &deviation,
 namespace evaluation_metrics {
 
 static inline double
-root_mean_square_error(const PredictDistribution &prediction,
-                       const TargetDistribution &truth) {
+root_mean_square_error(const JointDistribution &prediction,
+                       const MarginalDistribution &truth) {
   const Eigen::VectorXd error = prediction.mean - truth.mean;
   double mse = error.dot(error) / static_cast<double>(error.size());
   return sqrt(mse);
@@ -117,8 +117,8 @@ root_mean_square_error(const PredictDistribution &prediction,
  * Takes output from a model (PredictionDistribution)
  * and the corresponding truth and uses them to compute the stddev.
  */
-static inline double standard_deviation(const PredictDistribution &prediction,
-                                        const TargetDistribution &truth) {
+static inline double standard_deviation(const JointDistribution &prediction,
+                                        const MarginalDistribution &truth) {
   Eigen::VectorXd error = prediction.mean - truth.mean;
   const auto n_elements = static_cast<double>(error.size());
   const double mean_error = error.sum() / n_elements;
@@ -131,8 +131,8 @@ static inline double standard_deviation(const PredictDistribution &prediction,
  * distribution is multivariate normal.
  */
 static inline double
-negative_log_likelihood(const PredictDistribution &prediction,
-                        const TargetDistribution &truth) {
+negative_log_likelihood(const JointDistribution &prediction,
+                        const MarginalDistribution &truth) {
   const Eigen::VectorXd mean = prediction.mean - truth.mean;
   Eigen::MatrixXd covariance(prediction.covariance);
   if (truth.has_covariance()) {

--- a/albatross/evaluate.h
+++ b/albatross/evaluate.h
@@ -105,9 +105,8 @@ negative_log_likelihood(const Eigen::VectorXd &deviation,
  */
 namespace evaluation_metrics {
 
-static inline double
-root_mean_square_error(const JointDistribution &prediction,
-                       const MarginalDistribution &truth) {
+static inline double root_mean_square_error(const JointDistribution &prediction,
+                                            const MarginalDistribution &truth) {
   const Eigen::VectorXd error = prediction.mean - truth.mean;
   double mse = error.dot(error) / static_cast<double>(error.size());
   return sqrt(mse);

--- a/albatross/models/gp.h
+++ b/albatross/models/gp.h
@@ -127,8 +127,9 @@ public:
   }
 
 protected:
-  FitType serializable_fit_(const std::vector<FeatureType> &features,
-                            const MarginalDistribution &targets) const override {
+  FitType
+  serializable_fit_(const std::vector<FeatureType> &features,
+                    const MarginalDistribution &targets) const override {
     Eigen::MatrixXd cov = symmetric_covariance(covariance_function_, features);
     FitType model_fit;
     model_fit.train_features = features;
@@ -145,7 +146,6 @@ protected:
   predict_(const std::vector<FeatureType> &features) const override {
     const auto cross_cov = asymmetric_covariance(
         covariance_function_, features, this->model_fit_.train_features);
-    // Then we can use the information vector to determine the posterior
     const Eigen::VectorXd pred = cross_cov * this->model_fit_.information;
     Eigen::MatrixXd pred_cov =
         symmetric_covariance(covariance_function_, features);
@@ -158,9 +158,9 @@ protected:
   predict_marginal_(const std::vector<FeatureType> &features) const override {
     const auto cross_cov = asymmetric_covariance(
         covariance_function_, features, this->model_fit_.train_features);
-    // Then we can use the information vector to determine the posterior
     const Eigen::VectorXd pred = cross_cov * this->model_fit_.information;
-
+    // Here we efficiently only compute the diagonal of the posterior
+    // covariance matrix.
     auto ldlt = this->model_fit_.train_ldlt;
     Eigen::MatrixXd explained = ldlt.solve(cross_cov.transpose());
     Eigen::VectorXd marginal_variance =
@@ -176,7 +176,6 @@ protected:
   predict_mean_(const std::vector<FeatureType> &features) const override {
     const auto cross_cov = asymmetric_covariance(
         covariance_function_, features, this->model_fit_.train_features);
-    // Then we can use the information vector to determine the posterior
     const Eigen::VectorXd pred = cross_cov * this->model_fit_.information;
     return pred;
   }

--- a/albatross/models/least_squares.h
+++ b/albatross/models/least_squares.h
@@ -51,7 +51,7 @@ public:
 
   LeastSquaresFit
   serializable_fit_(const std::vector<Eigen::VectorXd> &features,
-                    const TargetDistribution &targets) const override {
+                    const MarginalDistribution &targets) const override {
     // The way this is currently implemented we assume all targets have the same
     // variance (or zero variance).
     assert(!targets.has_covariance());
@@ -68,7 +68,7 @@ public:
   }
 
 protected:
-  PredictDistribution
+  JointDistribution
   predict_(const std::vector<Eigen::VectorXd> &features) const override {
     int n = static_cast<s32>(features.size());
     Eigen::VectorXd predictions(n);
@@ -77,7 +77,7 @@ protected:
           features[static_cast<std::size_t>(i)].dot(this->model_fit_.coefs);
     }
 
-    return PredictDistribution(predictions);
+    return JointDistribution(predictions);
   }
 
   /*

--- a/tests/test_core_distribution.cc
+++ b/tests/test_core_distribution.cc
@@ -76,7 +76,7 @@ void expect_subset_equal(const Eigen::DiagonalMatrix<Scalar, Size> &original,
 template <typename DistributionType>
 class PolymorphicDistributionTest : public ::testing::Test {};
 
-typedef ::testing::Types<TargetDistribution, PredictDistribution>
+typedef ::testing::Types<MarginalDistribution, JointDistribution>
     DistributionsToTest;
 TYPED_TEST_CASE(PolymorphicDistributionTest, DistributionsToTest);
 

--- a/tests/test_core_model.cc
+++ b/tests/test_core_model.cc
@@ -25,7 +25,7 @@ TEST(test_core_model, test_fit_predict) {
   MockModel m;
   m.fit(dataset);
   // We should be able to perfectly predict in this case.
-  PredictDistribution predictions = m.predict(dataset.features);
+  JointDistribution predictions = m.predict(dataset.features);
   EXPECT_LT((predictions.mean - dataset.targets.mean).norm(), 1e-10);
 }
 

--- a/tests/test_evaluate.cc
+++ b/tests/test_evaluate.cc
@@ -51,7 +51,7 @@ TEST(test_evaluate, test_negative_log_likelihood) {
 }
 
 TEST_F(LinearRegressionTest, test_leave_one_out) {
-  PredictDistribution preds = model_ptr_->fit_and_predict(
+  JointDistribution preds = model_ptr_->fit_and_predict(
       dataset_.features, dataset_.targets, dataset_.features);
   double in_sample_rmse = root_mean_square_error(preds, dataset_.targets);
   const auto folds = leave_one_out(dataset_);
@@ -90,7 +90,7 @@ bool is_monotonic_increasing(Eigen::VectorXd &x) {
 TEST_F(LinearRegressionTest, test_cross_validated_predict) {
   const auto folds = leave_one_group_out<double>(dataset_, group_by_interval);
 
-  PredictDistribution preds = cross_validated_predict(folds, model_ptr_.get());
+  JointDistribution preds = cross_validated_predict(folds, model_ptr_.get());
 
   // Make sure the group cross validation resulted in folds that
   // are out of order

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -90,4 +90,22 @@ TEST(test_models, test_with_target_distribution) {
 
   EXPECT_LE(scores.mean(), scores_without_variance.mean());
 }
+
+TEST(test_models, test_predict_variants) {
+  auto dataset = make_heteroscedastic_toy_linear_data();
+
+  auto model = MakeGaussianProcess().create();
+  model->fit(dataset);
+  const auto joint_predictions = model->predict(dataset.features);
+  const auto marginal_predictions = model->predict_marginal(dataset.features);
+  const auto mean_predictions = model->predict_mean(dataset.features);
+
+  for (Eigen::Index i = 0; i < joint_predictions.mean.size(); i++) {
+    EXPECT_NEAR(joint_predictions.mean[i], mean_predictions[i], 1e-6);
+    EXPECT_NEAR(joint_predictions.mean[i], marginal_predictions.mean[i], 1e-6);
+    EXPECT_NEAR(joint_predictions.covariance(i, i),
+                marginal_predictions.covariance.diagonal()[i], 1e-6);
+  }
+}
+
 } // namespace albatross

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -99,36 +99,36 @@ struct EigenMatrixXd : public SerializableType<Eigen::MatrixXd> {
   }
 };
 
-struct FullDenseDistribution : public SerializableType<DenseDistribution> {
-  DenseDistribution create() const override {
+struct FullJointDistribution : public SerializableType<JointDistribution> {
+  JointDistribution create() const override {
     Eigen::MatrixXd cov(3, 3);
     cov << 1., 2., 3., 4., 5., 6., 7, 8, 9;
     Eigen::VectorXd mean = Eigen::VectorXd::Ones(3);
-    return DenseDistribution(mean, cov);
+    return JointDistribution(mean, cov);
   }
 };
 
-struct MeanOnlyDenseDistribution : public SerializableType<DenseDistribution> {
-  DenseDistribution create() const override {
+struct MeanOnlyJointDistribution : public SerializableType<JointDistribution> {
+  JointDistribution create() const override {
     Eigen::MatrixXd mean = Eigen::VectorXd::Ones(3);
-    return DenseDistribution(mean);
+    return JointDistribution(mean);
   }
 };
 
-struct FullDiagonalDistribution
-    : public SerializableType<DiagonalDistribution> {
-  DiagonalDistribution create() const override {
+struct FullMarginalDistribution
+    : public SerializableType<MarginalDistribution> {
+  MarginalDistribution create() const override {
     Eigen::VectorXd diag = Eigen::VectorXd::Ones(3);
     Eigen::VectorXd mean = Eigen::VectorXd::Ones(3);
-    return DiagonalDistribution(mean, diag.asDiagonal());
+    return MarginalDistribution(mean, diag.asDiagonal());
   }
 };
 
-struct MeanOnlyDiagonalDistribution
-    : public SerializableType<DiagonalDistribution> {
-  DiagonalDistribution create() const override {
+struct MeanOnlyMarginalDistribution
+    : public SerializableType<MarginalDistribution> {
+  MarginalDistribution create() const override {
     Eigen::MatrixXd mean = Eigen::VectorXd::Ones(3);
-    return DiagonalDistribution(mean);
+    return MarginalDistribution(mean);
   }
 };
 
@@ -314,8 +314,8 @@ struct PolymorphicSerializeTest : public ::testing::Test {
 typedef ::testing::Types<
     LDLT, SerializableType<Eigen::Matrix3d>, SerializableType<Eigen::Matrix2i>,
     EmptyEigenVectorXd, EigenVectorXd, EmptyEigenMatrixXd, EigenMatrixXd,
-    FullDenseDistribution, MeanOnlyDenseDistribution, FullDiagonalDistribution,
-    MeanOnlyDiagonalDistribution, ParameterStoreType,
+    FullJointDistribution, MeanOnlyJointDistribution, FullMarginalDistribution,
+    MeanOnlyMarginalDistribution, ParameterStoreType,
     SerializableType<MockModel>, UnfitSerializableModel, FitSerializableModel,
     FitDirectModel, UnfitDirectModel, UnfitRegressionModel,
     FitLinearRegressionModel, FitLinearSerializablePointer,

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -74,7 +74,7 @@ public:
 protected:
   // builds the map from int to value
   MockFit serializable_fit_(const std::vector<MockPredictor> &features,
-                            const TargetDistribution &targets) const override {
+                            const MarginalDistribution &targets) const override {
     int n = static_cast<int>(features.size());
     Eigen::VectorXd predictions(n);
 
@@ -87,7 +87,7 @@ protected:
   }
 
   // looks up the prediction in the map
-  PredictDistribution
+  JointDistribution
   predict_(const std::vector<MockPredictor> &features) const override {
     int n = static_cast<int>(features.size());
     Eigen::VectorXd predictions(n);
@@ -97,7 +97,7 @@ protected:
       predictions[i] = this->model_fit_.train_data.find(index)->second;
     }
 
-    return PredictDistribution(predictions);
+    return JointDistribution(predictions);
   }
 };
 
@@ -190,7 +190,7 @@ make_heteroscedastic_toy_linear_data(const double a = 5., const double b = 1.,
 
   auto diag_matrix = variance.asDiagonal();
 
-  TargetDistribution target_dist(targets, diag_matrix);
+  MarginalDistribution target_dist(targets, diag_matrix);
 
   return RegressionDataset<double>(dataset.features, target_dist);
 }

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -73,8 +73,9 @@ public:
 
 protected:
   // builds the map from int to value
-  MockFit serializable_fit_(const std::vector<MockPredictor> &features,
-                            const MarginalDistribution &targets) const override {
+  MockFit
+  serializable_fit_(const std::vector<MockPredictor> &features,
+                    const MarginalDistribution &targets) const override {
     int n = static_cast<int>(features.size());
     Eigen::VectorXd predictions(n);
 


### PR DESCRIPTION
The existing model interface provided a `predict` method which returned an entire distribution (mean, and dense covariance).  Sometimes however you may only need the mean, or the marginal variance in which case computing the entire posterior covariance, then only throwing it away (or only taking the diagonal) is a waste of computation time.

This change provides a new set of methods to the `RegressionModel<>` which let you explicitly ask for only the marginal posterior distribution `predict_marginal` or the posterior mean `predict_mean`.