### PR TITLE
Fix Matrix Covariance Function Methods.

### DIFF
--- a/albatross/covariance_functions/covariance_function.h
+++ b/albatross/covariance_functions/covariance_function.h
@@ -142,6 +142,16 @@ public:
   template <typename X,
             typename std::enable_if<
                 has_defined_call_impl<Derived, X &, X &>::value, int>::type = 0>
+  double operator()(const X &x) const {
+    return derived().call_impl_(x, x);
+  }
+
+  /*
+   * Covariance between each element and every other in a vector.
+   */
+  template <typename X,
+            typename std::enable_if<
+                has_defined_call_impl<Derived, X &, X &>::value, int>::type = 0>
   Eigen::MatrixXd operator()(const std::vector<X> &xs) const {
     int n = static_cast<int>(xs.size());
     Eigen::MatrixXd C(n, n);
@@ -198,15 +208,21 @@ public:
   }
 
   /*
-   * A stub to catch the case where a covariance function was called
+   * Stubs to catch the case where a covariance function was called
    * with arguments that aren't supported.
    */
+  template <typename X, typename std::enable_if<
+                            !has_defined_call_impl<Derived, X &, X &>::value,
+                            int>::type = 0>
+  double operator()(const X &x) const = delete; // see below for help debugging.
+
   template <typename X, typename Y,
             typename std::enable_if<
                 (!has_defined_call_impl<Derived, X &, Y &>::value &&
                  !has_defined_call_impl<Derived, Y &, X &>::value),
                 int>::type = 0>
-  double operator()(X &x, Y &y) const = delete; // see below for help debugging.
+  double operator()(const X &x,
+                    const Y &y) const = delete; // see below for help debugging.
                                                 /*
                                                  * If you encounter a deleted function error here ^ it implies that you've
                                                  * attempted to call a covariance function with arguments X, Y that are

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ test_call_trace.cc
 test_concatenate.cc
 test_core_distribution.cc
 test_core_model.cc
+test_covariance_function.cc
 test_covariance_functions.cc
 test_csv_utils.cc
 test_distance_metrics.cc

--- a/tests/test_covariance_function.cc
+++ b/tests/test_covariance_function.cc
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "core/traits.h"
+#include "covariance_functions/covariance_function.h"
+#include "covariance_functions/noise.h"
+#include "models/gp.h"
+#include "models/ransac_gp.h"
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+template <typename X, typename CovarianceFunction> class IdentityCov {
+public:
+  IdentityCov(CovarianceFunction &covariance_function,
+              const std::vector<X> &features)
+      : features_(features), cov_(covariance_function) {}
+
+  template <typename Y> void test(const std::vector<Y> &features) {
+    Eigen::MatrixXd c = cov_(features, features_);
+    std::cout << c << std::endl;
+  }
+
+  std::vector<X> features_;
+  CovarianceFunction cov_;
+};
+
+struct X {
+  bool operator==(const X &) const { return false; }
+};
+
+struct Y {};
+struct Z {};
+
+class HasXX : public CovarianceFunction<HasXX> {
+public:
+  double call_impl_(const X &, const X &) const { return 1.; };
+};
+
+class HasXY : public CovarianceFunction<HasXY> {
+public:
+  double call_impl_(const X &, const Y &) const { return 1.; };
+};
+
+class HasNone : public CovarianceFunction<HasNone> {};
+
+class HasMultiple : public CovarianceFunction<HasMultiple> {
+public:
+  double call_impl_(const X &, const Y &) const { return 1.; };
+
+  double call_impl_(const X &, const X &) const { return 1.; };
+
+  double call_impl_(const Y &, const Y &) const { return 1.; };
+
+  std::string name_ = "has_multiple";
+};
+
+TEST(test_covariance_function, test_operator_resolution) {
+
+  EXPECT_TRUE(bool(has_call_operator<HasXY, X, Y>::value));
+  EXPECT_TRUE(bool(has_call_operator<HasXY, Y, X>::value));
+  EXPECT_FALSE(bool(has_call_operator<HasXY, X, X>::value));
+  EXPECT_FALSE(bool(has_call_operator<HasXY, Y, Y>::value));
+  EXPECT_FALSE(bool(has_call_operator<HasXY, Z, Z>::value));
+
+  EXPECT_FALSE(bool(has_call_operator<HasNone, X, Y>::value));
+  EXPECT_FALSE(bool(has_call_operator<HasNone, Y, X>::value));
+  EXPECT_FALSE(bool(has_call_operator<HasNone, X, X>::value));
+  EXPECT_FALSE(bool(has_call_operator<HasNone, Y, Y>::value));
+  EXPECT_FALSE(bool(has_call_operator<HasNone, Z, Z>::value));
+
+  EXPECT_TRUE(bool(has_call_operator<HasMultiple, X, Y>::value));
+  EXPECT_TRUE(bool(has_call_operator<HasMultiple, Y, X>::value));
+  EXPECT_TRUE(bool(has_call_operator<HasMultiple, X, X>::value));
+  EXPECT_TRUE(bool(has_call_operator<HasMultiple, Y, Y>::value));
+  EXPECT_FALSE(bool(has_call_operator<HasMultiple, Z, Z>::value));
+}
+
+TEST(test_covariance_function, test_vector_operator) {
+  EXPECT_TRUE(
+      bool(has_call_operator<HasXY, std::vector<X>, std::vector<Y>>::value));
+  EXPECT_TRUE(
+      bool(has_call_operator<HasXY, std::vector<Y>, std::vector<X>>::value));
+  EXPECT_FALSE(
+      bool(has_call_operator<HasXY, std::vector<X>, std::vector<X>>::value));
+  EXPECT_FALSE(
+      bool(has_call_operator<HasXY, std::vector<Y>, std::vector<Y>>::value));
+  EXPECT_FALSE(
+      bool(has_call_operator<HasXY, std::vector<Z>, std::vector<Z>>::value));
+
+  EXPECT_TRUE(bool(
+      has_call_operator<HasMultiple, std::vector<X>, std::vector<Y>>::value));
+  EXPECT_TRUE(bool(
+      has_call_operator<HasMultiple, std::vector<Y>, std::vector<X>>::value));
+  EXPECT_TRUE(bool(
+      has_call_operator<HasMultiple, std::vector<X>, std::vector<X>>::value));
+  EXPECT_TRUE(bool(
+      has_call_operator<HasMultiple, std::vector<Y>, std::vector<Y>>::value));
+  EXPECT_FALSE(bool(
+      has_call_operator<HasMultiple, std::vector<Z>, std::vector<Z>>::value));
+}
+
+TEST(test_covariance_function, test_covariance_matrix) {
+
+  HasMultiple cov;
+
+  EXPECT_TRUE(bool(
+      has_call_operator<decltype(cov), std::vector<X>, std::vector<Y>>::value));
+  EXPECT_TRUE(bool(
+      has_call_operator<decltype(cov), std::vector<Y>, std::vector<X>>::value));
+  EXPECT_TRUE(bool(
+      has_call_operator<decltype(cov), std::vector<X>, std::vector<X>>::value));
+  EXPECT_TRUE(bool(
+      has_call_operator<decltype(cov), std::vector<Y>, std::vector<Y>>::value));
+  EXPECT_FALSE(bool(
+      has_call_operator<decltype(cov), std::vector<Z>, std::vector<Z>>::value));
+
+  std::vector<X> xs = {{}, {}, {}};
+  std::vector<Y> ys = {{}, {}};
+
+  EXPECT_EQ(cov(xs).size(), 9);
+  EXPECT_EQ(cov(ys).size(), 4);
+  EXPECT_EQ(cov(xs, ys).size(), 6);
+
+  const std::vector<X> const_xs = {{}, {}, {}};
+  const std::vector<Y> const_ys = {{}, {}};
+
+  EXPECT_EQ(cov(const_xs).size(), 9);
+  EXPECT_EQ(cov(const_ys).size(), 4);
+  EXPECT_EQ(cov(const_xs, const_ys).size(), 6);
+
+  EXPECT_EQ(cov(std::vector<X>({{}, {}, {}})).size(), 9);
+  EXPECT_EQ(cov(std::vector<Y>({{}, {}})).size(), 4);
+  EXPECT_EQ(cov(std::vector<X>({{}, {}, {}}), std::vector<Y>({{}, {}})).size(),
+            6);
+}
+
+} // namespace albatross

--- a/tests/test_traits.cc
+++ b/tests/test_traits.cc
@@ -17,6 +17,7 @@ namespace albatross {
 
 struct X {};
 struct Y {};
+struct Z {};
 
 class HasPublicCallOperator {
 public:
@@ -62,6 +63,26 @@ TEST(test_traits, test_has_any_call_impl_) {
   EXPECT_TRUE(bool(has_any_call_impl<HasProtectedCallImpl>::value));
   EXPECT_TRUE(bool(has_any_call_impl<HasPrivateCallImpl>::value));
   EXPECT_FALSE(bool(has_any_call_impl<HasNoCallImpl>::value));
+}
+
+class HasMultiplePublicCallImpl {
+public:
+  double call_impl_(const X &, const Y &) const { return 1.; };
+
+  double call_impl_(const X &, const X &) const { return 1.; };
+
+  double call_impl_(const Y &, const Y &) const { return 1.; };
+};
+
+TEST(test_traits, test_has_defined_call_impl_) {
+  EXPECT_TRUE(bool(has_defined_call_impl<HasPublicCallImpl, X, Y>::value));
+  EXPECT_FALSE(bool(has_defined_call_impl<HasPublicCallImpl, Y, X>::value));
+  EXPECT_TRUE(
+      bool(has_defined_call_impl<HasMultiplePublicCallImpl, X, X>::value));
+  EXPECT_TRUE(
+      bool(has_defined_call_impl<HasMultiplePublicCallImpl, Y, Y>::value));
+  EXPECT_FALSE(
+      bool(has_defined_call_impl<HasMultiplePublicCallImpl, X, Z>::value));
 }
 
 class ValidInOutSerializer {


### PR DESCRIPTION
Fixes a bug in which evaluating a covariance function using a vector of valid types would land on the deleted call operator instead of the desired one.  This was due to a missing `const` in the deleted method.

The bug fix is the addition of `const` on line 224 of `covariance_function.h`. 

Other Changes Include:
- An additional set of operators which map `covariance_function(x)` to `covariance_function(x, x)` and the corresponding deleted function to help debugging.
- Test to prevent a regression