### PR TITLE
CSV utilities to facilitate post processing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(albatross_HEADERS
     albatross/crossvalidation.h
     albatross/tuning_metrics.h
     albatross/map_utils.h
+    albatross/csv_utils.h
     albatross/core/keys.h
     albatross/core/model.h
     albatross/core/model_adapter.h

--- a/albatross/core/distribution.h
+++ b/albatross/core/distribution.h
@@ -19,6 +19,7 @@
 #include "indexing.h"
 #include <Eigen/Core>
 #include <iostream>
+#include <map>
 #include <vector>
 
 namespace albatross {
@@ -31,6 +32,10 @@ namespace albatross {
 template <typename CovarianceType> struct Distribution {
   Eigen::VectorXd mean;
   CovarianceType covariance;
+  // Sometimes it can be helpful to keep track of some
+  // auxillary information regarding how a distribution was
+  // derived, that can be stored in this map.
+  std::map<std::string, std::string> metadata;
 
   std::size_t size() const {
     // If the covariance is defined it must have the same number
@@ -56,6 +61,10 @@ template <typename CovarianceType> struct Distribution {
   Distribution(const Eigen::VectorXd &mean_, const CovarianceType &covariance_)
       : mean(mean_), covariance(covariance_){};
 
+  double get_diagonal(Eigen::Index i) const {
+    return has_covariance() ? covariance.diagonal()[i] : NAN;
+  }
+
   /*
    * If the CovarianceType is serializable, add a serialize method.
    */
@@ -65,6 +74,7 @@ template <typename CovarianceType> struct Distribution {
   serialize(Archive &archive) {
     archive(cereal::make_nvp("mean", mean));
     archive(cereal::make_nvp("covariance", covariance));
+    archive(cereal::make_nvp("metadata", metadata));
   }
 
   /*
@@ -81,7 +91,8 @@ template <typename CovarianceType> struct Distribution {
   }
 
   bool operator==(const Distribution &other) const {
-    return (mean == other.mean && covariance == other.covariance);
+    return (mean == other.mean && covariance == other.covariance &&
+            metadata == other.metadata);
   }
 };
 

--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -34,6 +34,7 @@ namespace albatross {
 template <typename FeatureType> struct RegressionDataset {
   std::vector<FeatureType> features;
   MarginalDistribution targets;
+  std::map<std::string, std::string> metadata;
 
   RegressionDataset(){};
 
@@ -50,12 +51,18 @@ template <typename FeatureType> struct RegressionDataset {
                     const Eigen::VectorXd &targets_)
       : RegressionDataset(features_, MarginalDistribution(targets_)) {}
 
+  bool operator==(const RegressionDataset &other) const {
+    return (features == other.features && targets == other.targets &&
+            metadata == other.metadata);
+  }
+
   template <class Archive>
   typename std::enable_if<valid_in_out_serializer<FeatureType, Archive>::value,
                           void>::type
   serialize(Archive &archive) {
     archive(cereal::make_nvp("features", features));
     archive(cereal::make_nvp("targets", targets));
+    archive(cereal::make_nvp("metadata", metadata));
   }
 
   template <class Archive>

--- a/albatross/csv_utils.h
+++ b/albatross/csv_utils.h
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CSV_UTILS_H
+#define ALBATROSS_CSV_UTILS_H
+
+#include "core/model.h"
+#include <cereal/archives/xml.hpp>
+#include <sstream>
+
+#include "cereal/external/rapidxml/rapidxml.hpp"
+
+/*
+ * This contains some tools which facilitate writing datasets and
+ * corresponding predicitons to CSV which can be useful for using
+ * external tools to investigate a model's performance.
+ *
+ * There are two options for making the write_to_csv work for a
+ * custom FeatureType.
+ *
+ * 1) Add the appropriate cereal serialization routines.  For example,
+ *
+ *   template <typename Archive> void serialize(Archive &archive) {
+ *       archive(cereal::make_nvp("foo", foo));
+ *       archive(cereal::make_nvp("bar", bar));
+ *   }
+ *
+ *   by using `cereal::make_nvp` each variable you archive will be
+ *   given a name and that name will end up being the column name
+ *   in the resulting CSV.  Doing this also enables a variety of
+ *   other serialization methods, including JSON, XML and BINARY.
+ *
+ *   This approach is likely the easier but slower option since the
+ *   CSV will be made by first serializing to XML, then flattening the
+ *   XML to determine the CSV columns and values.
+ *
+ * 2) Write your own custom `to_map` function for the specific
+ *   FeatureType you want to serialize.  This allows you to
+ *   derive or modify new columns in the resulting CSV.
+ *
+ *   auto to_map(const CustomFeature &feature) {
+ *     std::map<std::string, std::string> output;
+ *     output["foo"] = std::to_string(feature.foo);
+ *     output["bar"] = std::to_string(feature.bar);
+ *     output["other"] = std::to_string(feature.one) +
+ * std::to_string(feature.two);
+ *     return output;
+ *   };
+ *
+ */
+
+namespace albatross {
+
+using namespace cereal;
+
+/*
+ * This recursive function generates a map from key to value in an
+ * XML document by joining nested structure using a ".".
+ */
+template <typename NodeType>
+inline std::map<std::string, std::string>
+flatten_xml_serialization(const rapidxml::xml_node<NodeType> *node,
+                          bool prepend_parent = false) {
+  std::map<std::string, std::string> output;
+  std::string value = node->value();
+
+  if (value.size() > 0) {
+    // A node with non-zero value is a leaf node, add it to the map.
+    output[node->name()] = value;
+  } else {
+    // A node with zero value might contain children.  If so we add them.
+    for (auto child = node->first_node(); child;
+         child = child->next_sibling()) {
+      if (child->type() == rapidxml::node_type::node_element) {
+        for (const auto &pair : flatten_xml_serialization(child, true)) {
+          std::string joined_name = pair.first;
+          if (prepend_parent) {
+            joined_name = node->name() + std::string(".") + joined_name;
+          }
+          output[joined_name] = pair.second;
+        }
+      }
+    }
+  }
+  return output;
+}
+
+template <typename FeatureType>
+inline auto to_xml_buffer(const FeatureType &feature) {
+  std::ostringstream oss;
+  {
+    cereal::XMLOutputArchive archive(oss);
+    archive(feature);
+  }
+  std::istringstream fin(oss.str());
+
+  std::vector<char> buffer((std::istreambuf_iterator<char>(fin)),
+                           std::istreambuf_iterator<char>());
+  buffer.push_back('\0');
+  return buffer;
+}
+
+template <typename FeatureType>
+inline std::map<std::string, std::string> to_map(const FeatureType &feature) {
+
+  auto buffer = to_xml_buffer(feature);
+  // Parse the buffer using the xml file parsing library into doc
+  rapidxml::xml_document<> doc;
+  doc.parse<0>(&buffer[0]);
+
+  auto first_node = doc.first_node()->first_node();
+  auto output = flatten_xml_serialization(first_node);
+  return output;
+}
+
+// A special case for floating point features, otherwise they would
+// be given a column name of "value0" by cereal.
+inline std::map<std::string, std::string> to_map(const double &feature) {
+  return {{"feature", std::to_string(feature)}};
+}
+
+template <typename FeatureType>
+inline std::map<std::string, std::string>
+to_map(const FeatureType &feature, double target, double target_variance,
+       double prediction, double prediction_variance) {
+  auto output = to_map(feature);
+  output["target"] = std::to_string(target);
+  output["target_variance"] = std::to_string(target_variance);
+  output["prediction"] = std::to_string(prediction);
+  output["prediction_variance"] = std::to_string(prediction_variance);
+  return output;
+}
+
+/*
+ * Extracts the i^th element from a dataset / prediction pair and
+ * creates the corresponding column to value map.
+ */
+template <typename FeatureType, typename DistributionType>
+inline std::map<std::string, std::string>
+to_map(const RegressionDataset<FeatureType> &dataset,
+       const Distribution<DistributionType> &predictions, std::size_t i) {
+  assert(dataset.targets.size() == predictions.mean.size());
+  assert(i < dataset.features.size() && i >= 0);
+  const auto ei = static_cast<Eigen::Index>(i);
+
+  double target_variance = dataset.targets.get_diagonal(ei);
+  double predict_variance = predictions.get_diagonal(ei);
+
+  auto row = to_map(dataset.features[i], dataset.targets.mean[ei],
+                    target_variance, predictions.mean[ei], predict_variance);
+
+  row = map_join(row, dataset.metadata);
+  row = map_join(row, predictions.metadata);
+
+  return row;
+}
+
+/*
+ * This helper function makes it easier to use range based
+ * for loops that append a delimeter which can be followed
+ * by this function to turn the last delimeter into a new line
+ */
+inline void replace_last_character_with_newline(std::ostream &stream) {
+  stream.seekp(-1, std::ios_base::end);
+  stream << std::endl;
+}
+
+template <typename FeatureType, typename CovarianceType>
+inline std::vector<std::string>
+get_column_names(const RegressionDataset<FeatureType> &dataset,
+                 const Distribution<CovarianceType> &predictions) {
+  const auto first_row = to_map(dataset, predictions, 0);
+  return map_keys(first_row);
+}
+
+inline void write_row(std::ostream &stream,
+                      const std::map<std::string, std::string> &row,
+                      const std::vector<std::string> &columns) {
+  for (const auto &col : columns) {
+    stream << row.at(col) << ",";
+  }
+  replace_last_character_with_newline(stream);
+}
+
+inline void write_header(std::ostream &stream,
+                         const std::vector<std::string> &columns) {
+  for (const auto &col : columns) {
+    stream << col << ",";
+  }
+  replace_last_character_with_newline(stream);
+}
+
+template <typename FeatureType, typename CovarianceType>
+inline void write_to_csv(std::ostream &stream,
+                         const RegressionDataset<FeatureType> &dataset,
+                         const Distribution<CovarianceType> &predictions,
+                         const std::vector<std::string> &columns) {
+
+  for (std::size_t i = 0; i < dataset.features.size(); i++) {
+    const auto row = to_map(dataset, predictions, i);
+    write_row(stream, row, columns);
+  }
+}
+
+template <typename FeatureType, typename CovarianceType>
+inline void write_to_csv(std::ostream &stream,
+                         const RegressionDataset<FeatureType> &dataset,
+                         const Distribution<CovarianceType> &predictions,
+                         bool include_header = true) {
+  const auto columns = get_column_names(dataset, predictions);
+  if (include_header) {
+    write_header(stream, columns);
+  }
+  write_to_csv(stream, dataset, predictions, columns);
+}
+
+template <typename FeatureType, typename CovarianceType>
+inline void
+write_to_csv(std::ostream &stream,
+             const std::vector<RegressionDataset<FeatureType>> &datasets,
+             const std::vector<Distribution<CovarianceType>> &predictions) {
+  const auto columns = get_column_names(datasets[0], predictions[0]);
+  write_header(stream, columns);
+  assert(datasets.size() == predictions.size());
+  for (std::size_t i = 0; i < datasets.size(); i++) {
+    write_to_csv(stream, datasets[i], predictions[i], columns);
+  }
+}
+}
+
+#endif

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -6,7 +6,7 @@ run_tests() {
     # Run the long integration tests in release mode so they're fast.
     cmake -DENABLE_AUTOLINT=ON \
       -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="$C_COMPILER" -DCMAKE_CXX_COMPILER="$CXX_COMPILER" ../
-    make run_albatross_unit_tests run_inspection_example run_sinc_example run_tune_example run_temperature_example -j4
+    make run_albatross_unit_tests run_inspection_example run_sinc_example run_tune_example run_temperature_example -j2
     cd ..
 }
 

--- a/examples/plot_example_predictions.py
+++ b/examples/plot_example_predictions.py
@@ -26,27 +26,30 @@ if __name__ == "__main__":
     predictions_path = args.predictions
     print train_path
     train_data = pd.read_csv(train_path)
+    x_name = 'feature'
+    y_name = 'prediction'
+
     predictions_data = pd.read_csv(predictions_path)
-    std = np.sqrt(predictions_data['variance'].values)
+    std = np.sqrt(predictions_data['prediction_variance'].values)
 
     fig = plt.figure(figsize=(8, 8))
     # create +/- 3 sigma shading
-    plt.fill_between(predictions_data['x'],
-                     predictions_data['y'] - 3 * std,
-                     predictions_data['y'] + 3 * std, color='steelblue', alpha=0.1,
+    plt.fill_between(predictions_data[x_name],
+                     predictions_data[y_name] - 3 * std,
+                     predictions_data[y_name] + 3 * std, color='steelblue', alpha=0.1,
                      label='+/- 3 sigma')
     # and +/- 1 sigma shading
-    plt.fill_between(predictions_data['x'],
-                     predictions_data['y'] - std,
-                     predictions_data['y'] + std, color='steelblue',
+    plt.fill_between(predictions_data[x_name],
+                     predictions_data[y_name] - std,
+                     predictions_data[y_name] + std, color='steelblue',
                      alpha=0.5, label='+/- sigma')
     # Plot the mean
-    plt.plot(predictions_data['x'],
-             predictions_data['y'], color='steelblue',
+    plt.plot(predictions_data[x_name],
+             predictions_data[y_name], color='steelblue',
              label='mean')
     # Plot the truth
-    plt.plot(predictions_data['x'],
-             predictions_data['truth'].astype('float'), color='black',
+    plt.plot(predictions_data[x_name],
+             predictions_data['target'].astype('float'), color='black',
              label='truth')
     # Show the training points
     plt.scatter(train_data['x'],

--- a/examples/sinc_example.cc
+++ b/examples/sinc_example.cc
@@ -63,6 +63,18 @@ int main(int argc, char *argv[]) {
    */
   std::cout << "Instantiating the model." << std::endl;
   auto model = gp_from_covariance<double>(linear_model);
+
+  /*
+   * These parameters came from the tune_example.
+   */
+  model.set_params({
+      {"sigma_constant", 121.565},
+      {"sigma_independent_noise", 0.719013},
+      {"sigma_slope", 110.902},
+      {"sigma_squared_exponential", 5.73097},
+      {"squared_exponential_length_scale", 3.55464},
+  });
+
   model.fit(data);
 
   /*

--- a/examples/temperature_example/plot_temperature_example.py
+++ b/examples/temperature_example/plot_temperature_example.py
@@ -97,8 +97,8 @@ if __name__ == "__main__":
 
     # read in the training and prediction data
     preds = pd.read_csv(args.predictions)
-    pred_lons = preds['LON'].values
-    pred_lats = preds['LAT'].values
+    pred_lons = preds['lon'].values
+    pred_lats = preds['lat'].values
 
     df = pd.read_csv(args.train)
     lons = df['LON'].values
@@ -106,7 +106,7 @@ if __name__ == "__main__":
 
     norm = plt.Normalize(vmin=df['TEMP'].values.min(), vmax=df['TEMP'].values.max())
 
-    ncols = np.nonzero(np.diff(preds['LAT'].values) != 0)[0][0] + 1
+    ncols = np.nonzero(np.diff(preds['lat'].values) != 0)[0][0] + 1
     nrows = float(preds.shape[0]) / ncols
     if not (nrows - int(nrows) == 0.):
         raise ValueError("Couldn't infer data shape")
@@ -149,8 +149,7 @@ if __name__ == "__main__":
 
         plt.colorbar(pm, ax=axes[0], cax=cax, label=units)
 
-
-    plot_variable('TEMP', "Degrees F")
+    plot_variable('prediction', "Degrees F")
     plt.savefig("mean_temperature.png", norm=norm)
-    plot_variable('VARIANCE', "Standard Deviation (F)", vmax=3.0)
+    plot_variable('prediction_variance', "Standard Deviation (F)", vmax=3.0)
     plt.savefig("sd_temperature.png")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(albatross_unit_tests
 EXCLUDE_FROM_ALL
 test_core_distribution.cc
 test_core_model.cc
+test_csv_utils.cc
 test_covariance_functions.cc
 test_distance_metrics.cc
 test_evaluate.cc

--- a/tests/test_core_model.cc
+++ b/tests/test_core_model.cc
@@ -32,7 +32,7 @@ TEST(test_core_model, test_fit_predict) {
 TEST(test_core_model, test_regression_model_abstraction) {
   // This just tests to make sure that an implementation of a RegressionModel
   // can be passed around as a pointer to the abstract class.
-  std::unique_ptr<RegressionModel<MockPredictor>> m_ptr =
+  std::unique_ptr<RegressionModel<MockFeature>> m_ptr =
       std::make_unique<MockModel>();
 }
 } // namespace albatross

--- a/tests/test_csv_utils.cc
+++ b/tests/test_csv_utils.cc
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "csv.h"
+#include "csv_utils.h"
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+struct SubFeature {
+  double one = 1.;
+  int two = 2;
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::make_nvp("one", one));
+    archive(cereal::make_nvp("two", two));
+  }
+};
+
+struct TestFeature {
+  double foo;
+  int bar;
+  SubFeature feature;
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::make_nvp("foo", foo));
+    archive(cereal::make_nvp("bar", bar));
+    archive(cereal::make_nvp("sub_feature", feature));
+  }
+};
+
+/*
+ * This does nothing more than read the CSV, but would fail if
+ * the CSV were missing columns or had unparsable data.
+ */
+void read_test_csv(std::istream &stream) {
+  io::CSVReader<8> reader("garbage", stream);
+  reader.read_header(io::ignore_no_column, "bar", "foo", "prediction",
+                     "prediction_variance", "sub_feature.one",
+                     "sub_feature.two", "target", "target_variance");
+
+  bool more_to_parse = true;
+  while (more_to_parse) {
+    double prediction;
+    std::string prediction_variance_str;
+    double target;
+    std::string target_variance_str;
+    TestFeature f;
+    more_to_parse = reader.read_row(f.bar, f.foo, prediction,
+                                    prediction_variance_str, f.feature.one,
+                                    f.feature.two, target, target_variance_str);
+  }
+}
+
+TEST(test_csv_utils, test_writes) {
+  TestFeature one = {1.2, 2, {1.3, 3}};
+  TestFeature two = {2.2, 3, {2.3, 4}};
+  TestFeature three = {3.2, 4, {3.3, 5}};
+
+  std::vector<TestFeature> features = {one, two, three};
+  Eigen::VectorXd targets(3);
+  targets << 1., 2., 3.;
+
+  MarginalDistribution predictions(targets);
+
+  RegressionDataset<TestFeature> dataset(features, targets);
+
+  std::ostringstream oss;
+  write_to_csv(oss, dataset, predictions);
+
+  std::istringstream iss(oss.str());
+
+  read_test_csv(iss);
+}
+
+/*
+ * This does nothing more than read the CSV, but would fail if
+ * the CSV were missing columns or had unparsable data.
+ */
+void read_test_csv_with_metadata(std::istream &stream) {
+  io::CSVReader<10> reader("garbage", stream);
+  reader.read_header(io::ignore_no_column, "bar", "foo", "prediction",
+                     "prediction_variance", "sub_feature.one",
+                     "sub_feature.two", "target", "target_variance", "time",
+                     "model");
+
+  bool more_to_parse = true;
+  while (more_to_parse) {
+    double prediction;
+    std::string prediction_variance_str;
+    double target;
+    std::string time, model;
+    std::string target_variance_str;
+    TestFeature f;
+    more_to_parse = reader.read_row(
+        f.bar, f.foo, prediction, prediction_variance_str, f.feature.one,
+        f.feature.two, target, target_variance_str, time, model);
+  }
+}
+
+TEST(test_csv_utils, test_writes_metadata) {
+
+  TestFeature one = {1.2, 2, {1.3, 3}};
+  TestFeature two = {2.2, 3, {2.3, 4}};
+  TestFeature three = {3.2, 4, {3.3, 5}};
+
+  std::vector<TestFeature> features = {one, two, three};
+  Eigen::VectorXd targets(3);
+  targets << 1., 2., 3.;
+
+  MarginalDistribution prediction(targets);
+  prediction.metadata["model"] = "null";
+
+  RegressionDataset<TestFeature> first(features, targets);
+  first.metadata["time"] = "1";
+
+  RegressionDataset<TestFeature> second(features, targets);
+  second.metadata["time"] = "2";
+
+  std::vector<decltype(first)> datasets = {first, second};
+  std::vector<decltype(prediction)> predictions = {prediction, prediction};
+
+  std::ostringstream oss;
+  write_to_csv(oss, datasets, predictions);
+
+  std::istringstream iss(oss.str());
+  read_test_csv_with_metadata(iss);
+}
+
+struct CustomFeature {
+  double one = 1.;
+  int two = 2;
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::make_nvp("one", one));
+    archive(cereal::make_nvp("two", two));
+  }
+};
+
+auto to_map(const CustomFeature &feature) {
+  std::map<std::string, std::string> output;
+  output["one"] = std::to_string(feature.one);
+  output["two"] = std::to_string(feature.two);
+  output["three"] = std::to_string(feature.one) + std::to_string(feature.two);
+  return output;
+};
+
+/*
+ * This does nothing more than read the CSV, but would fail if
+ * the CSV were missing columns or had unparsable data.
+ */
+void read_test_csv_with_custom_to_map(std::istream &stream) {
+  io::CSVReader<7> reader("garbage", stream);
+  reader.read_header(io::ignore_no_column, "one", "two", "three", "prediction",
+                     "prediction_variance", "target", "target_variance");
+
+  bool more_to_parse = true;
+  while (more_to_parse) {
+    double prediction;
+    std::string prediction_variance_str;
+    double target;
+    std::string three;
+    std::string target_variance_str;
+    CustomFeature f;
+    more_to_parse =
+        reader.read_row(f.one, f.two, three, prediction,
+                        prediction_variance_str, target, target_variance_str);
+  }
+}
+
+TEST(test_csv_utils, test_custom_writes) {
+
+  CustomFeature one = {1.2, 2};
+  CustomFeature two = {2.2, 3};
+  std::vector<CustomFeature> features = {one, two};
+  Eigen::Vector2d targets;
+  targets << 1., 2.;
+
+  MarginalDistribution predictions(targets);
+
+  RegressionDataset<CustomFeature> dataset(features, targets);
+
+  std::ostringstream oss;
+  write_to_csv(oss, dataset, predictions);
+
+  std::istringstream iss(oss.str());
+  read_test_csv_with_custom_to_map(iss);
+}
+
+} // namespace albatross

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -33,8 +33,8 @@ using SquaredExponentialGaussianProcess =
     GaussianProcessRegression<double, CovFunc>;
 
 using SerializableMockPointer =
-    std::unique_ptr<SerializableRegressionModel<MockPredictor, MockFit>>;
-using RegressionMockPointer = std::unique_ptr<RegressionModel<MockPredictor>>;
+    std::unique_ptr<SerializableRegressionModel<MockFeature, MockFit>>;
+using RegressionMockPointer = std::unique_ptr<RegressionModel<MockFeature>>;
 using SerializableLeastSquaresPointer =
     std::unique_ptr<SerializableRegressionModel<double, LeastSquaresFit>>;
 using DoubleRegressionModelPointer = std::unique_ptr<RegressionModel<double>>;
@@ -167,6 +167,46 @@ struct ParameterStoreType : public SerializableType<ParameterStore> {
         {"1", {1., std::make_shared<GaussianPrior>(1., 2.)}},
         {"3", 3.}};
     return original;
+  }
+
+  bool are_equal(const RepresentationType &lhs,
+                 const RepresentationType &rhs) const override {
+    return lhs == rhs;
+  };
+};
+
+struct Dataset : public SerializableType<RegressionDataset<MockFeature>> {
+
+  RepresentationType create() const override {
+
+    std::vector<MockFeature> features = {{1}, {3}, {-2}};
+    Eigen::VectorXd targets(3);
+    targets << 5., 3., 9.;
+
+    RegressionDataset<MockFeature> dataset(features, targets);
+
+    return dataset;
+  }
+
+  bool are_equal(const RepresentationType &lhs,
+                 const RepresentationType &rhs) const override {
+    return lhs == rhs;
+  };
+};
+
+struct DatasetWithMetadata
+    : public SerializableType<RegressionDataset<MockFeature>> {
+
+  RepresentationType create() const override {
+
+    std::vector<MockFeature> features = {{1}, {3}, {-2}};
+    Eigen::VectorXd targets(3);
+    targets << 5., 3., 9.;
+
+    RegressionDataset<MockFeature> dataset(features, targets);
+    dataset.metadata["time"] = "1";
+
+    return dataset;
   }
 
   bool are_equal(const RepresentationType &lhs,
@@ -321,9 +361,9 @@ typedef ::testing::Types<
     FullJointDistribution, MeanOnlyJointDistribution, FullMarginalDistribution,
     MeanOnlyMarginalDistribution, ParameterStoreType,
     SerializableType<MockModel>, UnfitSerializableModel, FitSerializableModel,
-    FitDirectModel, UnfitDirectModel, UnfitRegressionModel,
-    FitLinearRegressionModel, FitLinearSerializablePointer,
-    UnfitGaussianProcess, FitGaussianProcess>
+    Dataset, DatasetWithMetadata, FitDirectModel, UnfitDirectModel,
+    UnfitRegressionModel, FitLinearRegressionModel,
+    FitLinearSerializablePointer, UnfitGaussianProcess, FitGaussianProcess>
     ToTest;
 
 TYPED_TEST_CASE(PolymorphicSerializeTest, ToTest);


### PR DESCRIPTION
Adds `csv_utils.h` which provides tools for writing datasets and predictiosn to csv files, which in turn makes it easy to transfer data to external applications.

Includes adding the ability to attach metadata to datasets and distributions which can help keep useful information about how predictions were made, or where data came from that is then also serialized via cereal or CSV.

The first commit contains the bulk of the actual added functionality, the second (larger) commit updates the tests and examples.