### PR TITLE
CallTrace for debugging.

### DIFF
--- a/albatross/covariance_functions/call_trace.h
+++ b/albatross/covariance_functions/call_trace.h
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_COVARIANCE_FUNCTIONS_CALL_TRACE_H
+#define ALBATROSS_COVARIANCE_FUNCTIONS_CALL_TRACE_H
+
+namespace albatross {
+
+#define LEVEL_DELIMITER " |  "
+
+struct CallAndValue {
+  std::string call_name;
+  std::string value;
+
+  void add_operator(const char c) {
+    assert(call_name.size() >= 3);
+    assert(value.size() >= 3);
+    call_name[2] = c;
+    value[2] = c;
+  }
+
+  void add_delimiter() {
+    call_name = LEVEL_DELIMITER + call_name;
+    value = LEVEL_DELIMITER + value;
+  };
+};
+
+/*
+ * Takes two call traces and appends one to the other after
+ * having applied a level offset delimiter.
+ */
+inline void append_child_call_trace(std::vector<CallAndValue> &parent,
+                                    std::vector<CallAndValue> &child,
+                                    const char &operator_character) {
+
+  auto add_delimeter = [](CallAndValue &cv) { cv.add_delimiter(); };
+  // Add an inset delimiter to each child.
+  std::for_each(child.begin(), child.end(), add_delimeter);
+  child.front().add_operator(operator_character);
+  parent.insert(parent.end(), child.begin(), child.end());
+}
+
+inline void print_call_trace(const std::vector<CallAndValue> &call_trace) {
+  std::size_t max_value_length = 0;
+
+  for (const auto &cv : call_trace) {
+    if (cv.value.size() > max_value_length) {
+      max_value_length = cv.value.size();
+    }
+  }
+
+  std::cout << std::setw(max_value_length + 2) << std::left << "VALUE"
+            << std::setw(100) << "FUNCTION" << std::endl;
+  std::cout << std::setw(max_value_length + 2) << std::left << "-----"
+            << std::setw(100) << "--------" << std::endl;
+  for (const auto &cv : call_trace) {
+    std::cout << std::setw(max_value_length + 2) << std::left << cv.value
+              << std::setw(100) << cv.call_name << std::endl;
+  }
+}
+
+template <typename Derived> class CallTraceBase {
+public:
+  template <typename X, typename Y> void print(const X &x, const Y &y) {
+    print_call_trace(derived().get_trace(x, y));
+  }
+
+protected:
+  Derived &derived() { return *static_cast<Derived *>(this); }
+
+  const Derived &derived() const { return *static_cast<const Derived *>(this); }
+};
+
+/*
+ * These methods can be useful when debugging a covariance function.
+ *
+ * The static composition (ie, products and sums) of CovarianceFunction
+ * types can lead to a series of operations that are difficult to follow.
+ *
+ * By doing something along the lines of:
+ *
+ *     SomeCovFunc cov_func;
+ *     FeatureX x;
+ *     FeatureY y;
+ *     cov_func.call_trace().print(x, y);
+ *
+ * You'll see a trace of all the calls that go into the final computation
+ * of cov_func(x, y).
+ */
+
+template <typename CovFunc>
+class CallTrace : public CallTraceBase<CallTrace<CovFunc>> {
+public:
+  CallTrace(const CovFunc &cov_func) : cov_func_(cov_func){};
+
+  template <typename X, typename Y,
+            typename std::enable_if<
+                has_defined_call_impl<CovFunc, X &, Y &>::value, int>::type = 0>
+  std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
+    return {{cov_func_.get_name(), std::to_string(cov_func_(x, y))}};
+  }
+
+  template <typename X, typename Y,
+            typename std::enable_if<
+                (has_defined_call_impl<CovFunc, Y &, X &>::value &&
+                 !has_defined_call_impl<CovFunc, X &, Y &>::value),
+                int>::type = 0>
+  std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
+    return {{cov_func_.get_name(), std::to_string(cov_func_(x, y))}};
+  }
+
+  template <typename X, typename Y,
+            typename std::enable_if<
+                (!has_defined_call_impl<CovFunc, Y &, X &>::value &&
+                 !has_defined_call_impl<CovFunc, X &, Y &>::value),
+                int>::type = 0>
+  std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
+    return {{cov_func_.get_name(), "UNDEFINED"}};
+  }
+
+  CovFunc cov_func_;
+};
+
+template <typename LHS, typename RHS>
+class CallTrace<SumOfCovarianceFunctions<LHS, RHS>>
+    : public CallTraceBase<CallTrace<SumOfCovarianceFunctions<LHS, RHS>>> {
+public:
+  CallTrace(const SumOfCovarianceFunctions<LHS, RHS> &cov_func)
+      : cov_func_(cov_func){};
+
+  template <typename X, typename Y,
+            typename std::enable_if<
+                has_defined_call_impl<SumOfCovarianceFunctions<LHS, RHS>, X &,
+                                      Y &>::value,
+                int>::type = 0>
+  std::string eval(const X &x, const Y &y) const {
+    std::ostringstream oss;
+    oss << cov_func_(x, y);
+    return oss.str();
+  }
+
+  template <typename X, typename Y,
+            typename std::enable_if<
+                !has_defined_call_impl<SumOfCovarianceFunctions<LHS, RHS>, X &,
+                                       Y &>::value,
+                int>::type = 0>
+  std::string eval(const X &x, const Y &y) const {
+    return "UNDEFINED";
+  }
+
+  template <typename X, typename Y>
+  std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
+    std::vector<CallAndValue> calls;
+    calls.push_back({SumOfCovarianceFunctions<LHS, RHS>().name_, eval(x, y)});
+
+    std::vector<CallAndValue> lhs_calls =
+        CallTrace<LHS>(this->cov_func_.lhs_).get_trace(x, y);
+    append_child_call_trace(calls, lhs_calls, '+');
+
+    std::vector<CallAndValue> rhs_calls =
+        CallTrace<RHS>(this->cov_func_.rhs_).get_trace(x, y);
+    append_child_call_trace(calls, rhs_calls, '+');
+
+    return calls;
+  }
+
+  SumOfCovarianceFunctions<LHS, RHS> cov_func_;
+};
+
+template <typename LHS, typename RHS>
+class CallTrace<ProductOfCovarianceFunctions<LHS, RHS>>
+    : public CallTraceBase<CallTrace<ProductOfCovarianceFunctions<LHS, RHS>>> {
+public:
+  CallTrace(const ProductOfCovarianceFunctions<LHS, RHS> &cov_func)
+      : cov_func_(cov_func){};
+
+  template <typename X, typename Y,
+            typename std::enable_if<
+                has_defined_call_impl<ProductOfCovarianceFunctions<LHS, RHS>,
+                                      X &, Y &>::value,
+                int>::type = 0>
+  std::string eval(const X &x, const Y &y) const {
+    std::ostringstream oss;
+    oss << cov_func_(x, y);
+    return oss.str();
+  }
+
+  template <typename X, typename Y,
+            typename std::enable_if<
+                !has_defined_call_impl<ProductOfCovarianceFunctions<LHS, RHS>,
+                                       X &, Y &>::value,
+                int>::type = 0>
+  std::string eval(const X &x, const Y &y) const {
+    return "UNDEFINED";
+  }
+
+  template <typename X, typename Y>
+  std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
+    std::vector<CallAndValue> calls;
+    calls.push_back(
+        {ProductOfCovarianceFunctions<LHS, RHS>().name_, eval(x, y)});
+
+    std::vector<CallAndValue> lhs_calls =
+        CallTrace<LHS>(this->cov_func_.lhs_).get_trace(x, y);
+    append_child_call_trace(calls, lhs_calls, '*');
+
+    std::vector<CallAndValue> rhs_calls =
+        CallTrace<RHS>(this->cov_func_.rhs_).get_trace(x, y);
+    append_child_call_trace(calls, rhs_calls, '*');
+
+    return calls;
+  }
+
+  ProductOfCovarianceFunctions<LHS, RHS> cov_func_;
+};
+
+// This defines the .call_trace method on CovarianceFunction
+template <typename Derived>
+inline CallTrace<Derived> CovarianceFunction<Derived>::call_trace() const {
+  return CallTrace<Derived>(this->derived());
+};
+}
+#endif

--- a/albatross/covariance_functions/covariance_function.h
+++ b/albatross/covariance_functions/covariance_function.h
@@ -26,6 +26,8 @@ template <typename X, typename Y> class SumOfCovarianceFunctions;
 
 template <typename X, typename Y> class ProductOfCovarianceFunctions;
 
+template <typename Derived> class CallTrace;
+
 /*
  * CovarianceFunction is a CRTP base class which can be used in a
  * way similar to a polymorphic abstract class.  For example if
@@ -213,6 +215,8 @@ public:
                                                  * errors should give you an indication of which types were attempted.
                                                  */
 
+  CallTrace<Derived> call_trace() const;
+
   template <typename Other>
   const SumOfCovarianceFunctions<Derived, Other>
   operator+(const CovarianceFunction<Other> &other) const;
@@ -236,6 +240,7 @@ public:
   SumOfCovarianceFunctions() : lhs_(), rhs_() {
     name_ = "(" + lhs_.name_ + "+" + rhs_.name_ + ")";
   };
+
   SumOfCovarianceFunctions(const LHS &lhs, const RHS &rhs)
       : lhs_(lhs), rhs_(rhs) {
     SumOfCovarianceFunctions();
@@ -292,6 +297,7 @@ public:
 protected:
   LHS lhs_;
   RHS rhs_;
+  friend class CallTrace<SumOfCovarianceFunctions<LHS, RHS>>;
 };
 
 /*
@@ -360,6 +366,7 @@ public:
 protected:
   LHS lhs_;
   RHS rhs_;
+  friend class CallTrace<ProductOfCovarianceFunctions<LHS, RHS>>;
 };
 
 template <typename Derived>

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -72,3 +72,25 @@ add_custom_target(
 add_dependencies(run_temperature_example
     temperature_example
 )
+
+add_executable(call_trace_example
+    EXCLUDE_FROM_ALL
+    call_trace_example.cc
+)
+
+add_dependencies(call_trace_example
+    albatross
+)
+
+target_link_libraries(call_trace_example m gflags pthread)
+
+add_custom_target(
+    run_call_trace_example ALL
+    DEPENDS ${example_HEADERS}
+    COMMAND call_trace_example
+    COMMENT "Running call_trace_example"
+)
+
+add_dependencies(run_call_trace_example
+    call_trace_example
+)

--- a/examples/call_trace_example.cc
+++ b/examples/call_trace_example.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+// clang-format off
+#include "covariance_functions/covariance_functions.h"
+#include "covariance_functions/call_trace.h"
+// clang-format on
+
+namespace albatross {
+
+class LinearScalar : public ScalingFunction {
+public:
+  std::string get_name() const override { return "linear_scalar"; }
+
+  double call_impl_(const double &x) const { return 1. + 3. * x; }
+};
+
+auto complicated_covariance_function() {
+
+  ScalingTerm<LinearScalar> linear_scalar;
+  Constant constant;
+  SquaredExponential<EuclideanDistance> squared_exp;
+
+  return (constant + squared_exp) * linear_scalar;
+}
+}
+
+int main(int argc, char *argv[]) {
+
+  auto cov = albatross::complicated_covariance_function();
+
+  double x = 1.;
+  double y = 0.;
+  cov.call_trace().print(x, y);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_FLAGS "-Wshadow -Wswitch-default -Wswitch-enum -Wundef -Wuninitial
 add_executable(albatross_unit_tests
 EXCLUDE_FROM_ALL
 test_functional_model.cc
+test_call_trace.cc
 test_core_distribution.cc
 test_core_model.cc
 test_csv_utils.cc

--- a/tests/test_call_trace.cc
+++ b/tests/test_call_trace.cc
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+// clang-format off
+#include "covariance_functions/covariance_functions.h"
+#include "covariance_functions/call_trace.h"
+// clang-format on
+#include <gtest/gtest.h>
+#include <iostream>
+
+namespace albatross {
+
+struct X {};
+struct Y {};
+
+class DefinedForX : public CovarianceFunction<DefinedForX> {
+public:
+  double call_impl_(const X &x, const X &y) const { return 1.; }
+  std::string name_ = "defined_for_x";
+};
+
+class DefinedForY : public CovarianceFunction<DefinedForY> {
+public:
+  double call_impl_(const Y &x, const Y &y) const { return 3.; }
+  std::string name_ = "defined_for_y";
+};
+
+class DefinedForXY : public CovarianceFunction<DefinedForXY> {
+public:
+  double call_impl_(const X &x, const X &y) const { return 5.; }
+
+  double call_impl_(const X &x, const Y &y) const { return 7.; }
+
+  double call_impl_(const Y &x, const Y &y) const { return 9.; }
+  std::string name_ = "defined_for_xy";
+};
+
+template <typename T> class CallTraceTest {
+public:
+  virtual int expected_number_of_calls() = 0;
+
+  virtual void check_expected_values(const X &x, const Y &y) = 0;
+
+  T covariance_function;
+};
+
+class SumXandXY : public CallTraceTest<
+                      SumOfCovarianceFunctions<DefinedForX, DefinedForXY>> {
+public:
+  int expected_number_of_calls() override { return 3; }
+
+  void check_expected_values(const X &x, const Y &y) override {
+    EXPECT_DOUBLE_EQ(this->covariance_function(x, x), 6.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(x, y), 7.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(y, x), 7.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(y, y), 9.);
+  }
+};
+
+class SumXandY
+    : public CallTraceTest<SumOfCovarianceFunctions<DefinedForX, DefinedForY>> {
+public:
+  int expected_number_of_calls() override { return 3; }
+
+  void check_expected_values(const X &x, const Y &y) override {
+    EXPECT_DOUBLE_EQ(this->covariance_function(x, x), 1.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(y, y), 3.);
+  }
+};
+
+class SumSumXandYandXY
+    : public CallTraceTest<SumOfCovarianceFunctions<
+          SumOfCovarianceFunctions<DefinedForX, DefinedForY>, DefinedForXY>> {
+public:
+  int expected_number_of_calls() override { return 5; }
+
+  void check_expected_values(const X &x, const Y &y) override {
+    EXPECT_DOUBLE_EQ(this->covariance_function(x, x), 6.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(y, x), 7.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(x, y), 7.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(y, y), 12.);
+  }
+};
+
+class ProdXandXY
+    : public CallTraceTest<
+          ProductOfCovarianceFunctions<DefinedForX, DefinedForXY>> {
+public:
+  int expected_number_of_calls() override { return 3; };
+
+  void check_expected_values(const X &x, const Y &y) override {
+    EXPECT_DOUBLE_EQ(this->covariance_function(x, x), 5.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(y, x), 7.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(x, y), 7.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(y, y), 9.);
+  }
+};
+
+class ProdSumXandXYProdXandXY
+    : public CallTraceTest<ProductOfCovarianceFunctions<
+          SumOfCovarianceFunctions<DefinedForX, DefinedForXY>,
+          ProductOfCovarianceFunctions<DefinedForX, DefinedForXY>>> {
+public:
+  int expected_number_of_calls() override { return 7; };
+
+  void check_expected_values(const X &x, const Y &y) override {
+    EXPECT_DOUBLE_EQ(this->covariance_function(x, x), 30.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(y, x), 49.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(x, y), 49.);
+    EXPECT_DOUBLE_EQ(this->covariance_function(y, y), 81.);
+  }
+};
+
+/*
+ * In the following we test any covariance functions which should support
+ * Eigen::Vector feature vectors.
+ */
+template <typename T>
+class TestCallTreeCovarianceFunctions : public ::testing::Test {
+
+public:
+  T test_case;
+};
+
+typedef ::testing::Types<SumXandXY, SumXandY, SumSumXandYandXY, ProdXandXY,
+                         ProdSumXandXYProdXandXY>
+    TestFunctions;
+
+TYPED_TEST_CASE(TestCallTreeCovarianceFunctions, TestFunctions);
+
+TYPED_TEST(TestCallTreeCovarianceFunctions, prints_call_trace) {
+  X x;
+  Y y;
+
+  this->test_case.check_expected_values(x, y);
+
+  const auto calls_xx =
+      this->test_case.covariance_function.call_trace().get_trace(x, x);
+  EXPECT_EQ(calls_xx.size(), this->test_case.expected_number_of_calls());
+
+  const auto calls_xy =
+      this->test_case.covariance_function.call_trace().get_trace(x, y);
+  EXPECT_EQ(calls_xy.size(), this->test_case.expected_number_of_calls());
+
+  const auto calls_yy =
+      this->test_case.covariance_function.call_trace().get_trace(y, y);
+  EXPECT_EQ(calls_yy.size(), this->test_case.expected_number_of_calls());
+}
+
+} // namespace albatross

--- a/tests/test_call_trace.cc
+++ b/tests/test_call_trace.cc
@@ -59,9 +59,12 @@ public:
   int expected_number_of_calls() override { return 3; }
 
   void check_expected_values(const X &x, const Y &y) override {
+    // (x, x) is defined for both, so 1. + 5.
     EXPECT_DOUBLE_EQ(this->covariance_function(x, x), 6.);
+    // (x, y) and (y, x) are only defined for XY so (undef + 7.) = 7.
     EXPECT_DOUBLE_EQ(this->covariance_function(x, y), 7.);
     EXPECT_DOUBLE_EQ(this->covariance_function(y, x), 7.);
+    // (y, y) is only defined for XY so (undef + 9.) = 9.
     EXPECT_DOUBLE_EQ(this->covariance_function(y, y), 9.);
   }
 };
@@ -72,7 +75,9 @@ public:
   int expected_number_of_calls() override { return 3; }
 
   void check_expected_values(const X &x, const Y &y) override {
+    // (x, x) is only defined for X so (1. + undef) = 1.
     EXPECT_DOUBLE_EQ(this->covariance_function(x, x), 1.);
+    // (y, y) is only defined for Y so (undef + 3.) = 3.
     EXPECT_DOUBLE_EQ(this->covariance_function(y, y), 3.);
   }
 };
@@ -84,9 +89,12 @@ public:
   int expected_number_of_calls() override { return 5; }
 
   void check_expected_values(const X &x, const Y &y) override {
+    // (x, x) breaksdown to ((1. + undef) + 5.) = 6.
     EXPECT_DOUBLE_EQ(this->covariance_function(x, x), 6.);
+    // (y, x) and (x, y) break down to ((undef + undef) + 7.)
     EXPECT_DOUBLE_EQ(this->covariance_function(y, x), 7.);
     EXPECT_DOUBLE_EQ(this->covariance_function(x, y), 7.);
+    // (y, y) breaks down to ((3. + undef) + 9.) = 12.
     EXPECT_DOUBLE_EQ(this->covariance_function(y, y), 12.);
   }
 };
@@ -98,9 +106,12 @@ public:
   int expected_number_of_calls() override { return 3; };
 
   void check_expected_values(const X &x, const Y &y) override {
+    // (x, x) breaks down to (1. * 5.)
     EXPECT_DOUBLE_EQ(this->covariance_function(x, x), 5.);
+    // (x, y) and (y, x) break down to (undef * 7.) = 7.
     EXPECT_DOUBLE_EQ(this->covariance_function(y, x), 7.);
     EXPECT_DOUBLE_EQ(this->covariance_function(x, y), 7.);
+    // (y, y) breaks down to (undef * 9.) = 9.
     EXPECT_DOUBLE_EQ(this->covariance_function(y, y), 9.);
   }
 };
@@ -113,9 +124,12 @@ public:
   int expected_number_of_calls() override { return 7; };
 
   void check_expected_values(const X &x, const Y &y) override {
+    // (x, x) breaks down to ((1. + 5.) * (1. * 5.)) = 30.
     EXPECT_DOUBLE_EQ(this->covariance_function(x, x), 30.);
+    // (x, y) and (y, x) break down to ((undef + 7.) * (undef * 7.)) = 49.
     EXPECT_DOUBLE_EQ(this->covariance_function(y, x), 49.);
     EXPECT_DOUBLE_EQ(this->covariance_function(x, y), 49.);
+    // (y, y) breaks down to ((undef + 9.) * (undef * 9)) = 81
     EXPECT_DOUBLE_EQ(this->covariance_function(y, y), 81.);
   }
 };


### PR DESCRIPTION
Add a `CallTrace` class which allows users to print out debug information about how exactly a particular covariance function will be evaluated for two given types.

Here are some examples (from the tests):

If we define three different covariance functions:
```
class DefinedForX : public CovarianceFunction<DefinedForX> {
public:
  double call_impl_(const X &x, const X &y) const { return 1.; }
  std::string name_ = "defined_for_x";
};

class DefinedForY : public CovarianceFunction<DefinedForY> {
public:
  double call_impl_(const Y &x, const Y &y) const { return 3.; }
  std::string name_ = "defined_for_y";
};

class DefinedForXY : public CovarianceFunction<DefinedForXY> {
public:
  double call_impl_(const X &x, const X &y) const { return 5.; }

  double call_impl_(const X &x, const Y &y) const { return 7.; }

  double call_impl_(const Y &x, const Y &y) const { return 9.; }
  std::string name_ = "defined_for_xy";
};
```
We can then compose them into a more complicated covariance function:
```
DefinedForX cov_xx;
DefinedForY cov_yy;
DefinedForXY cov_xy;

auto complicated = cov_xx + cov_yy + cov_xy;
```
And using this change we can then ask things like "What is the call trace when I call `complicated` with two `X` arguments:
```
X x;
complicated.call_trace().print(x, x)
>>
VALUE              FUNCTION                                                                                            
-----              --------                                                                                            
6                  ((defined_for_x+defined_for_y)+defined_for_xy)                                                      
 |  1               |  (defined_for_x+defined_for_y)                                                                   
 |   |  1.000000    |   |  defined_for_x                                                                               
 |   |+ UNDEFINED   |   |+ defined_for_y                                                                               
 |+ 5.000000        |+ defined_for_xy  ```
