### PR TITLE
Avoid Unnecessary Computation in Products.

### DIFF
--- a/albatross/covariance_functions/covariance_function.h
+++ b/albatross/covariance_functions/covariance_function.h
@@ -336,7 +336,11 @@ public:
                                      has_call_operator<RHS, X &, Y &>::value),
                                     int>::type = 0>
   double call_impl_(const X &x, const Y &y) const {
-    return this->lhs_(x, y) * this->rhs_(x, y);
+    double output = this->lhs_(x, y);
+    if (output != 0.) {
+      output *= this->rhs_(x, y);
+    }
+    return output;
   }
 
   /*


### PR DESCRIPTION
Only compute the right hand side of a covariance product if the left hand side isn't 0.

This way if you have some covariance function which is complex:
```
SlowCovarianceFunction slow;
```
we can then introduce decorrelating product functions,
```
class OnlyOdd : public CovarianceFunction<OnlyOdd> {
    double call_impl_(const int x, const int y) const {
        if (x % 2 && y %% 2) {
            return 1.;
        } else {
            return 0.;
        }
    }
}
```
Such that if you then form:
```
OnlyOdd odd;
auto product = odd * slow;
```
Evaluation of the slow function in `product` will only be done for `odd` numbers.