### PR TITLE
Use the parameter bounds from the priors in tuning.

### DIFF
--- a/albatross/core/priors.h
+++ b/albatross/core/priors.h
@@ -21,6 +21,7 @@
 namespace albatross {
 
 constexpr double LOG_2PI_ = 1.8378770664093453;
+constexpr double LARGE_VAL = HUGE_VAL;
 
 /*
  * To add a new prior you'll need to implement the Prior abstract
@@ -34,8 +35,8 @@ public:
   virtual ~Prior(){};
   virtual double log_pdf(double x) const = 0;
   virtual std::string get_name() const = 0;
-  virtual double lower_bound() const { return -INFINITY; }
-  virtual double upper_bound() const { return INFINITY; }
+  virtual double lower_bound() const { return -LARGE_VAL; }
+  virtual double upper_bound() const { return LARGE_VAL; }
   virtual bool operator==(const Prior &other) const {
     return typeid(*this) == typeid(other);
   }
@@ -56,9 +57,10 @@ public:
 
 class PositivePrior : public Prior {
 public:
-  double log_pdf(double x) const override { return x > 0. ? 0. : -INFINITY; }
+  double log_pdf(double x) const override { return x > 0. ? 0. : -LARGE_VAL; }
   std::string get_name() const override { return "positive"; };
   double lower_bound() const override { return 0.; }
+  double upper_bound() const override { return LARGE_VAL; }
 
   template <typename Archive> void serialize(Archive &archive) {
     archive(cereal::base_class<Prior>(this));

--- a/albatross/tune.h
+++ b/albatross/tune.h
@@ -22,6 +22,22 @@
 
 namespace albatross {
 
+inline std::string to_string(const nlopt::result result) {
+  std::map<nlopt::result, std::string> result_strings = {
+      {nlopt::result::FAILURE, "generic failure"},
+      {nlopt::result::INVALID_ARGS, "invalid_arguments"},
+      {nlopt::result::OUT_OF_MEMORY, "out of memory"},
+      {nlopt::result::ROUNDOFF_LIMITED, "roundoff limited"},
+      {nlopt::result::FORCED_STOP, "forced stop"},
+      {nlopt::result::SUCCESS, "generic success"},
+      {nlopt::result::STOPVAL_REACHED, "stop value reached"},
+      {nlopt::result::FTOL_REACHED, "ftol reached"},
+      {nlopt::result::XTOL_REACHED, "xtol reached"},
+      {nlopt::result::MAXEVAL_REACHED, "maxeval reached"},
+      {nlopt::result::MAXTIME_REACHED, "maxtime reached"}};
+  return result_strings[result];
+}
+
 template <class FeatureType> struct TuneModelConfg {
   RegressionModelCreator<FeatureType> model_creator;
   std::vector<RegressionDataset<FeatureType>> datasets;
@@ -53,14 +69,22 @@ template <class FeatureType> struct TuneModelConfg {
   void set_default_optimizer() {
     // The various algorithms in nlopt are coded by the first two characters.
     // In this case LN stands for local, gradient free.
-    auto x = model_creator()->get_params_as_vector();
+    auto m = model_creator();
+    auto x = m->get_params_as_vector();
     optimizer = nlopt::opt(nlopt::LN_PRAXIS, (unsigned)x.size());
     optimizer.set_ftol_abs(1e-8);
     optimizer.set_ftol_rel(1e-6);
+
+    const auto lb = m->get_param_lower_bounds();
+    optimizer.set_lower_bounds(lb);
+
+    const auto ub = m->get_param_upper_bounds();
+    optimizer.set_upper_bounds(ub);
     // the sensitivity to parameters varies greatly between parameters so
     // terminating based on change in x isn't a great criteria, we only
     // terminate based on xtol if the change is super small.
-    optimizer.set_xtol_rel(1e-8);
+    optimizer.set_xtol_abs(1e-18);
+    optimizer.set_xtol_rel(1e-18);
   }
 };
 
@@ -87,8 +111,10 @@ double objective_function(const std::vector<double> &x,
   model->set_params_from_vector(x);
 
   if (!model->params_are_valid()) {
-    config.output_stream << "Invalid Parameters" << std::endl;
-    return NAN;
+    config.output_stream << "Invalid Parameters:" << std::endl;
+    config.output_stream << pretty_param_details(model->get_params())
+                         << std::endl;
+    assert(false);
   }
 
   std::vector<double> metrics;
@@ -97,6 +123,9 @@ double objective_function(const std::vector<double> &x,
   }
   double metric = config.aggregator(metrics);
 
+  if (std::isnan(metric)) {
+    metric = INFINITY;
+  }
   config.output_stream << "-------------------" << std::endl;
   config.output_stream << model->pretty_string() << std::endl;
   config.output_stream << "objective: " << metric << std::endl;
@@ -115,12 +144,14 @@ tune_regression_model(const TuneModelConfg<FeatureType> &config) {
   nlopt::opt opt = config.optimizer;
   opt.set_min_objective(objective_function<FeatureType>, (void *)&config);
   double minf;
-  opt.optimize(x, minf);
+  nlopt::result result = opt.optimize(x, minf);
 
   // Tell the user what the final parameters were.
   example_model->set_params_from_vector(x);
   config.output_stream << "==================" << std::endl;
   config.output_stream << "TUNED MODEL PARAMS" << std::endl;
+  config.output_stream << "nlopt termination code: " << to_string(result)
+                       << std::endl;
   config.output_stream << "==================" << std::endl;
   config.output_stream << example_model->pretty_string() << std::endl;
 

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -54,7 +54,6 @@ TEST(test_tune, test_with_prior_bounds) {
                                 albatross::mean_aggregator, output_stream);
   config.optimizer.set_maxeval(20);
   auto params = tune_regression_model(config);
-  EXPECT_NE(output_stream.str().find("Invalid Parameters"), std::string::npos);
   auto m = model_with_prior();
   m->set_params(params);
   EXPECT_TRUE(m->params_are_valid());


### PR DESCRIPTION
The tuning routine wasn't taking into account the prior bounds, with this change they get explicitly used in `nlopt`.