### PR TITLE
Specialize `adjust_storage_size()` so it works correctly for cereal::JSONInputArchive.

### DIFF
--- a/albatross/cereal/eigen.h
+++ b/albatross/cereal/eigen.h
@@ -47,7 +47,6 @@ inline void load(Archive &archive, Eigen::Matrix<_Scalar, _Rows, _Cols> &v) {
   archive(cereal::make_size_tag(rows_plus_two));
   archive(rows);
   archive(cols);
-  assert(rows == rows_plus_two - 2);
   /*
    * In order to determine the size of a matrix, we have to first determine
    * how many rows, then inspect the size of the first row to get the

--- a/albatross/eigen/serializable_ldlt.h
+++ b/albatross/eigen/serializable_ldlt.h
@@ -34,13 +34,25 @@ inline void save_lower_triangle(Archive &archive,
   }
 }
 
+inline void adjust_storage_size(__attribute__((unused))
+                                cereal::JSONInputArchive &archive,
+                                cereal::size_type *storage_size) {
+  // TODO: understand why the storage size upon load is always augmented by two
+  // when using a JSON archive.
+  *storage_size -= 2;
+}
+
+template <class Archive>
+inline void adjust_storage_size(
+        __attribute__((unused)) Archive &archive,
+        __attribute__((unused)) cereal::size_type *storage_size) {}
+
 template <class Archive, typename _Scalar, int _Rows, int _Cols>
 inline void load_lower_triangle(Archive &archive,
                                 Eigen::Matrix<_Scalar, _Rows, _Cols> &v) {
   cereal::size_type storage_size;
   archive(cereal::make_size_tag(storage_size));
-  // TODO: understand why the storage size upon load is always augmented by two.
-  storage_size -= 2;
+  adjust_storage_size(archive, &storage_size);
   // We assume the matrix is square and compute the number of rows from the
   // storage size using the quadratic formula.
   //     rows^2 + rows - 2 * storage_size = 0

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -368,7 +368,7 @@ typedef ::testing::Types<
 
 TYPED_TEST_CASE(PolymorphicSerializeTest, ToTest);
 
-TYPED_TEST(PolymorphicSerializeTest, test_roundtrip_serialize) {
+TYPED_TEST(PolymorphicSerializeTest, test_roundtrip_serialize_json) {
   TypeParam model_and_rep;
   using X = typename TypeParam::RepresentationType;
   const X original = model_and_rep.create();
@@ -398,4 +398,36 @@ TYPED_TEST(PolymorphicSerializeTest, test_roundtrip_serialize) {
   // And make sure the serialized strings are the same,
   EXPECT_EQ(os_again.str(), os.str());
 }
+
+TYPED_TEST(PolymorphicSerializeTest, test_roundtrip_serialize_binary) {
+  TypeParam model_and_rep;
+  using X = typename TypeParam::RepresentationType;
+  const X original = model_and_rep.create();
+
+  // Serialize it
+  std::ostringstream os;
+  {
+    cereal::BinaryOutputArchive oarchive(os);
+    oarchive(original);
+  }
+  // Deserialize it.
+  std::istringstream is(os.str());
+  X deserialized;
+  {
+    cereal::BinaryInputArchive iarchive(is);
+    iarchive(deserialized);
+  }
+  // Make sure the original and deserialized representations are
+  // equivalent.
+  EXPECT_TRUE(model_and_rep.are_equal(original, deserialized));
+  // Reserialize the deserialized object
+  std::ostringstream os_again;
+  {
+    cereal::BinaryOutputArchive oarchive(os_again);
+    oarchive(deserialized);
+  }
+  // And make sure the serialized strings are the same,
+  EXPECT_EQ(os_again.str(), os.str());
+}
+
 } // namespace albatross


### PR DESCRIPTION
I needed to revert this line for the `cereal::BinaryInputArchive()` to work. Do we still need it for the JSON archive?