### PR TITLE
Add Metadata to Models

### DIFF
--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -35,6 +35,8 @@ template <typename T> struct PredictTypeIdentity { typedef T type; };
 // predict variants for which you only want the mean.
 using PredictMeanOnly = Eigen::VectorXd;
 
+using Insights = std::map<std::string, std::string>;
+
 /*
  * A model that uses a single Feature to estimate the value of a double typed
  * target.
@@ -68,7 +70,7 @@ public:
     assert(features.size() > 0);
     assert(features.size() == static_cast<std::size_t>(targets.size()));
     has_been_fit_ = true;
-    metadata_["input_feature_count"] = std::to_string(features.size());
+    insights_["input_feature_count"] = std::to_string(features.size());
     fit_(features, targets);
   }
 
@@ -138,7 +140,7 @@ public:
 
   virtual std::string get_name() const = 0;
 
-  std::map<std::string, std::string> get_metadata() const { return metadata_; }
+  Insights get_insights() const { return insights_; }
 
   virtual std::unique_ptr<RegressionModel<FeatureType>>
   ransac_model(double inlier_threshold, std::size_t min_inliers,
@@ -259,7 +261,7 @@ protected:
   }
 
   bool has_been_fit_;
-  std::map<std::string, std::string> metadata_;
+  Insights insights_;
 };
 
 template <typename FeatureType>

--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -67,8 +67,9 @@ public:
            const MarginalDistribution &targets) {
     assert(features.size() > 0);
     assert(features.size() == static_cast<std::size_t>(targets.size()));
-    fit_(features, targets);
     has_been_fit_ = true;
+    metadata_["input_feature_count"] = std::to_string(features.size());
+    fit_(features, targets);
   }
 
   /*
@@ -76,14 +77,14 @@ public:
    */
   void fit(const std::vector<FeatureType> &features,
            const Eigen::VectorXd &targets) {
-    fit(features, MarginalDistribution(targets));
+    return fit(features, MarginalDistribution(targets));
   }
 
   /*
    * Convenience function which unpacks a dataset into features and targets.
    */
   void fit(const RegressionDataset<FeatureType> &dataset) {
-    fit(dataset.features, dataset.targets);
+    return fit(dataset.features, dataset.targets);
   }
 
   /*
@@ -136,6 +137,8 @@ public:
   virtual bool has_been_fit() const { return has_been_fit_; }
 
   virtual std::string get_name() const = 0;
+
+  std::map<std::string, std::string> get_metadata() const { return metadata_; }
 
   virtual std::unique_ptr<RegressionModel<FeatureType>>
   ransac_model(double inlier_threshold, std::size_t min_inliers,
@@ -256,6 +259,7 @@ protected:
   }
 
   bool has_been_fit_;
+  std::map<std::string, std::string> metadata_;
 };
 
 template <typename FeatureType>

--- a/albatross/models/ransac.h
+++ b/albatross/models/ransac.h
@@ -229,7 +229,7 @@ protected:
     RegressionDataset<FeatureType> inliers =
         ransac(dataset, fold_indexer, sub_model_, metric_, inlier_threshold_,
                random_sample_size_, min_inliers_, max_iterations_);
-    this->metadata_["post_ransac_feature_count"] =
+    this->insights_["post_ransac_feature_count"] =
         std::to_string(inliers.features.size());
     this->sub_model_->fit(inliers);
   }

--- a/albatross/models/ransac.h
+++ b/albatross/models/ransac.h
@@ -229,6 +229,8 @@ protected:
     RegressionDataset<FeatureType> inliers =
         ransac(dataset, fold_indexer, sub_model_, metric_, inlier_threshold_,
                random_sample_size_, min_inliers_, max_iterations_);
+    this->metadata_["post_ransac_feature_count"] =
+        std::to_string(inliers.features.size());
     this->sub_model_->fit(inliers);
   }
 

--- a/albatross/models/ransac_gp.h
+++ b/albatross/models/ransac_gp.h
@@ -160,6 +160,8 @@ protected:
 
     const GaussianProcessFit<FeatureType> fit(inlier_features, inlier_cov,
                                               inlier_targets);
+    this->metadata_["post_ransac_feature_count"] =
+        std::to_string(inliers.size());
     this->sub_model_->set_fit(fit);
   }
 

--- a/albatross/models/ransac_gp.h
+++ b/albatross/models/ransac_gp.h
@@ -160,7 +160,7 @@ protected:
 
     const GaussianProcessFit<FeatureType> fit(inlier_features, inlier_cov,
                                               inlier_targets);
-    this->metadata_["post_ransac_feature_count"] =
+    this->insights_["post_ransac_feature_count"] =
         std::to_string(inliers.size());
     this->sub_model_->set_fit(fit);
   }


### PR DESCRIPTION
Add `metadata_` to all RegressionModels which provides a way of returning arbitrary informative information about how a model was fit to the user.