### PR TITLE
Add additional tests of ransac with groups.

### DIFF
--- a/albatross/evaluate.h
+++ b/albatross/evaluate.h
@@ -56,7 +56,7 @@ negative_log_likelihood(const Eigen::VectorXd &deviation,
   const double rank = static_cast<double>(diag.size());
   const double mahalanobis = deviation.dot(ldlt.solve(deviation));
   const double log_det = log_sum(diag);
-  return -0.5 * (log_det + mahalanobis + rank * log(2 * M_PI));
+  return 0.5 * (log_det + mahalanobis + rank * log(2 * M_PI));
 }
 
 /*

--- a/albatross/models/ransac.h
+++ b/albatross/models/ransac.h
@@ -101,10 +101,9 @@ ransac(const typename RansacFunctions<FitType>::Fitter &fitter,
         inliers.push_back(test_ind);
       }
     }
-
     // If there is enough agreement, consider this random set of inliers
     // as a candidate model.
-    if (inliers.size() > min_inliers) {
+    if (inliers.size() + random_sample_size >= min_inliers) {
       const auto inlier_inds = concatenate_subset_of_groups(inliers, indexer);
       ref_inds.insert(ref_inds.end(), inlier_inds.begin(), inlier_inds.end());
       std::sort(ref_inds.begin(), ref_inds.end());

--- a/tests/test_evaluate.cc
+++ b/tests/test_evaluate.cc
@@ -44,10 +44,17 @@ TEST(test_evaluate, test_negative_log_likelihood) {
   cov << 1., 0.9, 0.8, 0.9, 1., 0.9, 0.8, 0.9, 1.;
 
   const auto nll = albatross::negative_log_likelihood(x, cov);
-  EXPECT_NEAR(nll, -6.0946974293510134, 1e-6);
+  EXPECT_NEAR(nll, 6.0946974293510134, 1e-6);
 
   const auto ldlt_nll = albatross::negative_log_likelihood(x, cov.ldlt());
   EXPECT_NEAR(nll, ldlt_nll, 1e-6);
+
+  const DiagonalMatrixXd diagonal_matrix = cov.diagonal().asDiagonal();
+  const Eigen::MatrixXd dense_diagonal = diagonal_matrix.toDenseMatrix();
+  const auto diag_nll = albatross::negative_log_likelihood(x, diagonal_matrix);
+  const auto dense_diag_nll =
+      albatross::negative_log_likelihood(x, dense_diagonal);
+  EXPECT_NEAR(diag_nll, dense_diag_nll, 1e-6);
 }
 
 TEST_F(LinearRegressionTest, test_leave_one_out) {
@@ -65,27 +72,6 @@ TEST_F(LinearRegressionTest, test_leave_one_out) {
   // than the in sample version.  This should always be true as the in sample
   // version has already seen the values we're trying to predict.
   EXPECT_LT(in_sample_rmse, out_of_sample_rmse);
-}
-
-// Group values by interval, but return keys that once sorted won't be
-// in order
-std::string group_by_interval(const double &x) {
-  if (x <= 3) {
-    return "2";
-  } else if (x <= 6) {
-    return "3";
-  } else {
-    return "1";
-  }
-}
-
-bool is_monotonic_increasing(const Eigen::VectorXd &x) {
-  for (Eigen::Index i = 0; i < x.size() - 1; i++) {
-    if (x[i + 1] - x[i] <= 0.) {
-      return false;
-    }
-  }
-  return true;
 }
 
 TEST_F(LinearRegressionTest, test_cross_validated_predict) {

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -282,6 +282,27 @@ inline auto random_spherical_points(std::size_t n = 10, double radius = 1.,
   return points;
 }
 
+// Group values by interval, but return keys that once sorted won't be
+// in order
+inline std::string group_by_interval(const double &x) {
+  if (x <= 3) {
+    return "2";
+  } else if (x <= 6) {
+    return "3";
+  } else {
+    return "1";
+  }
+}
+
+inline bool is_monotonic_increasing(const Eigen::VectorXd &x) {
+  for (Eigen::Index i = 0; i < x.size() - 1; i++) {
+    if (x[i + 1] - x[i] <= 0.) {
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace albatross
 
 #endif


### PR DESCRIPTION
RANSAC wasn't working with groups, mostly because the negative log likelihood computation was wrong for joint distributions!

- Adds further tests of the negative log likelihood functions.
- Adds test for group indexed RANSAC
- Moves a few helper functions around.