### PR TITLE
Switch to using nlopt_cxx instead of nlopt

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -38,7 +38,7 @@ add_dependencies(tune_example
     albatross
 )
 
-target_link_libraries(tune_example m gflags pthread nlopt)
+target_link_libraries(tune_example m gflags pthread nlopt_cxx)
 
 add_custom_target(
     run_tune_example ALL
@@ -84,7 +84,7 @@ add_dependencies(temperature_example
     albatross
 )
 
-target_link_libraries(temperature_example m gflags pthread nlopt)
+target_link_libraries(temperature_example m gflags pthread nlopt_cxx)
 
 add_custom_target(
     run_temperature_example ALL

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ add_dependencies(albatross_unit_tests
     clang-format-all
 )
 
-target_link_libraries(albatross_unit_tests m gtest gtest_main pthread gflags nlopt)
+target_link_libraries(albatross_unit_tests m gtest gtest_main pthread gflags nlopt_cxx)
 
 add_custom_target(
 run_albatross_unit_tests ALL


### PR DESCRIPTION
This fixes some issues when trying to build on `nixos`.