### PR TITLE
Overloaded Predict

### DIFF
--- a/albatross/core/model_adapter.h
+++ b/albatross/core/model_adapter.h
@@ -139,17 +139,20 @@ protected:
 
   JointDistribution
   predict_(const std::vector<FeatureType> &features) const override {
-    return sub_model_.predict(convert_features(features));
+    return sub_model_.template predict<JointDistribution>(
+        convert_features(features));
   }
 
-  virtual MarginalDistribution
+  MarginalDistribution
   predict_marginal_(const std::vector<FeatureType> &features) const override {
-    return sub_model_.predict_marginal(convert_features(features));
+    return sub_model_.template predict<MarginalDistribution>(
+        convert_features(features));
   }
 
-  virtual Eigen::VectorXd
+  Eigen::VectorXd
   predict_mean_(const std::vector<FeatureType> &features) const override {
-    return sub_model_.predict_mean(convert_features(features));
+    return sub_model_.template predict<Eigen::VectorXd>(
+        convert_features(features));
   }
 
   const std::vector<SubFeature>

--- a/examples/temperature_example/temperature_example_utils.h
+++ b/examples/temperature_example/temperature_example_utils.h
@@ -138,7 +138,7 @@ void write_predictions(const std::string output_path,
 
   albatross::RegressionDataset<Station> dataset(features, targets);
 
-  const auto predictions = model.predict_marginal(features);
+  const auto predictions = model.predict<MarginalDistribution>(features);
   albatross::write_to_csv(ostream, dataset, predictions);
 }
 


### PR DESCRIPTION
Switch from using `predict_marginal`, `predict_mean` methods to a single `predict<PredictType>` method which behaves differently depending on a template argument.

For example, you can now do:

```
// same as before
JointDistribution pred = model.predict(features);
JointDistribution pred = model.predict<JointDistribution>(features);

// only compute the diagonal of the prediction covariance
MarginalDistribution pred = model.predict<MarginalDistribution>(features);

// only compute the predicted mean
Eigen::VectorXd mean = model.predict<Eigen::VectorXd>(features);
Eigen::VectorXd mean = model.predict<PredictMeanOnly>(features);
```

In subsequent changes we'll (hopefully) get the cross validation routines able to choose how much work they should be doing depending on the `EvaluationMetric`.