### PR TITLE
RANSAC Outlier Detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(albatross_HEADERS
     albatross/tuning_metrics.h
     albatross/map_utils.h
     albatross/csv_utils.h
+    albatross/outlier.h
     albatross/core/keys.h
     albatross/core/dataset.h
     albatross/core/model.h

--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -163,7 +163,6 @@ public:
 protected:
   virtual void fit_(const std::vector<FeatureType> &features,
                     const MarginalDistribution &targets) = 0;
-
   /*
    * Predict specializations
    */

--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -66,8 +66,7 @@ public:
   void fit(const std::vector<FeatureType> &features,
            const MarginalDistribution &targets) {
     assert(features.size() > 0);
-    assert(static_cast<s32>(features.size()) ==
-           static_cast<s32>(targets.size()));
+    assert(features.size() == static_cast<std::size_t>(targets.size()));
     fit_(features, targets);
     has_been_fit_ = true;
   }
@@ -174,8 +173,7 @@ protected:
           detail::PredictTypeIdentity<JointDistribution> &&identity) const {
     assert(has_been_fit());
     JointDistribution preds = predict_(features);
-    assert(static_cast<s32>(preds.mean.size()) ==
-           static_cast<s32>(features.size()));
+    assert(static_cast<std::size_t>(preds.mean.size()) == features.size());
     return preds;
   }
 
@@ -184,8 +182,7 @@ protected:
           detail::PredictTypeIdentity<MarginalDistribution> &&identity) const {
     assert(has_been_fit());
     MarginalDistribution preds = predict_marginal_(features);
-    assert(static_cast<s32>(preds.mean.size()) ==
-           static_cast<s32>(features.size()));
+    assert(static_cast<std::size_t>(preds.mean.size()) == features.size());
     return preds;
   }
 
@@ -194,7 +191,7 @@ protected:
           detail::PredictTypeIdentity<Eigen::VectorXd> &&identity) const {
     assert(has_been_fit());
     Eigen::VectorXd preds = predict_mean_(features);
-    assert(static_cast<s32>(preds.size()) == static_cast<s32>(features.size()));
+    assert(static_cast<std::size_t>(preds.size()) == features.size());
     return preds;
   }
 

--- a/albatross/models/least_squares.h
+++ b/albatross/models/least_squares.h
@@ -70,11 +70,11 @@ public:
 protected:
   Eigen::VectorXd
   predict_mean_(const std::vector<Eigen::VectorXd> &features) const override {
-    int n = static_cast<s32>(features.size());
+    std::size_t n = features.size();
     Eigen::VectorXd mean(n);
-    for (s32 i = 0; i < n; i++) {
-      mean(i) =
-          features[static_cast<std::size_t>(i)].dot(this->model_fit_.coefs);
+    for (std::size_t i = 0; i < n; i++) {
+      mean(static_cast<Eigen::Index>(i)) =
+          features[i].dot(this->model_fit_.coefs);
     }
     return mean;
   }

--- a/albatross/models/ransac_gp.h
+++ b/albatross/models/ransac_gp.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_MODELS_RANSAC_GP_H
+#define ALBATROSS_MODELS_RANSAC_GP_H
+
+#include "crossvalidation.h"
+#include "gp.h"
+#include "outlier.h"
+#include <random>
+
+namespace albatross {
+
+template <typename FeatureType, typename CovarianceFunction>
+class RansacGaussianProcessRegression
+    : public GaussianProcessRegression<FeatureType, CovarianceFunction> {
+public:
+  using BaseModel = GaussianProcessRegression<FeatureType, CovarianceFunction>;
+  using FitType = GaussianProcessFit<FeatureType>;
+
+  RansacGaussianProcessRegression(CovarianceFunction &covariance_function,
+                                  double threshold_, std::size_t min_inliers_,
+                                  std::size_t min_features_,
+                                  std::size_t max_iterations_)
+      : BaseModel(covariance_function), threshold(threshold_),
+        min_inliers(min_inliers_), min_features(min_features_),
+        max_iterations(max_iterations_){};
+
+  template <typename Archive> void save(Archive &archive) const {
+    archive(cereal::base_class<BaseModel>(this),
+            cereal::make_nvp("threshold", threshold),
+            cereal::make_nvp("min_inliers", min_inliers),
+            cereal::make_nvp("min_features", min_features),
+            cereal::make_nvp("max_iterations", max_iterations));
+  }
+
+  template <typename Archive> void load(Archive &archive) {
+    archive(cereal::base_class<BaseModel>(this),
+            cereal::make_nvp("threshold", threshold),
+            cereal::make_nvp("min_inliers", min_inliers),
+            cereal::make_nvp("min_features", min_features),
+            cereal::make_nvp("max_iterations", max_iterations));
+  }
+
+protected:
+  /*
+   *
+   */
+  virtual std::vector<JointDistribution> cross_validated_predictions_(
+      const RegressionDataset<FeatureType> &dataset,
+      const FoldIndexer &fold_indexer,
+      const detail::PredictTypeIdentity<JointDistribution> &identity) override {
+    const auto folds = folds_from_fold_indexer(dataset, fold_indexer);
+    return this->template cross_validated_predictions<JointDistribution>(folds);
+  }
+
+  virtual std::vector<MarginalDistribution> cross_validated_predictions_(
+      const RegressionDataset<FeatureType> &dataset,
+      const FoldIndexer &fold_indexer,
+      const detail::PredictTypeIdentity<MarginalDistribution> &identity)
+      override {
+    const auto folds = folds_from_fold_indexer(dataset, fold_indexer);
+    return this->template cross_validated_predictions<MarginalDistribution>(
+        folds);
+  }
+
+  virtual std::vector<Eigen::VectorXd> cross_validated_predictions_(
+      const RegressionDataset<FeatureType> &dataset,
+      const FoldIndexer &fold_indexer,
+      const detail::PredictTypeIdentity<PredictMeanOnly> &identity) override {
+    const auto folds = folds_from_fold_indexer(dataset, fold_indexer);
+    return this->template cross_validated_predictions<PredictMeanOnly>(folds);
+  }
+
+  FitType
+  serializable_fit_(const std::vector<FeatureType> &features,
+                    const MarginalDistribution &targets) const override {
+    /*
+     * This function is basically just setting up the call to `ransac` by
+     * defining `fitter`, `outlier_metric` and `model_metric` functions
+     * that can perform each operation efficiently for Gaussian processes.
+     */
+
+    Eigen::MatrixXd cov =
+        symmetric_covariance(this->covariance_function_, features);
+
+    if (max_iterations < 1) {
+      return fit_from_covariance(features, cov, targets);
+    }
+
+    struct FitAndIndices {
+      FitType model_fit;
+      Indexer fit_indices;
+    };
+
+    std::function<FitAndIndices(const Indexer &)> fitter =
+        [&](const Indexer &indexer) {
+          const auto train_features = subset(indexer, features);
+          const auto train_targets = subset(indexer, targets);
+          auto train_cov = symmetric_subset(indexer, cov);
+          const FitAndIndices fit_and_indices = {
+              fit_from_covariance(train_features, train_cov, train_targets),
+              indexer};
+          return fit_and_indices;
+        };
+
+    std::function<double(const Indexer &, const FitAndIndices &)>
+        outlier_metric = [&](const Indexer &test_indices,
+                             const FitAndIndices &fit_and_indices) {
+          const auto cross_cov =
+              subset(fit_and_indices.fit_indices, test_indices, cov);
+          const auto pred_cov = symmetric_subset(test_indices, cov);
+          const auto pred = predict_from_covariance_and_fit(
+              cross_cov, pred_cov, fit_and_indices.model_fit);
+          const auto target = subset(test_indices, targets);
+          double metric_value = metric(pred, target);
+          return metric_value;
+        };
+
+    std::function<double(const Indexer &)> model_metric = [&](
+        const Indexer &inliers) {
+      RegressionDataset<FeatureType> inlier_dataset(subset(inliers, features),
+                                                    subset(inliers, targets));
+      const FoldIndexer inlier_loo = leave_one_out_indexer(inlier_dataset);
+
+      BaseModel model;
+      model.set_params(this->get_params());
+      double mean_metric = cross_validated_scores<double>(
+                               metric, inlier_dataset, inlier_loo, &model)
+                               .mean();
+      return mean_metric;
+    };
+
+    // Now that the ransac functions are defined we can actually perform
+    // RANSAC, then return the subsequent outlier free fit.
+    const RegressionDataset<FeatureType> dataset(features, targets);
+    const auto loo_indexer = leave_one_out_indexer(dataset);
+
+    auto inliers = ransac<FitAndIndices>(
+        fitter, outlier_metric, model_metric, map_values(loo_indexer),
+        threshold, min_features, min_inliers, max_iterations);
+
+    const auto inlier_features = subset(inliers, features);
+    const auto inlier_targets = subset(inliers, targets);
+    const auto inlier_cov = symmetric_subset(inliers, cov);
+
+    return fit_from_covariance(inlier_features, inlier_cov, inlier_targets);
+  }
+
+  double threshold;
+  std::size_t min_inliers;
+  std::size_t min_features;
+  std::size_t max_iterations;
+  EvaluationMetric<JointDistribution> metric =
+      albatross::evaluation_metrics::negative_log_likelihood;
+};
+
+template <typename FeatureType, typename CovFunc>
+std::unique_ptr<RansacGaussianProcessRegression<FeatureType, CovFunc>>
+ransac_gp_pointer_from_covariance(CovFunc covariance_function,
+                                  double threshold = 1.,
+                                  std::size_t min_inliers = 3,
+                                  std::size_t min_features = 3,
+                                  std::size_t max_iterations = 20) {
+  return std::make_unique<
+      RansacGaussianProcessRegression<FeatureType, CovFunc>>(
+      covariance_function, threshold, min_inliers, min_features,
+      max_iterations);
+};
+
+} // namespace albatross
+
+#endif

--- a/albatross/outlier.h
+++ b/albatross/outlier.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CORE_OUTLIER_H
+#define ALBATROSS_CORE_OUTLIER_H
+
+#include "core/dataset.h"
+#include "core/indexing.h"
+#include "core/model.h"
+#include "crossvalidation.h"
+#include "random_utils.h"
+#include <functional>
+#include <random>
+#include <set>
+
+namespace albatross {
+
+using Indexer = std::vector<std::size_t>;
+using GroupIndexer = std::vector<std::vector<std::size_t>>;
+
+Indexer concatenate_subset_of_groups(const Indexer &subset_indices,
+                                     const GroupIndexer &indexer) {
+
+  Indexer output;
+  for (const auto i : subset_indices) {
+    assert(i < static_cast<std::size_t>(indexer.size()));
+    output.insert(output.end(), indexer[i].begin(), indexer[i].end());
+  }
+  return output;
+}
+
+/*
+ * This RANdom SAmple Consensus (RANSAC) algorithm works as follows.
+ *
+ *   1) Randomly sample a small number of data points and fit a
+ *      reference model to that data.
+ *   2) Assemble all the data points that agree with the
+ *      reference model into a set of inliers.
+ *   3) Evaluate the quality of the inliers.
+ *   4) Repeat N times keeping track of the best set of inliers.
+ *
+ * One of the large drawbacks of this approach is the computational
+ * load since it requires fitting and predicting repeatedly.
+ * The goal of this implementation is to provide a way
+ * for the user to optionally perform a lot of computation upfront,
+ * then use call backs which take indices as input to selectively
+ * update/downdate the model to produce the fits and evaluation
+ * metrics.
+ */
+template <typename FitType>
+Indexer
+ransac(std::function<FitType(const Indexer &)> &fitter,
+       std::function<double(const Indexer &, const FitType &)> &outlier_metric,
+       std::function<double(const Indexer &)> &model_metric,
+       const GroupIndexer &indexer, double threshold, std::size_t min_features,
+       std::size_t min_inliers, std::size_t max_iterations) {
+
+  std::default_random_engine gen;
+
+  Indexer reference;
+  double best_metric = HUGE_VAL;
+  Indexer best_inds;
+
+  for (std::size_t i = 0; i < max_iterations; i++) {
+    // Sample a random subset of the data and fit a model.
+    reference =
+        randint_without_replacement(min_features, 0, indexer.size() - 1, gen);
+    auto ref_inds = concatenate_subset_of_groups(reference, indexer);
+    const auto fit = fitter(ref_inds);
+
+    // Find which of the other groups agree with the reference model
+    auto test_groups = indices_complement(reference, indexer.size());
+    Indexer inliers;
+    for (const auto &test_ind : test_groups) {
+      double metric_value = outlier_metric(indexer[test_ind], fit);
+      if (metric_value < threshold) {
+        inliers.push_back(test_ind);
+      }
+    }
+
+    // If there is enough agreement, consider this random set of inliers
+    // as a candidate model.
+    if (inliers.size() > min_inliers) {
+      const auto inlier_inds = concatenate_subset_of_groups(inliers, indexer);
+      ref_inds.insert(ref_inds.end(), inlier_inds.begin(), inlier_inds.end());
+      std::sort(ref_inds.begin(), ref_inds.end());
+      double model_metric_value = model_metric(ref_inds);
+      if (model_metric_value < best_metric) {
+        best_inds = ref_inds;
+        best_metric = model_metric_value;
+      }
+    }
+  }
+  assert(best_metric < HUGE_VAL);
+  return best_inds;
+}
+
+template <typename FeatureType, typename PredictType>
+RegressionDataset<FeatureType>
+ransac(const RegressionDataset<FeatureType> &dataset,
+       const FoldIndexer &fold_indexer, RegressionModel<FeatureType> *model,
+       EvaluationMetric<PredictType> &metric, double threshold,
+       std::size_t min_features, std::size_t min_inliers, int max_iterations) {
+
+  using FitType = RegressionModel<FeatureType> *;
+
+  using FitFunc = std::function<FitType(const std::vector<std::size_t> &)>;
+  using OutlierFunc =
+      std::function<double(const std::vector<std::size_t> &, const FitType &)>;
+  using ModelMetricFunc =
+      std::function<double(const std::vector<std::size_t> &)>;
+
+  FitFunc fitter = [&](const std::vector<std::size_t> &inds) {
+    RegressionDataset<FeatureType> dataset_subset(
+        subset(inds, dataset.features), subset(inds, dataset.targets));
+    model->fit(dataset_subset);
+    return model;
+  };
+
+  OutlierFunc outlier_metric = [&](const std::vector<std::size_t> &inds,
+                                   const FitType &fit) {
+    const auto pred = fit->predict(subset(inds, dataset.features));
+    const auto target = subset(inds, dataset.targets);
+    double metric_value = metric(pred, target);
+    return metric_value;
+  };
+
+  ModelMetricFunc model_metric = [&](const std::vector<std::size_t> &inds) {
+    RegressionDataset<FeatureType> inlier_dataset(
+        subset(inds, dataset.features), subset(inds, dataset.targets));
+    const auto inlier_loo = leave_one_out_indexer(inlier_dataset);
+    return cross_validated_scores(metric, inlier_dataset, inlier_loo, model)
+        .mean();
+
+  };
+
+  const auto best_inds = ransac<FitType>(
+      fitter, outlier_metric, model_metric, map_values(fold_indexer), threshold,
+      min_features, min_inliers, max_iterations);
+  RegressionDataset<FeatureType> best_dataset(
+      subset(best_inds, dataset.features), subset(best_inds, dataset.targets));
+  return best_dataset;
+}
+
+} // namespace albatross
+
+#endif

--- a/albatross/random_utils.h
+++ b/albatross/random_utils.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_RANDOM_UTILS_H
+#define ALBATROSS_RANDOM_UTILS_H
+
+#include "core/indexing.h"
+#include <random>
+#include <set>
+
+/*
+ * Samples integers between low and high (inclusive) with replacement.
+ */
+inline std::vector<std::size_t>
+randint_without_replacement(std::size_t n, std::size_t low, std::size_t high,
+                            std::default_random_engine &gen) {
+  assert(n >= 0);
+  assert(n <= (high - low));
+
+  std::uniform_int_distribution<std::size_t> dist(low, high);
+  std::set<int> samples;
+  while (samples.size() < n) {
+    samples.insert(dist(gen));
+  }
+  return std::vector<std::size_t>(samples.begin(), samples.end());
+}
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,8 @@ test_serializable_ldlt.cc
 test_serialize.cc
 test_tune.cc
 test_tuning_metrics.cc
+test_random_utils.cc
+test_outlier.cc
 )
 
 add_dependencies(albatross_unit_tests

--- a/tests/test_evaluate.cc
+++ b/tests/test_evaluate.cc
@@ -80,7 +80,7 @@ std::string group_by_interval(const double &x) {
 }
 
 bool is_monotonic_increasing(const Eigen::VectorXd &x) {
-  for (s32 i = 0; i < static_cast<s32>(x.size()) - 1; i++) {
+  for (Eigen::Index i = 0; i < x.size() - 1; i++) {
     if (x[i + 1] - x[i] <= 0.) {
       return false;
     }

--- a/tests/test_outlier.cc
+++ b/tests/test_outlier.cc
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#include "models/ransac_gp.h"
+#include "outlier.h"
+#include "test_utils.h"
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+TEST(test_outlier, test_ransac) {
+  auto dataset = make_toy_linear_data();
+  const auto model_ptr = toy_gaussian_process();
+
+  EvaluationMetric<JointDistribution> nll =
+      albatross::evaluation_metrics::negative_log_likelihood;
+
+  dataset.targets.mean[3] = 400.;
+  dataset.targets.mean[5] = -300.;
+
+  const auto fold_indexer = leave_one_out_indexer(dataset);
+  const auto modified =
+      ransac(dataset, fold_indexer, model_ptr.get(), nll, 1., 3, 3, 20);
+
+  EXPECT_EQ(modified.features.size(), dataset.features.size() - 2);
+
+  // Make sure we threw out the correct features.
+  EXPECT_EQ(std::find(modified.features.begin(), modified.features.end(),
+                      dataset.features[3]),
+            modified.features.end());
+  EXPECT_EQ(std::find(modified.features.begin(), modified.features.end(),
+                      dataset.features[5]),
+            modified.features.end());
+}
+
+static inline std::unique_ptr<RegressionModel<double>>
+toy_ransac_gaussian_process() {
+  return ransac_gp_pointer_from_covariance<double>(toy_covariance_function());
+}
+
+TEST(test_outlier, test_ransac_gp) {
+  auto dataset = make_toy_linear_data();
+
+  const auto fold_indexer = leave_one_out_indexer(dataset);
+
+  const auto model_ptr = toy_ransac_gaussian_process();
+
+  EvaluationMetric<JointDistribution> nll =
+      albatross::evaluation_metrics::negative_log_likelihood;
+
+  dataset.targets.mean[3] = 400.;
+  dataset.targets.mean[5] = -300.;
+
+  const auto scores =
+      cross_validated_scores(nll, dataset, fold_indexer, model_ptr.get());
+
+  // Here we make sure the leave one out likelihoods for inliers are all
+  // reasonable, and for the known outliers we assert the likelihood is
+  // really really really small.
+  for (Eigen::Index i = 0; i < scores.size(); i++) {
+    if (i == 3 || i == 5) {
+      EXPECT_GE(scores[i], 1.e5);
+    } else {
+      EXPECT_LE(scores[i], 0.);
+    }
+  }
+}
+
+} // namespace albatross

--- a/tests/test_random_utils.cc
+++ b/tests/test_random_utils.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#include "assert.h"
+#include "random_utils.h"
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+TEST(test_random_utils, randint_without_replacement) {
+
+  int iterations = 10;
+  int k = 6;
+
+  std::default_random_engine gen;
+
+  for (int i = 0; i < iterations; i++) {
+    for (int n = 0; n <= k; n++) {
+      const auto inds = randint_without_replacement(n, i, i + k, gen);
+      for (const auto &j : inds) {
+        EXPECT_LE(j, i + k);
+        EXPECT_GE(j, i);
+      }
+    }
+  }
+}
+
+} // namespace albatross

--- a/tests/test_scaling_function.cc
+++ b/tests/test_scaling_function.cc
@@ -74,11 +74,11 @@ auto make_attenuation_data(const double attenuation = 3.14159,
   gen.seed(3);
   std::normal_distribution<> d{0., sigma_noise};
 
-  s32 n = 10;
+  std::size_t n = 10;
   std::vector<double> features;
   Eigen::VectorXd targets(n);
 
-  for (s32 i = 0; i < n; i++) {
+  for (std::size_t i = 0; i < n; i++) {
     // x ranges from 0 to 2
     double x = static_cast<double>(i) * (2. / static_cast<double>(n));
     features.push_back(x);

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -149,7 +149,7 @@ expect_parameter_vector_equal(const std::vector<ParameterValue> &x,
 static inline auto make_toy_linear_data(const double a = 5.,
                                         const double b = 1.,
                                         const double sigma = 0.1,
-                                        const s32 n = 10) {
+                                        const std::size_t n = 10) {
   std::random_device rd{};
   std::mt19937 gen{rd()};
   gen.seed(3);
@@ -157,7 +157,7 @@ static inline auto make_toy_linear_data(const double a = 5.,
   std::vector<double> features;
   Eigen::VectorXd targets(n);
 
-  for (s32 i = 0; i < n; i++) {
+  for (std::size_t i = 0; i < n; i++) {
     double x = static_cast<double>(i);
     features.push_back(x);
     targets[i] = a + x * b + d(gen);
@@ -259,7 +259,7 @@ public:
   RegressionDataset<double> dataset_;
 };
 
-inline auto random_spherical_points(s32 n = 10, double radius = 1.,
+inline auto random_spherical_points(std::size_t n = 10, double radius = 1.,
                                     int seed = 5) {
   std::random_device rd{};
   std::mt19937 gen{rd()};
@@ -270,7 +270,7 @@ inline auto random_spherical_points(s32 n = 10, double radius = 1.,
 
   std::vector<Eigen::VectorXd> points;
 
-  for (s32 i = 0; i < n; i++) {
+  for (std::size_t i = 0; i < n; i++) {
     const double lon = rand_lon(gen);
     const double lat = rand_lat(gen);
     Eigen::VectorXd x(3);


### PR DESCRIPTION
Adds a method `ransac` which performs [random sample consensus](https://en.wikipedia.org/wiki/Random_sample_consensus) outlier detection.

The core implementation takes functions which provide a way of fitting a model, identifying inliers and evaluating a consensus set.  These functions are then used to run though the process of creating a model using a small random subset of data, finding any other data points that agree with that model and repeating keeping track of the set of "inliers" that perform best.