### PR TITLE
Update Subset and Serialization Utilities

### DIFF
--- a/albatross/core/indexing.h
+++ b/albatross/core/indexing.h
@@ -61,6 +61,18 @@ inline Eigen::VectorXd subset(const std::vector<SizeType> &indices,
 }
 
 /*
+ * Convenience method which subsets the features and targets of a dataset.
+ */
+template <typename SizeType, typename FeatureType>
+inline RegressionDataset<FeatureType>
+subset(const std::vector<SizeType> &indices,
+       const RegressionDataset<FeatureType> &dataset) {
+  return RegressionDataset<FeatureType>(subset(indices, dataset.features),
+                                        subset(indices, dataset.targets),
+                                        dataset.metadata);
+}
+
+/*
  * Extracts a subset of columns from an Eigen::Matrix
  */
 template <typename SizeType>

--- a/albatross/core/serialize.h
+++ b/albatross/core/serialize.h
@@ -51,6 +51,7 @@ public:
         "model_definition",
         cereal::base_class<RegressionModel<FeatureType>>(this)));
     archive(cereal::make_nvp("model_fit", this->model_fit_));
+    archive(cereal::make_nvp("insights", this->insights_));
   }
 
   template <class Archive>
@@ -61,6 +62,7 @@ public:
         "model_definition",
         cereal::base_class<RegressionModel<FeatureType>>(this)));
     archive(cereal::make_nvp("model_fit", this->model_fit_));
+    archive(cereal::make_nvp("insights", this->insights_));
   }
 
   /*

--- a/albatross/csv_utils.h
+++ b/albatross/csv_utils.h
@@ -223,6 +223,18 @@ inline void write_to_csv(std::ostream &stream,
   write_to_csv(stream, dataset, predictions, columns);
 }
 
+/*
+ * Make it easier to write only a dataset (without predictions).
+ */
+template <typename FeatureType>
+inline void write_to_csv(std::ostream &stream,
+                         const RegressionDataset<FeatureType> &dataset,
+                         bool include_header = true) {
+  Eigen::VectorXd zeros = Eigen::VectorXd::Zero(dataset.targets.mean.size());
+  MarginalDistribution zero_predictions(zeros);
+  write_to_csv(stream, dataset, zero_predictions, include_header);
+}
+
 template <typename FeatureType, typename CovarianceType>
 inline void
 write_to_csv(std::ostream &stream,

--- a/albatross/csv_utils.h
+++ b/albatross/csv_utils.h
@@ -247,6 +247,22 @@ write_to_csv(std::ostream &stream,
     write_to_csv(stream, datasets[i], predictions[i], columns);
   }
 }
+
+template <typename _Scalar, int _Rows, int _Cols>
+inline void write_to_csv(std::ostream &stream,
+                         const Eigen::Matrix<_Scalar, _Rows, _Cols> &x) {
+  for (Eigen::Index i = 0; i < x.rows(); ++i) {
+    for (Eigen::Index j = 0; j < x.cols(); ++j) {
+      stream << x(i, j);
+      if (j < x.cols() - 1) {
+        stream << ",";
+      }
+    }
+    if (i < x.rows() - 1) {
+      stream << std::endl;
+    }
+  }
+}
 }
 
 #endif

--- a/albatross/random_utils.h
+++ b/albatross/random_utils.h
@@ -27,7 +27,11 @@ randint_without_replacement(std::size_t n, std::size_t low, std::size_t high,
   assert(n >= 0);
 
   std::size_t n_choices = high - low + 1;
-  assert(n <= n_choices);
+  if (n > n_choices) {
+    std::cout << "ERROR: n (" << n << ") is larger than n_choices ("
+              << n_choices << ")" << std::endl;
+    assert(false);
+  }
 
   if (n == (high - low + 1)) {
     std::vector<std::size_t> all_inds(n);

--- a/tests/test_csv_utils.cc
+++ b/tests/test_csv_utils.cc
@@ -82,6 +82,25 @@ TEST(test_csv_utils, test_writes) {
   read_test_csv(iss);
 }
 
+TEST(test_csv_utils, test_writes_without_predictions) {
+  TestFeature one = {1.2, 2, {1.3, 3}};
+  TestFeature two = {2.2, 3, {2.3, 4}};
+  TestFeature three = {3.2, 4, {3.3, 5}};
+
+  std::vector<TestFeature> features = {one, two, three};
+  Eigen::VectorXd targets(3);
+  targets << 1., 2., 3.;
+
+  RegressionDataset<TestFeature> dataset(features, targets);
+
+  std::ostringstream oss;
+  write_to_csv(oss, dataset);
+
+  std::istringstream iss(oss.str());
+
+  read_test_csv(iss);
+}
+
 /*
  * This does nothing more than read the CSV, but would fail if
  * the CSV were missing columns or had unparsable data.

--- a/tests/test_csv_utils.cc
+++ b/tests/test_csv_utils.cc
@@ -215,4 +215,14 @@ TEST(test_csv_utils, test_custom_writes) {
   read_test_csv_with_custom_to_map(iss);
 }
 
+TEST(test_csv_utils, test_writes_eigen) {
+
+  Eigen::MatrixXd x = Eigen::MatrixXd::Random(3, 4);
+
+  std::ostringstream oss;
+  write_to_csv(oss, x);
+
+  EXPECT_GT(oss.str().size(), 0);
+}
+
 } // namespace albatross

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -235,7 +235,8 @@ public:
 
   bool are_equal(const RepresentationType &lhs,
                  const RepresentationType &rhs) const override {
-    return *lhs == *rhs && lhs->get_fit() == rhs->get_fit();
+    return (*lhs == *rhs && lhs->get_fit() == rhs->get_fit() &&
+            lhs->get_insights() == rhs->get_insights());
   };
 };
 


### PR DESCRIPTION
This contains a handful of small changes which:

- Allow you do call `subset(dataset)` directly instead of needing to manually do it for features and targets.
- Write a dataset to csv without any predictions.
- Write an eigen matrix to csv (this makes it easy to load into python).
- Serialize any insights along with a model.
- Improve error messaging around an assert in random utils.

Then it also contains some unit tests for those changes that are testable.