### PR TITLE
Pretty Printing

### DIFF
--- a/albatross/core/parameter_handling_mixin.h
+++ b/albatross/core/parameter_handling_mixin.h
@@ -13,6 +13,7 @@
 #ifndef ALBATROSS_CORE_PARAMETER_HANDLING_MIXIN_H
 #define ALBATROSS_CORE_PARAMETER_HANDLING_MIXIN_H
 
+#include <algorithm>
 #include <assert.h>
 #include <iomanip>
 #include <map>
@@ -117,10 +118,12 @@ inline std::string pretty_priors(const ParameterStore &params) {
 inline std::string pretty_param_details(const ParameterStore &params) {
   std::ostringstream ss;
 
-  std::size_t max_name_length = 0;
-  for (const auto &pair : params) {
-    max_name_length = std::max(max_name_length, pair.first.size());
-  }
+  auto compare_size = [](const auto &x, const auto &y) {
+    return x.first.size() < y.first.size();
+  };
+  auto max_name_length =
+      std::max_element(params.begin(), params.end(), compare_size)
+          ->first.size();
 
   for (const auto &pair : params) {
     std::string prior_name;

--- a/albatross/core/parameter_handling_mixin.h
+++ b/albatross/core/parameter_handling_mixin.h
@@ -14,6 +14,7 @@
 #define ALBATROSS_CORE_PARAMETER_HANDLING_MIXIN_H
 
 #include <assert.h>
+#include <iomanip>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -115,6 +116,12 @@ inline std::string pretty_priors(const ParameterStore &params) {
 
 inline std::string pretty_param_details(const ParameterStore &params) {
   std::ostringstream ss;
+
+  std::size_t max_name_length = 0;
+  for (const auto &pair : params) {
+    max_name_length = std::max(max_name_length, pair.first.size());
+  }
+
   for (const auto &pair : params) {
     std::string prior_name;
     if (pair.second.has_prior()) {
@@ -122,8 +129,9 @@ inline std::string pretty_param_details(const ParameterStore &params) {
     } else {
       prior_name = "none";
     }
-    ss << "    " << pair.first << " value: " << pair.second.value
-       << ", prior: " << prior_name << ", bounds: ["
+    ss << "    " << std::left << std::setw(max_name_length + 1) << pair.first
+       << " value: " << std::left << std::setw(10) << pair.second.value
+       << " prior: " << std::setw(15) << prior_name << " bounds: ["
        << (pair.second.has_prior() ? pair.second.prior->lower_bound()
                                    : -INFINITY)
        << ", " << (pair.second.has_prior() ? pair.second.prior->upper_bound()

--- a/albatross/core/priors.h
+++ b/albatross/core/priors.h
@@ -101,7 +101,7 @@ public:
 
   std::string get_name() const override {
     std::ostringstream oss;
-    oss << "gaussian[" << lower_ << "," << upper_ << "]";
+    oss << "uniform[" << lower_ << "," << upper_ << "]";
     return oss.str();
   };
 

--- a/examples/sinc_example.cc
+++ b/examples/sinc_example.cc
@@ -64,10 +64,12 @@ int main(int argc, char *argv[]) {
   std::cout << "Instantiating the model." << std::endl;
   auto model = gp_from_covariance<double>(linear_model);
 
+  std::cout << pretty_param_details(model.get_params()) << std::endl;
+
   /*
    * These parameters came from the tune_example.
    */
-  model.set_params({
+  model.set_param_values({
       {"sigma_constant", 121.565},
       {"sigma_independent_noise", 0.719013},
       {"sigma_slope", 110.902},

--- a/examples/temperature_example/temperature_example.cc
+++ b/examples/temperature_example/temperature_example.cc
@@ -66,7 +66,7 @@ int main(int argc, char *argv[]) {
 
   // These parameters are that came from tuning the model to the leave
   // one out negative log likelihood.
-  ParameterStore params = {
+  model.set_param_values({
       {"elevation_scaling_center", 3965.98},
       {"elevation_scaling_factor", 0.000810492},
       {"exponential_length_scale", 28197.6},
@@ -75,8 +75,7 @@ int main(int argc, char *argv[]) {
       {"sigma_exponential", 2.07548},
       {"sigma_independent_noise", 1.8288},
       {"sigma_squared_exponential", 3.77329},
-  };
-  model.set_params(params);
+  });
 
   std::cout << "Training the model." << std::endl;
   model.fit(data);


### PR DESCRIPTION
Fix some formatting and naming issues surrounding printing priors for debugging.

Now `pretty_param_details` looks like this:

```
    sigma_constant                   value: 100        prior: positive        bounds: [0, inf]
    sigma_independent_noise          value: 10         prior: positive        bounds: [0, inf]
    sigma_slope                      value: 100        prior: none            bounds: [-inf, inf]
    sigma_squared_exponential        value: 100        prior: positive        bounds: [0, inf]
    squared_exponential_length_scale value: 1.5        prior: positive        bounds: [0, inf]
```