### PR TITLE
Parameter Macro

### DIFF
--- a/albatross/core/parameter_macros.h
+++ b/albatross/core/parameter_macros.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CORE_PARAMETER_MACROS_H
+#define ALBATROSS_CORE_PARAMETER_MACROS_H
+
+#include "core/parameter_handling_mixin.h"
+#include <cassert>
+#include <map>
+
+using albatross::Parameter;
+using albatross::ParameterKey;
+using albatross::ParameterValue;
+using albatross::ParameterStore;
+
+/*
+ * The for each functionality was taken from:
+ *   https://codecraft.co/2014/11/25/variadic-macros-tricks/
+ */
+
+// Accept any number of args >= N, but expand to just the Nth one.
+#define _GET_NTH_ARG(_1, _2, _3, _4, _5, _6, _7, _8, _9, N, ...) N
+
+// Define some macros to help us create overrides based on the
+// arity of a for-each-style macro.
+#define _fe_0(_call, ...)
+#define _fe_1(_call, x) _call(x)
+#define _fe_2(_call, x, ...) _call(x) _fe_1(_call, __VA_ARGS__)
+#define _fe_3(_call, x, ...) _call(x) _fe_2(_call, __VA_ARGS__)
+#define _fe_4(_call, x, ...) _call(x) _fe_3(_call, __VA_ARGS__)
+#define _fe_5(_call, x, ...) _call(x) _fe_4(_call, __VA_ARGS__)
+#define _fe_6(_call, x, ...) _call(x) _fe_5(_call, __VA_ARGS__)
+#define _fe_7(_call, x, ...) _call(x) _fe_6(_call, __VA_ARGS__)
+#define _fe_8(_call, x, ...) _call(x) _fe_7(_call, __VA_ARGS__)
+
+#define CALL_MACRO_X_FOR_EACH(x, ...)                                          \
+  _GET_NTH_ARG("ignored", ##__VA_ARGS__, _fe_8, _fe_7, _fe_6, _fe_5, _fe_4,    \
+               _fe_3, _fe_2, _fe_1, _fe_0)                                     \
+  (x, ##__VA_ARGS__)
+
+/*
+ * These macros build up a function that when called with,
+ *
+ *   DEFINE_GET_PARAMS(1, 2, ...)
+ *
+ * builds a code block that looks like:
+ *
+ *   ParameterStore get_params() const override {
+ *     return {{"$1", $1},
+ *             {"$2", $2},
+ *             ...
+ *             };
+ *    }
+ */
+#define ADD_MAP_ELEMENT(x) {#x, x},
+
+#define BUILD_MAP(...)                                                         \
+  { CALL_MACRO_X_FOR_EACH(ADD_MAP_ELEMENT, ##__VA_ARGS__) }
+
+#define DEFINE_GET_PARAMS(...)                                                 \
+  ParameterStore get_params() const override { return BUILD_MAP(__VA_ARGS__); };
+
+/*
+ * These macros build up a function that when called with,
+ *
+ *   DEFINE_SET_PARAMS_UNCHECKED(1, 2, ...)
+ *
+ * builds a code block that looks like:
+ *
+ *   void unchecked_set_param (const std::string &key,
+ *                             const ParameterValue &value) override {
+ *     if (key == "$1") {
+ *       $1 = value;
+ *     } else if (key == "$2") {
+ *       $2 = value;
+ *     }
+ *     ...
+ *     } else {
+ *       assert(false);
+ *     }
+ *   }
+ */
+
+/*
+ * Similar to the CALL_MACRO_X_FOR_EACH macros, this builds
+ * an if else tree
+ */
+#define _build_if_0(_cond, _action, ...)
+#define _build_if_1(_cond, _action, x)                                         \
+  if (_cond(x)) {                                                              \
+    _action(x);                                                                \
+  } else {                                                                     \
+    assert(false);                                                             \
+  };
+#define _build_if_2(_cond, _action, x, ...)                                    \
+  if (_cond(x)) {                                                              \
+    _action(x);                                                                \
+  } else                                                                       \
+  _build_if_1(_cond, _action, __VA_ARGS__)
+#define _build_if_3(_cond, _action, x, ...)                                    \
+  if (_cond(x)) {                                                              \
+    _action(x);                                                                \
+  } else                                                                       \
+  _build_if_2(_cond, _action, __VA_ARGS__)
+#define _build_if_4(_cond, _action, x, ...)                                    \
+  if (_cond(x)) {                                                              \
+    _action(x);                                                                \
+  } else                                                                       \
+  _build_if_3(_cond, _action, __VA_ARGS__)
+#define _build_if_5(_cond, _action, x, ...)                                    \
+  if (_cond(x)) {                                                              \
+    _action(x);                                                                \
+  } else                                                                       \
+  _build_if_4(_cond, _action, __VA_ARGS__)
+#define _build_if_6(_cond, _action, x, ...)                                    \
+  if (_cond(x)) {                                                              \
+    _action(x);                                                                \
+  } else                                                                       \
+  _build_if_5(_cond, _action, __VA_ARGS__)
+#define _build_if_7(_cond, _action, x, ...)                                    \
+  if (_cond(x)) {                                                              \
+    _action(x);                                                                \
+  } else                                                                       \
+  _build_if_6(_cond, _action, __VA_ARGS__)
+#define _build_if_8(_cond, _action, x, ...)                                    \
+  if (_cond(x)) {                                                              \
+    _action(x);                                                                \
+  } else                                                                       \
+  _build_if_7(_cond, _action, __VA_ARGS__)
+
+#define BUILD_IF(cond, action, ...)                                            \
+  _GET_NTH_ARG("ignored", ##__VA_ARGS__, _build_if_8, _build_if_7,             \
+               _build_if_6, _build_if_5, _build_if_4, _build_if_3,             \
+               _build_if_2, _build_if_1, _build_if_0)                          \
+  (cond, action, ##__VA_ARGS__)
+
+#define SET_PARAMS_CONDITION(x) key == #x
+
+#define SET_PARAMS_ACTION(x) x = value
+
+#define DEFINE_SET_PARAMS_UNCHECKED(...)                                       \
+  void unchecked_set_param(const ParameterKey &key, const Parameter &value)    \
+      override {                                                               \
+    BUILD_IF(SET_PARAMS_CONDITION, SET_PARAMS_ACTION, __VA_ARGS__);            \
+  };
+
+/*
+ * Builds a code block which declares each argument as a Parameter.
+ *
+ *   Parameter $1;
+ *   Parameter $2;
+ *
+ */
+#define DECLARE_PARAM(x) Parameter x;
+
+#define DECLARE_PARAMS(...) CALL_MACRO_X_FOR_EACH(DECLARE_PARAM, ##__VA_ARGS__)
+
+#define ALBATROSS_DECLARE_PARAMS(...)                                          \
+  DEFINE_GET_PARAMS(__VA_ARGS__);                                              \
+  DEFINE_SET_PARAMS_UNCHECKED(__VA_ARGS__);                                    \
+  DECLARE_PARAMS(__VA_ARGS__);
+
+#endif

--- a/albatross/covariance_functions/covariance_function.h
+++ b/albatross/covariance_functions/covariance_function.h
@@ -14,7 +14,7 @@
 #define ALBATROSS_COVARIANCE_FUNCTIONS_COVARIANCE_FUNCTION_H
 
 #include "../core/traits.h"
-#include "core/parameter_handling_mixin.h"
+#include "core/parameter_macros.h"
 #include "map_utils.h"
 #include <Eigen/Core>
 #include <Eigen/Dense>

--- a/albatross/covariance_functions/noise.h
+++ b/albatross/covariance_functions/noise.h
@@ -23,9 +23,11 @@ template <typename Observed>
 class IndependentNoise : public CovarianceFunction<IndependentNoise<Observed>> {
 public:
   IndependentNoise(double sigma_noise = 0.1) : name_("independent_noise") {
-    this->params_["sigma_independent_noise"] = {
-        sigma_noise, std::make_shared<NonNegativePrior>()};
+    sigma_independent_noise = {sigma_noise,
+                               std::make_shared<NonNegativePrior>()};
   };
+
+  ALBATROSS_DECLARE_PARAMS(sigma_independent_noise);
 
   ~IndependentNoise(){};
 
@@ -37,8 +39,7 @@ public:
    */
   double call_impl_(const Observed &x, const Observed &y) const {
     if (x == y) {
-      double sigma_noise = this->get_param_value("sigma_independent_noise");
-      return sigma_noise * sigma_noise;
+      return sigma_independent_noise.value * sigma_independent_noise.value;
     } else {
       return 0.;
     }

--- a/albatross/covariance_functions/polynomials.h
+++ b/albatross/covariance_functions/polynomials.h
@@ -32,10 +32,11 @@ struct ConstantTerm {};
  */
 class Constant : public CovarianceFunction<Constant> {
 public:
-  Constant(double sigma_constant = default_sigma) : name_("constant") {
-    this->params_["sigma_constant"] = {sigma_constant,
-                                       std::make_shared<NonNegativePrior>()};
+  Constant(double sigma_constant_ = default_sigma) : name_("constant") {
+    sigma_constant = {sigma_constant_, std::make_shared<NonNegativePrior>()};
   };
+
+  ALBATROSS_DECLARE_PARAMS(sigma_constant);
 
   ~Constant(){};
 
@@ -55,8 +56,7 @@ public:
   template <typename X, typename Y>
   double call_impl_(const X &x __attribute__((unused)),
                     const Y &y __attribute__((unused))) const {
-    double sigma_constant = this->get_param_value("sigma_constant");
-    return sigma_constant * sigma_constant;
+    return sigma_constant.value * sigma_constant.value;
   }
 
   const std::string name_;

--- a/albatross/covariance_functions/radial.h
+++ b/albatross/covariance_functions/radial.h
@@ -45,13 +45,16 @@ public:
       !std::is_base_of<AngularDistance, DistanceMetricType>::value,
       "SquaredExponential covariance with AngularDistance is not PSD.");
 
-  SquaredExponential(double length_scale = default_length_scale,
-                     double sigma_squared_exponential = default_radial_sigma)
+  ALBATROSS_DECLARE_PARAMS(squared_exponential_length_scale,
+                           sigma_squared_exponential);
+
+  SquaredExponential(double length_scale_ = default_length_scale,
+                     double sigma_squared_exponential_ = default_radial_sigma)
       : distance_metric_(), name_() {
-    this->params_["squared_exponential_length_scale"] = {
-        length_scale, std::make_shared<PositivePrior>()};
-    this->params_["sigma_squared_exponential"] = {
-        sigma_squared_exponential, std::make_shared<NonNegativePrior>()};
+    squared_exponential_length_scale = {length_scale_,
+                                        std::make_shared<PositivePrior>()};
+    sigma_squared_exponential = {sigma_squared_exponential_,
+                                 std::make_shared<NonNegativePrior>()};
     std::ostringstream oss;
     oss << "squared_exponential[" << this->distance_metric_.get_name() << "]";
     name_ = oss.str();
@@ -64,10 +67,9 @@ public:
                 int>::type = 0>
   double call_impl_(const X &x, const X &y) const {
     double distance = this->distance_metric_(x, y);
-    double length_scale =
-        this->get_param_value("squared_exponential_length_scale");
-    double sigma = this->get_param_value("sigma_squared_exponential");
-    return squared_exponential_covariance(distance, length_scale, sigma);
+    return squared_exponential_covariance(
+        distance, squared_exponential_length_scale.value,
+        sigma_squared_exponential.value);
   }
 
   DistanceMetricType distance_metric_;
@@ -86,13 +88,15 @@ inline double exponential_covariance(double distance, double length_scale,
 template <class DistanceMetricType>
 class Exponential : public CovarianceFunction<Exponential<DistanceMetricType>> {
 public:
-  Exponential(double length_scale = default_length_scale,
-              double sigma_exponential = default_radial_sigma)
+  ALBATROSS_DECLARE_PARAMS(exponential_length_scale, sigma_exponential);
+
+  Exponential(double length_scale_ = default_length_scale,
+              double sigma_exponential_ = default_radial_sigma)
       : distance_metric_(), name_() {
-    this->params_["exponential_length_scale"] = {
-        length_scale, std::make_shared<PositivePrior>()};
-    this->params_["sigma_exponential"] = {sigma_exponential,
-                                          std::make_shared<NonNegativePrior>()};
+    exponential_length_scale = {length_scale_,
+                                std::make_shared<PositivePrior>()};
+    sigma_exponential = {sigma_exponential_,
+                         std::make_shared<NonNegativePrior>()};
     std::ostringstream oss;
     oss << "exponential[" << this->distance_metric_.get_name() << "]";
     name_ = oss.str();
@@ -107,9 +111,8 @@ public:
                 int>::type = 0>
   double call_impl_(const X &x, const X &y) const {
     double distance = this->distance_metric_(x, y);
-    double length_scale = this->get_param_value("exponential_length_scale");
-    double sigma = this->get_param_value("sigma_exponential");
-    return exponential_covariance(distance, length_scale, sigma);
+    return exponential_covariance(distance, exponential_length_scale.value,
+                                  sigma_exponential.value);
   }
 
   DistanceMetricType distance_metric_;

--- a/tests/test_covariance_functions.cc
+++ b/tests/test_covariance_functions.cc
@@ -10,6 +10,7 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+#include "core/parameter_macros.h"
 #include "covariance_functions/covariance_functions.h"
 #include <Eigen/Core>
 #include <Eigen/Dense>
@@ -96,6 +97,22 @@ TYPED_TEST(TestVectorCovarianceFunctions, can_set_params) {
   }
 }
 
+class DummyCovariance : public CovarianceFunction<DummyCovariance> {
+public:
+  DummyCovariance(double foo_ = sqrt(2.), double bar_ = log(2.)) {
+    foo.value = foo_;
+    bar.value = bar_;
+  }
+
+  ALBATROSS_DECLARE_PARAMS(foo, bar)
+
+  double call_impl_(const double &x, const double &y) const {
+    return foo.value + bar.value;
+  }
+
+  std::string name_ = "dummy";
+};
+
 /*
  * In the following we test any covariance functions which should support
  * Eigen::Vector feature vectors.
@@ -108,8 +125,9 @@ public:
 };
 
 typedef ::testing::Types<
-    IndependentNoise<double>, Polynomial<2>,
-    SumOfCovarianceFunctions<IndependentNoise<double>, Polynomial<2>>>
+    DummyCovariance, IndependentNoise<double>, Polynomial<2>,
+    SumOfCovarianceFunctions<IndependentNoise<double>, Polynomial<2>>,
+    SumOfCovarianceFunctions<IndependentNoise<double>, DummyCovariance>>
     DoubleCompatibleCovarianceFunctions;
 
 TYPED_TEST_CASE(TestDoubleCovarianceFunctions,

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -222,8 +222,11 @@ struct AdaptedFeature {
   double value;
 };
 
-static inline auto make_adapted_toy_linear_data() {
-  const auto dataset = make_toy_linear_data();
+static inline auto make_adapted_toy_linear_data(const double a = 5.,
+                                                const double b = 1.,
+                                                const double sigma = 0.1,
+                                                const std::size_t n = 10) {
+  const auto dataset = make_toy_linear_data(a, b, sigma, n);
 
   std::vector<AdaptedFeature> adapted_features;
   for (const auto &f : dataset.features) {


### PR DESCRIPTION
This PR addresses an issue I've been seeing where covariance functions which require multiple parameters spend a huge amount of CPU in the `this->get_param_value(key)` calls.  This change preserves the default behavior, but provides a (rather complex) macro 
 `ALBATROSS_DECLARE_PARAMS` which generates the code to override the default `ParameterHandlingMixin` get/set params behavior with a variation that uses class members directly.

For example,

`ALBATROSS_DECLARE_PARAMS(foo, bar)`

would expand to:

```
ParameterStore get_params() const override {
    return {{"foo", foo},
            {"bar", bar}};
}

void unchecked_set_param (const std::string &key,
                          const ParameterValue &value) override {
       if (key == "foo") {
         foo = value;
       } else if (key == "bar") {
         bar = value;
       } else {
         assert(false);
       }
}

Parameter foo;
Parameter bar;
```

Which lets you define things like covariance functions by doing:
```
class A : public CovarianceFunction<A> {
public:
  ALBATROSS_DECLARE_PARAMS(sigma)

  A(double sigma_ = 1.) {
    sigma.value = sigma_;
  }

  double call_impl_(const double &x, const double &y) const {
    return sigma.value * sigma.value;
  }

  std::string name_ = "a";
};
```
instead of
```
class B : public CovarianceFunction<B> {
public:
  B(double sigma_ = 1.) {
    this->params_["sigma"] = {sigma_};
  }

  double call_impl_(const double &x, const double &y) const {
    double sigma = this->get_param_value("sigma");
    return sigma.value * sigma.value;
  }

  std::string name_ = "b";
};
```