### PR TITLE
Tests for traits.

### DIFF
--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -141,7 +141,7 @@ public:
   ransac_model(double inlier_threshold, std::size_t min_inliers,
                std::size_t random_sample_size, std::size_t max_iterations) {
     static_assert(
-        is_complete<GenericRansac<void, FeatureType>>(0),
+        is_complete<GenericRansac<void, FeatureType>>::value,
         "ransac methods aren't complete yet, be sure you've included ransac.h");
     return make_generic_ransac_model<FeatureType>(
         this, inlier_threshold, min_inliers, random_sample_size, max_iterations,

--- a/albatross/core/traits.h
+++ b/albatross/core/traits.h
@@ -151,14 +151,18 @@ public:
 };
 
 /*
+ * Checks if a class type is complete by using sizeof.
+ *
  * https://stackoverflow.com/questions/25796126/static-assert-that-template-typename-t-is-not-complete
  */
-template <typename T>
-constexpr auto is_complete(int = 0) -> decltype(!sizeof(T)) {
-  return true;
-}
+template <typename X> class is_complete {
+  template <typename T, typename = decltype(!sizeof(T))>
+  static std::true_type test(int);
+  template <typename T> static std::false_type test(...);
 
-template <typename T> constexpr bool is_complete(...) { return false; }
+public:
+  static constexpr bool value = decltype(test<X>(0))::value;
+};
 
 } // namespace albatross
 

--- a/albatross/models/gp.h
+++ b/albatross/models/gp.h
@@ -186,7 +186,8 @@ public:
                std::size_t random_sample_size,
                std::size_t max_iterations) override {
     static_assert(
-        is_complete<GaussianProcessRansac<FeatureType, CovarianceFunction>>(0),
+        is_complete<
+            GaussianProcessRansac<FeatureType, CovarianceFunction>>::value,
         "ransac methods aren't complete yet, be sure you've included "
         "ransac_gp.h");
     return make_gp_ransac_model<FeatureType, CovarianceFunction>(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ test_radial.cc
 test_scaling_function.cc
 test_serializable_ldlt.cc
 test_serialize.cc
+test_traits.cc
 test_tune.cc
 test_tuning_metrics.cc
 test_random_utils.cc

--- a/tests/test_traits.cc
+++ b/tests/test_traits.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "core/traits.h"
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+struct X {};
+struct Y {};
+
+class HasPublicCallOperator {
+public:
+  double operator()(const X &x, const Y &y) const { return 1.; };
+};
+
+class HasProtectedCallOperator {
+protected:
+  double operator()(const X &x, const Y &y) const { return 1.; };
+};
+
+class HasPrivateCallOperator {
+  double operator()(const X &x, const Y &y) const { return 1.; };
+};
+
+class HasNoCallOperator {};
+
+TEST(test_traits, test_has_call_operator) {
+  EXPECT_TRUE(bool(has_call_operator<HasPublicCallOperator, X, Y>::value));
+  EXPECT_FALSE(bool(has_call_operator<HasPrivateCallOperator, X, Y>::value));
+  EXPECT_FALSE(bool(has_call_operator<HasProtectedCallOperator, X, Y>::value));
+  EXPECT_FALSE(bool(has_call_operator<HasNoCallOperator, X, Y>::value));
+}
+
+class ValidInOutSerializer {
+public:
+  template <typename Archive> void serialize(Archive &archive){};
+};
+
+class ValidSaveLoadSerializer {
+public:
+  template <typename Archive> void save(Archive &archive) const {};
+
+  template <typename Archive> void load(Archive &archive){};
+};
+
+class ValidInSerializer {
+public:
+  template <typename Archive> void load(Archive &archive){};
+};
+
+class ValidOutSerializer {
+public:
+  template <typename Archive> void save(Archive &archive) const {};
+};
+
+class InValidInOutSerializer {};
+
+TEST(test_traits, test_valid_in_out_serializer) {
+  EXPECT_TRUE(bool(valid_in_out_serializer<ValidInOutSerializer, X>::value));
+  EXPECT_TRUE(bool(valid_in_out_serializer<ValidSaveLoadSerializer, X>::value));
+  EXPECT_FALSE(bool(valid_in_out_serializer<ValidInSerializer, X>::value));
+  EXPECT_FALSE(bool(valid_in_out_serializer<ValidOutSerializer, X>::value));
+  EXPECT_FALSE(bool(valid_in_out_serializer<InValidInOutSerializer, X>::value));
+}
+
+TEST(test_traits, test_valid_input_serializer) {
+  EXPECT_TRUE(bool(valid_input_serializer<ValidInOutSerializer, X>::value));
+  EXPECT_TRUE(bool(valid_input_serializer<ValidSaveLoadSerializer, X>::value));
+  EXPECT_TRUE(bool(valid_input_serializer<ValidInSerializer, X>::value));
+  EXPECT_FALSE(bool(valid_input_serializer<ValidOutSerializer, X>::value));
+  EXPECT_FALSE(bool(valid_input_serializer<InValidInOutSerializer, X>::value));
+}
+
+TEST(test_traits, test_valid_output_serializer) {
+  EXPECT_TRUE(bool(valid_output_serializer<ValidInOutSerializer, X>::value));
+  EXPECT_TRUE(bool(valid_output_serializer<ValidSaveLoadSerializer, X>::value));
+  EXPECT_FALSE(bool(valid_output_serializer<ValidInSerializer, X>::value));
+  EXPECT_TRUE(bool(valid_output_serializer<ValidOutSerializer, X>::value));
+  EXPECT_FALSE(bool(valid_output_serializer<InValidInOutSerializer, X>::value));
+}
+
+class Complete {};
+
+class Incomplete;
+
+TEST(test_traits, test_is_complete) {
+  EXPECT_TRUE(bool(is_complete<Complete>::value));
+  EXPECT_FALSE(bool(is_complete<Incomplete>::value));
+}
+
+} // namespace albatross


### PR DESCRIPTION
Added some tests for traits and reorganized a few so they (more) consistently take the form
```
template <typename X>
struct some_trait {
 private:
    template <typename Y, ...logic which breaks when not true ...>
    std::true_type test(int)
    template <typename Y>
     std::false_type test(...)
 public:
    static constexpr bool value = decltype(test<X>(0))::value;
}
```
which lets them be used with a syntax that looks like,
```
some_trait<X>::value
```