### PR TITLE
Adapated Ransac Bug

### DIFF
--- a/albatross/core/functional_model.h
+++ b/albatross/core/functional_model.h
@@ -68,7 +68,7 @@ protected:
   FitType model_fit_;
   const typename GenericModelFunctions<FeatureType, FitType>::Fitter fitter_;
   const typename GenericModelFunctions<FeatureType, FitType>::Predictor
-      &predictor_;
+      predictor_;
   std::string model_name_;
 };
 

--- a/albatross/core/model_adapter.h
+++ b/albatross/core/model_adapter.h
@@ -141,7 +141,7 @@ public:
     GenericModelFunctions<FeatureType, FitType> funcs;
 
     decltype(funcs.fitter) fitter =
-        [&](const std::vector<FeatureType> &features,
+        [=](const std::vector<FeatureType> &features,
             const MarginalDistribution &targets) {
           std::unique_ptr<RegressionModel<SubFeature>> sub_ransac =
               sub_model_.ransac_model(inlier_threshold, min_inliers,

--- a/albatross/core/model_adapter.h
+++ b/albatross/core/model_adapter.h
@@ -141,11 +141,12 @@ public:
     GenericModelFunctions<FeatureType, FitType> funcs;
 
     decltype(funcs.fitter) fitter =
-        [=](const std::vector<FeatureType> &features,
-            const MarginalDistribution &targets) {
+        [this, inlier_threshold, min_inliers, random_sample_size,
+         max_iterations](const std::vector<FeatureType> &features,
+                         const MarginalDistribution &targets) {
           std::unique_ptr<RegressionModel<SubFeature>> sub_ransac =
-              sub_model_.ransac_model(inlier_threshold, min_inliers,
-                                      random_sample_size, max_iterations);
+              this->sub_model_.ransac_model(inlier_threshold, min_inliers,
+                                            random_sample_size, max_iterations);
           sub_ransac->fit(convert_features(features), targets);
           return std::move(sub_ransac);
         };

--- a/tests/test_model_adapter.cc
+++ b/tests/test_model_adapter.cc
@@ -53,10 +53,8 @@ public:
                              cereal::base_class<TestAdaptedModelBase>(this)));
   }
 };
-} // namespace albatross
 
-void test_get_set(albatross::RegressionModel<double> &model,
-                  const std::string &key) {
+void test_get_set(RegressionModel<double> &model, const std::string &key) {
   // Make sure a key exists, then modify it and make sure it
   // takes on the new value.
   const auto orig = model.get_param_value(key);
@@ -67,8 +65,8 @@ void test_get_set(albatross::RegressionModel<double> &model,
 TEST(test_model_adapter, test_get_set_params) {
   // An adapted model should contain both higher level parameters,
   // and the sub model parameters.
-  auto model = albatross::TestAdaptedModel();
-  auto sqr_exp_params = albatross::SqrExp().get_params();
+  auto model = TestAdaptedModel();
+  auto sqr_exp_params = SqrExp().get_params();
   auto params = model.get_params();
   // Make sure all the sub model params are in the adapted params
   for (const auto &pair : sqr_exp_params) {
@@ -77,3 +75,65 @@ TEST(test_model_adapter, test_get_set_params) {
   // And the higher level parameter.
   test_get_set(model, "center");
 };
+
+TEST(test_model_adapter, test_fit) {
+  auto adpated_dataset = make_adapted_toy_linear_data();
+  auto adapted_model = adapted_toy_gaussian_process();
+  adapted_model->fit(adpated_dataset);
+  const auto adapted_pred = adapted_model->predict(adpated_dataset.features);
+
+  auto dataset = make_toy_linear_data();
+  auto model = toy_gaussian_process();
+  model->fit(dataset);
+  const auto pred = model->predict(dataset.features);
+
+  EXPECT_EQ(adapted_pred, pred);
+}
+
+TEST(test_model_adapter, test_ransac_fit) {
+  auto dataset = make_adapted_toy_linear_data();
+  auto adapted_model = adapted_toy_gaussian_process();
+  adapted_model->fit(dataset);
+  const auto adapted_pred = adapted_model->predict(dataset.features);
+
+  const auto fold_indexer = leave_one_out_indexer(dataset);
+
+  double inlier_threshold = 1.;
+  std::size_t min_inliers = 2;
+  std::size_t min_features = 3;
+  std::size_t max_iterations = 20;
+
+  auto ransac_model = adapted_model->ransac_model(inlier_threshold, min_inliers,
+                                                  min_features, max_iterations);
+
+  EvaluationMetric<JointDistribution> nll =
+      evaluation_metrics::negative_log_likelihood;
+
+  dataset.targets.mean[3] = 400.;
+  dataset.targets.mean[5] = -300.;
+
+  ransac_model->fit(dataset);
+
+  const auto scores =
+      cross_validated_scores(nll, dataset, fold_indexer, ransac_model.get());
+
+  // Here we use the original model_ptr and make sure it also was fit after
+  // we called `model_ptr->ransac_model.fit()`
+  const auto in_sample_preds =
+      adapted_model->template predict<Eigen::VectorXd>(dataset.features);
+
+  // Here we make sure the leave one out likelihoods for inliers are all
+  // reasonable, and for the known outliers we assert the likelihood is
+  // really really really small.
+  for (Eigen::Index i = 0; i < scores.size(); i++) {
+    double in_sample_error = fabs(in_sample_preds[i] - dataset.targets.mean[i]);
+    if (i == 3 || i == 5) {
+      EXPECT_GE(scores[i], 1.e5);
+      EXPECT_GE(in_sample_error, 100.);
+    } else {
+      EXPECT_LE(scores[i], 0.);
+      EXPECT_LE(in_sample_error, 0.1);
+    }
+  }
+}
+}


### PR DESCRIPTION
Using ransac with the adapted model had an awful bug in which some of the input parameters were passed by reference but could then lose scope.

This is basically a two character change (ie switching a lambda function to a copy capture and removing a reference operator in a member declaration).  The rest are just tests which don't pass without those changes.