### PR TITLE
GP Cross Validation

### DIFF
--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -200,6 +200,12 @@ protected:
 
   /*
    * Cross validation specializations
+   *
+   * Note the naming here uses a trailing underscore.  This is to avoid
+   * name hiding when implementing one of these methods in a derived
+   * class:
+   *
+   * https://stackoverflow.com/questions/1628768/why-does-an-overridden-function-in-the-derived-class-hide-other-overloads-of-the
    */
   virtual std::vector<JointDistribution> cross_validated_predictions_(
       const RegressionDataset<FeatureType> &dataset,

--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -107,7 +107,7 @@ public:
   std::vector<PredictType>
   cross_validated_predictions(const RegressionDataset<FeatureType> &dataset,
                               const FoldIndexer &fold_indexer) {
-    return cross_validated_predictions(
+    return cross_validated_predictions_(
         dataset, fold_indexer, detail::PredictTypeIdentity<PredictType>());
   }
 
@@ -201,7 +201,7 @@ protected:
   /*
    * Cross validation specializations
    */
-  virtual std::vector<JointDistribution> cross_validated_predictions(
+  virtual std::vector<JointDistribution> cross_validated_predictions_(
       const RegressionDataset<FeatureType> &dataset,
       const FoldIndexer &fold_indexer,
       const detail::PredictTypeIdentity<JointDistribution> &identity) {
@@ -209,7 +209,7 @@ protected:
     return cross_validated_predictions<JointDistribution>(folds);
   }
 
-  virtual std::vector<MarginalDistribution> cross_validated_predictions(
+  virtual std::vector<MarginalDistribution> cross_validated_predictions_(
       const RegressionDataset<FeatureType> &dataset,
       const FoldIndexer &fold_indexer,
       const detail::PredictTypeIdentity<MarginalDistribution> &identity) {
@@ -217,7 +217,7 @@ protected:
     return cross_validated_predictions<MarginalDistribution>(folds);
   }
 
-  virtual std::vector<Eigen::VectorXd> cross_validated_predictions(
+  virtual std::vector<Eigen::VectorXd> cross_validated_predictions_(
       const RegressionDataset<FeatureType> &dataset,
       const FoldIndexer &fold_indexer,
       const detail::PredictTypeIdentity<PredictMeanOnly> &identity) {

--- a/albatross/crossvalidation.h
+++ b/albatross/crossvalidation.h
@@ -65,6 +65,24 @@ cross_validated_scores(const EvaluationMetric<PredictType> &metric,
 }
 
 /*
+ * Iterates over each fold in a cross validation set and fits/predicts and
+ * scores the fold, returning a vector of scores for each fold.
+ */
+template <typename FeatureType, typename PredictType = JointDistribution>
+static inline Eigen::VectorXd
+cross_validated_scores(const EvaluationMetric<PredictType> &metric,
+                       const RegressionDataset<FeatureType> &dataset,
+                       const FoldIndexer &fold_indexer,
+                       RegressionModel<FeatureType> *model) {
+  // Create a vector of predictions.
+  std::vector<PredictType> predictions =
+      model->template cross_validated_predictions<PredictType>(dataset,
+                                                               fold_indexer);
+  const auto folds = folds_from_fold_indexer(dataset, fold_indexer);
+  return compute_scores<FeatureType, PredictType>(metric, folds, predictions);
+}
+
+/*
  * Returns a single cross validated prediction distribution
  * for some cross validation folds, taking into account the
  * fact that each fold may contain reordered data.

--- a/albatross/map_utils.h
+++ b/albatross/map_utils.h
@@ -62,6 +62,18 @@ std::vector<K> map_keys(const std::map<K, V> m) {
   return keys;
 }
 
+/*
+ * Returns a vector consisting of all the values in a map.
+ */
+template <typename K, typename V>
+std::vector<V> map_values(const std::map<K, V> m) {
+  std::vector<V> values;
+  for (const auto &pair : m) {
+    values.push_back(pair.second);
+  }
+  return values;
+}
+
 template <typename K, typename V>
 std::map<K, V> map_join(const std::map<K, V> m, const std::map<K, V> other) {
   std::map<K, V> join;

--- a/albatross/models/least_squares.h
+++ b/albatross/models/least_squares.h
@@ -68,16 +68,20 @@ public:
   }
 
 protected:
-  JointDistribution
-  predict_(const std::vector<Eigen::VectorXd> &features) const override {
+  Eigen::VectorXd
+  predict_mean_(const std::vector<Eigen::VectorXd> &features) const override {
     int n = static_cast<s32>(features.size());
-    Eigen::VectorXd predictions(n);
+    Eigen::VectorXd mean(n);
     for (s32 i = 0; i < n; i++) {
-      predictions(i) =
+      mean(i) =
           features[static_cast<std::size_t>(i)].dot(this->model_fit_.coefs);
     }
+    return mean;
+  }
 
-    return JointDistribution(predictions);
+  JointDistribution
+  predict_(const std::vector<Eigen::VectorXd> &features) const override {
+    return JointDistribution(predict_mean_(features));
   }
 
   /*

--- a/examples/sinc_example.cc
+++ b/examples/sinc_example.cc
@@ -37,7 +37,7 @@ tune_model(RegressionModelCreator<double> &model_creator,
    */
   std::cout << "Tuning the model." << std::endl;
 
-  TuningMetric<double> metric = albatross::gp_fast_loo_nll<double>;
+  TuningMetric<double> metric = albatross::loo_nll;
 
   TuneModelConfig<double> config(model_creator, data, metric);
   return tune_regression_model<double>(config);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,6 @@ test_core_model.cc
 test_csv_utils.cc
 test_covariance_functions.cc
 test_distance_metrics.cc
-test_eigen_utils.cc
 test_evaluate.cc
 test_map_utils.cc
 test_model_adapter.cc

--- a/tests/test_tuning_metrics.cc
+++ b/tests/test_tuning_metrics.cc
@@ -19,19 +19,6 @@
 
 namespace albatross {
 
-TEST(test_tuning_metrics, test_fast_loo_equals_slow) {
-  auto dataset = make_toy_linear_data(5., 1., 0.1, 4);
-
-  auto model_creator = toy_gaussian_process;
-  auto model = model_creator();
-
-  double fast_loo_nll = gp_fast_loo_nll(dataset, model.get());
-
-  double slow_loo_nll = loo_nll(dataset, model.get());
-
-  EXPECT_NEAR(fast_loo_nll, slow_loo_nll, 1e-6);
-}
-
 /*
  * Here we setup a typed test to make it easy to add new
  * tuning metrics and make sure they run fine.
@@ -54,7 +41,7 @@ public:
  * Add any new tuning metrics here:
  */
 typedef ::testing::Types<TestMetric<loo_nll>, TestMetric<loo_rmse>,
-                         TestMetric<gp_fast_loo_nll<double>>>
+                         TestMetric<gp_nll>>
     MetricsToTest;
 
 TYPED_TEST_CASE(TuningMetricTester, MetricsToTest);
@@ -66,16 +53,6 @@ TYPED_TEST(TuningMetricTester, test_sanity) {
   const auto model = model_creator();
   const auto metric = this->test_metric.function(dataset, model.get());
   EXPECT_FALSE(std::isnan(metric));
-}
-
-TEST(test_tuning_metrics, test_fast_loo_works_on_adapted_model) {
-  auto dataset = make_adapted_toy_linear_data();
-
-  auto model_creator = adapted_toy_gaussian_process;
-  auto model = model_creator();
-
-  double fast_loo_nll =
-      gp_fast_loo_nll<AdaptedFeature, double>(dataset, model.get());
 }
 
 } // namespace albatross


### PR DESCRIPTION
Builds on the cross validation API from #45 by moving the fast Gaussian process cross validation code into specialized `RegressionModel.cross_validated_predict_` methods.

Includes the ability to do arbitrary leave one group (previously it was only leave one out).