### PR TITLE
Add the ability to specify a prior on parameters.

### DIFF
--- a/albatross/core/model_adapter.h
+++ b/albatross/core/model_adapter.h
@@ -104,12 +104,12 @@ public:
   }
 
   void unchecked_set_param(const std::string &name,
-                           const double value) override {
+                           const Parameter &param) override {
 
     if (map_contains(this->params_, name)) {
-      this->params_[name] = value;
+      this->params_[name] = param;
     } else {
-      sub_model_.set_param(name, value);
+      sub_model_.set_param(name, param);
     }
   }
 

--- a/albatross/core/priors.h
+++ b/albatross/core/priors.h
@@ -69,7 +69,7 @@ class UniformPrior : public Prior {
 public:
   UniformPrior(double lower = 0., double upper = 1.)
       : lower_(lower), upper_(upper) {
-    assert(upper_ < lower_);
+    assert(upper_ > lower_);
   };
 
   std::string get_name() const override {

--- a/albatross/core/priors.h
+++ b/albatross/core/priors.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CORE_PRIORS_H
+#define ALBATROSS_CORE_PRIORS_H
+
+#include <cereal/archives/binary.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+#include <cereal/types/polymorphic.hpp>
+
+namespace albatross {
+
+constexpr double LOG_2PI_ = 1.8378770664093453;
+
+/*
+ * To add a new prior you'll need to implement the Prior abstract
+ * class.  If you want to be able to serialize models that use
+ * the prior you'll then also need to register the class following
+ * examples at the bottom of this file.
+ */
+
+class Prior {
+public:
+  virtual ~Prior(){};
+  virtual double log_pdf(double x) const = 0;
+  virtual std::string get_name() const = 0;
+  virtual double lower_bound() const { return -INFINITY; }
+  virtual double upper_bound() const { return INFINITY; }
+  virtual bool operator==(const Prior &other) const {
+    return typeid(*this) == typeid(other);
+  }
+  bool operator!=(const Prior &other) { return !((*this) == other); }
+
+  template <typename Archive> void serialize(Archive &archive) {}
+};
+
+class UninformativePrior : public Prior {
+public:
+  std::string get_name() const override { return "uninformative"; };
+  double log_pdf(double x) const override { return 0.; }
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::base_class<Prior>(this));
+  }
+};
+
+class PositivePrior : public Prior {
+public:
+  double log_pdf(double x) const override { return x > 0. ? 0. : -INFINITY; }
+  std::string get_name() const override { return "positive"; };
+  double lower_bound() const override { return 0.; }
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::base_class<Prior>(this));
+  }
+};
+
+class UniformPrior : public Prior {
+public:
+  UniformPrior(double lower = 0., double upper = 1.)
+      : lower_(lower), upper_(upper) {
+    assert(upper_ < lower_);
+  };
+
+  std::string get_name() const override {
+    std::ostringstream oss;
+    oss << "gaussian[" << lower_ << "," << upper_ << "]";
+    return oss.str();
+  };
+
+  double lower_bound() const override { return lower_; }
+  double upper_bound() const override { return upper_; }
+
+  double log_pdf(double x) const override { return -log(upper_ - lower_); }
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::base_class<Prior>(this), lower_, upper_);
+  }
+
+private:
+  double lower_;
+  double upper_;
+};
+
+class GaussianPrior : public Prior {
+public:
+  GaussianPrior(double mu = 0., double sigma = 1.) : mu_(mu), sigma_(sigma) {}
+
+  bool operator==(const Prior &other) const override {
+    // This seems pretty hacky but also seems to be one of the few ways
+    // to override the == operator with a possibly polymorphic argument.
+    if (Prior::operator==(other)) {
+      auto other_cast = static_cast<const GaussianPrior &>(other);
+      return other_cast.mu_ == mu_ && other_cast.sigma_ == sigma_;
+    } else {
+      return false;
+    }
+  }
+
+  std::string get_name() const override {
+    std::ostringstream oss;
+    oss << "gaussian[" << mu_ << "," << sigma_ << "]";
+    return oss.str();
+  }
+
+  double log_pdf(double x) const override {
+    double deviation = (x - mu_) / sigma_;
+    return -0.5 * (LOG_2PI_ * 2 * log(sigma_) + deviation * deviation);
+  }
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::base_class<Prior>(this), mu_, sigma_);
+  }
+
+private:
+  double mu_;
+  double sigma_;
+};
+
+class LogNormalPrior : public Prior {
+public:
+  LogNormalPrior(double mu = 0., double sigma = 1.) : mu_(mu), sigma_(sigma) {}
+
+  bool operator==(const Prior &other) const override {
+    // This seems pretty hacky but also seems to be one of the few ways
+    // to override the == operator with a possibly polymorphic argument.
+    if (Prior::operator==(other)) {
+      auto other_cast = static_cast<const LogNormalPrior &>(other);
+      return other_cast.mu_ == mu_ && other_cast.sigma_ == sigma_;
+    } else {
+      return false;
+    }
+  }
+
+  std::string get_name() const override {
+    std::ostringstream oss;
+    oss << "log_normal[" << mu_ << "," << sigma_ << "]";
+    return oss.str();
+  }
+
+  double log_pdf(double x) const override {
+    double deviation = (log(x) - mu_) / sigma_;
+    return -0.5 * LOG_2PI_ - log(sigma_) - log(x) - deviation * deviation;
+  }
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::base_class<Prior>(this), mu_, sigma_);
+  }
+
+private:
+  double mu_;
+  double sigma_;
+};
+
+} // namespace albatross
+
+CEREAL_REGISTER_TYPE(albatross::UninformativePrior);
+CEREAL_REGISTER_TYPE(albatross::PositivePrior);
+CEREAL_REGISTER_TYPE(albatross::UniformPrior);
+CEREAL_REGISTER_TYPE(albatross::GaussianPrior);
+CEREAL_REGISTER_TYPE(albatross::LogNormalPrior);
+
+#endif

--- a/albatross/covariance_functions/covariance_functions.h
+++ b/albatross/covariance_functions/covariance_functions.h
@@ -77,15 +77,18 @@ template <typename Term> struct CovarianceFunction {
   inline auto set_param(const ParameterKey &key, const ParameterValue &value) {
     return term.set_param(key, value);
   };
+  inline auto set_param(const ParameterKey &key, const Parameter &param) {
+    return term.set_param(key, param);
+  };
+  inline auto set_prior(const ParameterKey &key, const ParameterPrior &prior) {
+    return term.set_prior(key, prior);
+  };
   inline auto pretty_string() const { return term.pretty_string(); };
   inline auto get_params_as_vector() const {
     return term.get_params_as_vector();
   };
   inline auto set_params_from_vector(const std::vector<ParameterValue> &x) {
     return term.set_params_from_vector(x);
-  };
-  inline auto unchecked_set_param(const std::string &name, const double value) {
-    return term.unchecked_set_param(name, value);
   };
 };
 

--- a/albatross/covariance_functions/covariance_term.h
+++ b/albatross/covariance_functions/covariance_term.h
@@ -72,11 +72,11 @@ public:
   }
 
   void unchecked_set_param(const std::string &name,
-                           const double value) override {
+                           const Parameter &param) override {
     if (map_contains(lhs_.get_params(), name)) {
-      lhs_.set_param(name, value);
+      lhs_.set_param(name, param);
     } else {
-      rhs_.set_param(name, value);
+      rhs_.set_param(name, param);
     }
   }
 

--- a/albatross/covariance_functions/noise.h
+++ b/albatross/covariance_functions/noise.h
@@ -20,7 +20,8 @@ namespace albatross {
 template <typename Observed> class IndependentNoise : public CovarianceTerm {
 public:
   IndependentNoise(double sigma_noise = 0.1) {
-    this->params_["sigma_independent_noise"] = sigma_noise;
+    this->params_["sigma_independent_noise"] = {
+        sigma_noise, std::make_shared<PositivePrior>()};
   };
 
   ~IndependentNoise(){};
@@ -33,7 +34,7 @@ public:
    */
   double operator()(const Observed &x, const Observed &y) const {
     if (x == y) {
-      double sigma_noise = this->params_.at("sigma_independent_noise");
+      double sigma_noise = this->get_param_value("sigma_independent_noise");
       return sigma_noise * sigma_noise;
     } else {
       return 0.;

--- a/albatross/covariance_functions/polynomials.h
+++ b/albatross/covariance_functions/polynomials.h
@@ -31,7 +31,8 @@ struct ConstantTerm {};
 class Constant : public CovarianceTerm {
 public:
   Constant(double sigma_constant = 10.) {
-    this->params_["sigma_constant"] = sigma_constant;
+    this->params_["sigma_constant"] = {sigma_constant,
+                                       std::make_shared<PositivePrior>()};
   };
 
   ~Constant(){};
@@ -54,7 +55,7 @@ public:
   template <typename X, typename Y>
   double operator()(const X &x __attribute__((unused)),
                     const Y &y __attribute__((unused))) const {
-    double sigma_constant = this->params_.at("sigma_constant");
+    double sigma_constant = this->get_param_value("sigma_constant");
     return sigma_constant * sigma_constant;
   }
 };

--- a/albatross/covariance_functions/radial.h
+++ b/albatross/covariance_functions/radial.h
@@ -38,11 +38,11 @@ public:
   }
 
   void unchecked_set_param(const std::string &name,
-                           const double value) override {
+                           const Parameter &param) override {
     if (map_contains(this->params_, name)) {
-      this->params_[name] = value;
+      this->params_[name] = param;
     } else {
-      distance_metric_.set_param(name, value);
+      distance_metric_.set_param(name, param);
     }
   }
 
@@ -73,8 +73,10 @@ public:
 
   SquaredExponential(double length_scale = 100000.,
                      double sigma_squared_exponential = 10.) {
-    this->params_["squared_exponential_length_scale"] = length_scale;
-    this->params_["sigma_squared_exponential"] = sigma_squared_exponential;
+    this->params_["squared_exponential_length_scale"] = {
+        length_scale, std::make_shared<PositivePrior>()};
+    this->params_["sigma_squared_exponential"] = {
+        sigma_squared_exponential, std::make_shared<PositivePrior>()};
   };
 
   ~SquaredExponential(){};
@@ -92,8 +94,9 @@ public:
                 int>::type = 0>
   double operator()(const X &x, const X &y) const {
     double distance = this->distance_metric_(x, y);
-    double length_scale = this->params_.at("squared_exponential_length_scale");
-    double sigma = this->params_.at("sigma_squared_exponential");
+    double length_scale =
+        this->get_param_value("squared_exponential_length_scale");
+    double sigma = this->get_param_value("sigma_squared_exponential");
     return squared_exponential_covariance(distance, length_scale, sigma);
   }
 };
@@ -111,8 +114,10 @@ template <class DistanceMetricImpl>
 class Exponential : public RadialCovariance<DistanceMetricImpl> {
 public:
   Exponential(double length_scale = 100000., double sigma_exponential = 10.) {
-    this->params_["exponential_length_scale"] = length_scale;
-    this->params_["sigma_exponential"] = sigma_exponential;
+    this->params_["exponential_length_scale"] = {
+        length_scale, std::make_shared<PositivePrior>()};
+    this->params_["sigma_exponential"] = {sigma_exponential,
+                                          std::make_shared<PositivePrior>()};
   };
 
   ~Exponential(){};
@@ -130,8 +135,8 @@ public:
                 int>::type = 0>
   double operator()(const X &x, const X &y) const {
     double distance = this->distance_metric_(x, y);
-    double length_scale = this->params_.at("exponential_length_scale");
-    double sigma = this->params_.at("sigma_exponential");
+    double length_scale = this->get_param_value("exponential_length_scale");
+    double sigma = this->get_param_value("sigma_exponential");
     return exponential_covariance(distance, length_scale, sigma);
   }
 };

--- a/albatross/covariance_functions/scaling_function.h
+++ b/albatross/covariance_functions/scaling_function.h
@@ -95,8 +95,8 @@ public:
   }
 
   void unchecked_set_param(const std::string &name,
-                           const double value) override {
-    scaling_function_.set_param(name, value);
+                           const Parameter &param) override {
+    scaling_function_.set_param(name, param);
   }
 
   /*

--- a/albatross/models/gp.h
+++ b/albatross/models/gp.h
@@ -114,8 +114,8 @@ public:
   }
 
   void unchecked_set_param(const std::string &name,
-                           const double value) override {
-    covariance_function_.set_param(name, value);
+                           const Parameter &param) override {
+    covariance_function_.set_param(name, param);
   }
 
   std::string pretty_string() const {

--- a/albatross/tune.h
+++ b/albatross/tune.h
@@ -22,34 +22,13 @@
 
 namespace albatross {
 
-inline std::vector<ParameterValue>
-transform_parameters(const std::vector<ParameterValue> &x) {
-  std::vector<ParameterValue> transformed(x.size());
-
-  // https://stackoverflow.com/questions/12915676/how-can-i-avoid-the-compiler-error-stdtransform
-  auto double_log = [&](double z) { return log(z); };
-  std::transform(x.begin(), x.end(), transformed.begin(), double_log);
-
-  return transformed;
-}
-
-inline std::vector<ParameterValue>
-inverse_parameters(const std::vector<ParameterValue> &x) {
-  std::vector<ParameterValue> inverted(x.size());
-
-  // https://stackoverflow.com/questions/12915676/how-can-i-avoid-the-compiler-error-stdtransform
-  auto double_exp = [&](double z) { return exp(z); };
-  std::transform(x.begin(), x.end(), inverted.begin(), double_exp);
-
-  return inverted;
-}
-
 template <class FeatureType> struct TuneModelConfg {
   RegressionModelCreator<FeatureType> model_creator;
   std::vector<RegressionDataset<FeatureType>> datasets;
   TuningMetric<FeatureType> metric;
   TuningMetricAggregator aggregator;
   std::ostream &output_stream;
+  nlopt::opt optimizer;
 
   TuneModelConfg(const RegressionModelCreator<FeatureType> &model_creator_,
                  const RegressionDataset<FeatureType> &dataset_,
@@ -57,7 +36,9 @@ template <class FeatureType> struct TuneModelConfg {
                  const TuningMetricAggregator &aggregator_ = mean_aggregator,
                  std::ostream &output_stream_ = std::cout)
       : model_creator(model_creator_), datasets({dataset_}), metric(metric_),
-        aggregator(aggregator_), output_stream(output_stream_){};
+        aggregator(aggregator_), output_stream(output_stream_), optimizer() {
+    set_default_optimizer();
+  };
 
   TuneModelConfg(const RegressionModelCreator<FeatureType> &model_creator_,
                  const std::vector<RegressionDataset<FeatureType>> &datasets_,
@@ -65,7 +46,22 @@ template <class FeatureType> struct TuneModelConfg {
                  const TuningMetricAggregator &aggregator_ = mean_aggregator,
                  std::ostream &output_stream_ = std::cout)
       : model_creator(model_creator_), datasets(datasets_), metric(metric_),
-        aggregator(aggregator_), output_stream(output_stream_){};
+        aggregator(aggregator_), output_stream(output_stream_), optimizer() {
+    set_default_optimizer();
+  };
+
+  void set_default_optimizer() {
+    // The various algorithms in nlopt are coded by the first two characters.
+    // In this case LN stands for local, gradient free.
+    auto x = model_creator()->get_params_as_vector();
+    optimizer = nlopt::opt(nlopt::LN_PRAXIS, (unsigned)x.size());
+    optimizer.set_ftol_abs(1e-8);
+    optimizer.set_ftol_rel(1e-6);
+    // the sensitivity to parameters varies greatly between parameters so
+    // terminating based on change in x isn't a great criteria, we only
+    // terminate based on xtol if the change is super small.
+    optimizer.set_xtol_rel(1e-8);
+  }
 };
 
 /*
@@ -88,7 +84,12 @@ double objective_function(const std::vector<double> &x,
 
   const auto model = config.model_creator();
 
-  model->set_params_from_vector(inverse_parameters(x));
+  model->set_params_from_vector(x);
+
+  if (!model->params_are_valid()) {
+    config.output_stream << "Invalid Parameters" << std::endl;
+    return NAN;
+  }
 
   std::vector<double> metrics;
   for (std::size_t i = 0; i < config.datasets.size(); i++) {
@@ -108,25 +109,16 @@ ParameterStore
 tune_regression_model(const TuneModelConfg<FeatureType> &config) {
 
   const auto example_model = config.model_creator();
-  auto x = transform_parameters(example_model->get_params_as_vector());
+  auto x = example_model->get_params_as_vector();
 
   assert(x.size());
-
-  // The various algorithms in nlopt are coded by the first two characters.
-  // In this case LN stands for local, gradient free.
-  nlopt::opt opt(nlopt::LN_PRAXIS, (unsigned)x.size());
+  nlopt::opt opt = config.optimizer;
   opt.set_min_objective(objective_function<FeatureType>, (void *)&config);
-  opt.set_ftol_abs(1e-8);
-  opt.set_ftol_rel(1e-6);
-  // the sensitivity to parameters varies greatly between parameters so
-  // terminating based on change in x isn't a great criteria, we only
-  // terminate based on xtol if the change is super small.
-  opt.set_xtol_rel(1e-8);
   double minf;
   opt.optimize(x, minf);
 
   // Tell the user what the final parameters were.
-  example_model->set_params_from_vector(inverse_parameters(x));
+  example_model->set_params_from_vector(x);
   config.output_stream << "==================" << std::endl;
   config.output_stream << "TUNED MODEL PARAMS" << std::endl;
   config.output_stream << "==================" << std::endl;

--- a/albatross/tuning_metrics.h
+++ b/albatross/tuning_metrics.h
@@ -46,7 +46,8 @@ inline double gp_fast_loo_nll(const RegressionDataset<FeatureType> &dataset,
   const auto predictions =
       fast_gp_loo_cross_validated_predict(dataset, gp_model);
   const auto deviations = dataset.targets.mean - predictions.mean;
-  return negative_log_likelihood(deviations, predictions.covariance);
+  return negative_log_likelihood(deviations, predictions.covariance) -
+         model->prior_log_likelihood();
 }
 
 inline double loo_nll(const RegressionDataset<double> &dataset,
@@ -54,7 +55,8 @@ inline double loo_nll(const RegressionDataset<double> &dataset,
   auto loo_folds = leave_one_out(dataset);
   return cross_validated_scores(evaluation_metrics::negative_log_likelihood,
                                 loo_folds, model)
-      .sum();
+             .sum() -
+         model->prior_log_likelihood();
 }
 
 inline double loo_rmse(const RegressionDataset<double> &dataset,

--- a/examples/example_utils.h
+++ b/examples/example_utils.h
@@ -40,7 +40,7 @@ public:
   std::string get_name() const { return "slope_term"; }
 
   double operator()(const double &x, const double &y) const {
-    double sigma_slope = this->params_.at("sigma_slope");
+    double sigma_slope = this->get_param_value("sigma_slope");
     return sigma_slope * sigma_slope * x * y;
   }
 };

--- a/examples/temperature_example/temperature_example_utils.h
+++ b/examples/temperature_example/temperature_example_utils.h
@@ -70,8 +70,10 @@ public:
 class ElevationScalingFunction : public albatross::ScalingFunction {
 public:
   ElevationScalingFunction(double center = 1000., double factor = 3.5 / 300) {
-    this->params_["elevation_scaling_center"] = center;
-    this->params_["elevation_scaling_factor"] = factor;
+    this->params_["elevation_scaling_center"] = {
+        center, std::make_shared<UniformPrior>(0., 5000.)};
+    this->params_["elevation_scaling_factor"] = {
+        factor, std::make_shared<PositivePrior>()};
   };
 
   std::string get_name() const { return "elevation_scaled"; }
@@ -79,10 +81,9 @@ public:
   double operator()(const Station &x) const {
     // This is the negative orientation rectifier function which
     // allows lower elevations to have a higher variance.
-    double center = this->params_.at("elevation_scaling_center");
-    return 1. +
-           this->params_.at("elevation_scaling_factor") *
-               fmax(0., (center - x.height));
+    double center = this->get_param_value("elevation_scaling_center");
+    double factor = this->get_param_value("elevation_scaling_factor");
+    return 1. + factor * fmax(0., (center - x.height));
   }
 };
 

--- a/examples/tune_example.cc
+++ b/examples/tune_example.cc
@@ -61,7 +61,11 @@ int main(int argc, char *argv[]) {
    * using lambdas.
    */
   RegressionModelCreator<double> model_creator = [linear_model]() {
-    return gp_pointer_from_covariance<double>(linear_model);
+    auto m = gp_pointer_from_covariance<double>(linear_model);
+    // We can place a prior on the length scale.
+    ParameterPrior prior = std::make_shared<GaussianPrior>(5., 1.);
+    m->set_prior("squared_exponential_length_scale", prior);
+    return m;
   };
 
   /*

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -162,14 +162,16 @@ struct LDLT : public SerializableType<Eigen::SerializableLDLT> {
 struct ParameterStoreType : public SerializableType<ParameterStore> {
 
   RepresentationType create() const override {
-    ParameterStore original = {{"2", 2.}, {"1", 1.}, {"3", 3.}};
+    ParameterStore original = {
+        {"2", {2., std::make_shared<PositivePrior>()}},
+        {"1", {1., std::make_shared<GaussianPrior>(1., 2.)}},
+        {"3", 3.}};
     return original;
   }
 
   bool are_equal(const RepresentationType &lhs,
                  const RepresentationType &rhs) const override {
-    expect_params_equal(lhs, rhs);
-    return true;
+    return lhs == rhs;
   };
 };
 
@@ -207,6 +209,8 @@ public:
     auto dataset = mock_training_data();
     auto model = MockModel(log(2.));
     model.fit(dataset);
+    ParameterPrior prior = std::make_shared<GaussianPrior>(4., 3.);
+    model.set_prior("parameter", prior);
     return model;
   }
 

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -209,7 +209,7 @@ public:
     auto dataset = mock_training_data();
     auto model = MockModel(log(2.));
     model.fit(dataset);
-    ParameterPrior prior = std::make_shared<GaussianPrior>(4., 3.);
+    ParameterPrior prior = std::make_shared<UniformPrior>(3., 4.);
     model.set_prior("parameter", prior);
     return model;
   }

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -28,7 +28,79 @@ TEST(test_tune, test_single_dataset) {
   std::ostringstream output_stream;
   TuneModelConfg<double> config(model_creator, dataset, metric,
                                 albatross::mean_aggregator, output_stream);
+  config.optimizer.set_maxeval(20);
   auto params = tune_regression_model(config);
+}
+
+TEST(test_tune, test_with_prior_bounds) {
+  // Here we create a situation where tuning should hit a few
+  // invalid parameters which will result in a NAN objective
+  // function and we want to make sure the tuning recovers.
+  auto dataset = make_toy_linear_data();
+
+  auto model_with_prior = [] {
+    auto model_creator = toy_gaussian_process;
+    auto model = model_creator();
+    for (const auto &pair : model->get_params()) {
+      Parameter param = {1.e-8, std::make_shared<PositivePrior>()};
+      model->set_param(pair.first, param);
+    }
+    return model;
+  };
+
+  TuningMetric<double> metric = loo_nll;
+  std::ostringstream output_stream;
+  TuneModelConfg<double> config(model_with_prior, dataset, metric,
+                                albatross::mean_aggregator, output_stream);
+  config.optimizer.set_maxeval(20);
+  auto params = tune_regression_model(config);
+  EXPECT_NE(output_stream.str().find("Invalid Parameters"), std::string::npos);
+  auto m = model_with_prior();
+  m->set_params(params);
+  EXPECT_TRUE(m->params_are_valid());
+}
+
+TEST(test_tune, test_with_prior) {
+  // Here we create a situation where tuning should hit a few
+  // invalid parameters which will result in a NAN objective
+  // function and we want to make sure the tuning recovers.
+  auto dataset = make_toy_linear_data();
+
+  auto model_with_prior = [] {
+    auto model_creator = toy_gaussian_process;
+    auto model = model_creator();
+    for (const auto &pair : model->get_params()) {
+      model->set_prior(pair.first, std::make_shared<GaussianPrior>(
+                                       pair.second.value + 0.1, 0.001));
+    }
+    return model;
+  };
+
+  // Tune with a prior
+  TuningMetric<double> metric = loo_nll;
+  std::ostringstream output_stream;
+  TuneModelConfg<double> config(model_with_prior, dataset, metric,
+                                albatross::mean_aggregator, output_stream);
+  config.optimizer.set_maxeval(20);
+  auto params = tune_regression_model(config);
+
+  // Tune without a prior
+  TuneModelConfg<double> config_no_prior(toy_gaussian_process, dataset, metric,
+                                         albatross::mean_aggregator,
+                                         output_stream);
+  config_no_prior.optimizer.set_maxeval(20);
+  auto params_no_prior = tune_regression_model(config_no_prior);
+
+  // Make sure tuning to the prior results in parameters that are
+  // more likely.
+  auto m = model_with_prior();
+  m->set_params(params);
+  double ll_with_prior = m->prior_log_likelihood();
+
+  for (const auto &pair : params_no_prior) {
+    m->set_param(pair.first, pair.second.value);
+  }
+  EXPECT_GT(ll_with_prior, m->prior_log_likelihood());
 }
 
 TEST(test_tune, test_multiple_datasets) {
@@ -41,6 +113,7 @@ TEST(test_tune, test_multiple_datasets) {
   std::ostringstream output_stream;
   TuneModelConfg<double> config(model_creator, datasets, metric,
                                 albatross::mean_aggregator, output_stream);
+  config.optimizer.set_maxeval(20);
   auto params = tune_regression_model(config);
 }
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -54,7 +54,8 @@ public:
 class MockModel : public SerializableRegressionModel<MockPredictor, MockFit> {
 public:
   MockModel(double parameter = 3.14159) {
-    this->params_["parameter"] = parameter;
+    this->params_["parameter"] = {parameter,
+                                  std::make_shared<GaussianPrior>(3., 2.)};
   };
 
   std::string get_name() const override { return "mock_model"; };
@@ -124,20 +125,6 @@ mock_training_data(const int n = 10) {
     targets[i] = static_cast<double>(i + n);
   }
   return RegressionDataset<MockPredictor>(features, targets);
-}
-
-static inline void expect_params_equal(const ParameterStore &x,
-                                       const ParameterStore &y) {
-  // Make sure all pairs in x are in y.
-  for (const auto &x_pair : x) {
-    const auto y_value = y.at(x_pair.first);
-    EXPECT_DOUBLE_EQ(x_pair.second, y_value);
-  }
-  // And all pairs in y are in x.
-  for (const auto &y_pair : y) {
-    const auto x_value = x.at(y_pair.first);
-    EXPECT_DOUBLE_EQ(y_pair.second, x_value);
-  }
 }
 
 static inline void


### PR DESCRIPTION
This change lets you optionally specify a prior on parameters.

Some obvious applications of this are in situations where a parameter represents a variance which must necessarily be positive.  Other applications would include placing a more informative prior on parameters which have some physical meaning, for example `air_temperature_farenheit ~ UniformPrior(-50., 150.)`, or where the parameters come from some other model, `measurement_bias ~ Gaussian(0.1, 0.5)`.

This was done by changing the `ParameterStore` from `map<string, double>` to `map<string, Parameter>` where the `Parameter` class has been defined to be
```
struct Parameter {
    double value;
    shared_pointer<Prior> prior;
}
```
The `prior` is a pointer in order to allow for polymorphism, so that users can use a variety of albatross provided or custom built priors. (see `priors.h`) or none at all via the default `nullptr`.  I was tempted to use `optional` but that would require adding more third party dependencies.

Changes include:
* Changing the `ParameterStore` as mentioned.
* Some common priors (`Uninformative`, `Positive`, `Uniform`, `Gaussian` and `LogNormal`). 
* Tuning scripts now return `nan` values for invalid parameters.
* Likelihood based tuning metrics now include likelihood of the priors.