### PR TITLE
Exclude Fixed Parameters

### DIFF
--- a/albatross/core/parameter_handling_mixin.h
+++ b/albatross/core/parameter_handling_mixin.h
@@ -243,9 +243,12 @@ public:
     std::vector<double> lb;
     const auto params = get_params();
     for (const auto &pair : params) {
-      double bound = pair.second.has_prior() ? pair.second.prior->lower_bound()
-                                             : -LARGE_VAL;
-      lb.push_back(fmax(bound, -LARGE_VAL));
+      if (!pair.second.is_fixed()) {
+        double bound = pair.second.has_prior()
+                           ? pair.second.prior->lower_bound()
+                           : -LARGE_VAL;
+        lb.push_back(fmax(bound, -LARGE_VAL));
+      }
     }
     return lb;
   }
@@ -254,9 +257,12 @@ public:
     std::vector<double> ub;
     const auto params = get_params();
     for (const auto &pair : params) {
-      double bound = pair.second.has_prior() ? pair.second.prior->upper_bound()
-                                             : LARGE_VAL;
-      ub.push_back(fmin(bound, LARGE_VAL));
+      if (!pair.second.is_fixed()) {
+        double bound = pair.second.has_prior()
+                           ? pair.second.prior->upper_bound()
+                           : LARGE_VAL;
+        ub.push_back(fmin(bound, LARGE_VAL));
+      }
     }
     return ub;
   }

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -72,6 +72,8 @@ TEST(test_tune, test_with_prior) {
       model->set_prior(pair.first, std::make_shared<GaussianPrior>(
                                        pair.second.value + 0.1, 0.001));
     }
+    auto param_names = map_keys(model->get_params());
+    model->set_prior(param_names[0], std::make_shared<FixedPrior>());
     return model;
   };
 


### PR DESCRIPTION
Make sure to exclude lower bounds when tuning using fixed parameters.