### PR TITLE
Improve Traits

### DIFF
--- a/albatross/core/traits.h
+++ b/albatross/core/traits.h
@@ -43,7 +43,7 @@ template <class T> struct call_impl_arg_type {
 
 /*
  * This determines whether or not a class has a method defined for,
- *   `operator() (X x, Y y, Z z, ...)`
+ *   `operator() (const X &x, const Y &y, const Z &z, ...)`
  * The result of the inspection gets stored in the member `value`.
  */
 template <typename T, typename... Args> class has_call_operator {
@@ -66,10 +66,11 @@ public:
 template <typename T, typename... Args> class has_valid_call_impl {
 
   template <typename C>
-  static auto test(C *) -> typename std::is_same<
+  static typename std::is_same<
       decltype(std::declval<const C>().call_impl_(
           std::declval<typename call_impl_arg_type<Args>::type>()...)),
-      double>::type;
+      double>::type
+  test(C *);
   template <typename> static std::false_type test(...);
 
 public:

--- a/albatross/covariance_functions/call_trace.h
+++ b/albatross/covariance_functions/call_trace.h
@@ -104,25 +104,25 @@ public:
 
   template <typename X, typename Y,
             typename std::enable_if<
-                has_defined_call_impl<CovFunc, X &, Y &>::value, int>::type = 0>
+                has_valid_call_impl<CovFunc, X &, Y &>::value, int>::type = 0>
   std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
     return {{cov_func_.get_name(), std::to_string(cov_func_(x, y))}};
   }
 
-  template <typename X, typename Y,
-            typename std::enable_if<
-                (has_defined_call_impl<CovFunc, Y &, X &>::value &&
-                 !has_defined_call_impl<CovFunc, X &, Y &>::value),
-                int>::type = 0>
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(has_valid_call_impl<CovFunc, Y &, X &>::value &&
+                               !has_valid_call_impl<CovFunc, X &, Y &>::value),
+                              int>::type = 0>
   std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
     return {{cov_func_.get_name(), std::to_string(cov_func_(x, y))}};
   }
 
-  template <typename X, typename Y,
-            typename std::enable_if<
-                (!has_defined_call_impl<CovFunc, Y &, X &>::value &&
-                 !has_defined_call_impl<CovFunc, X &, Y &>::value),
-                int>::type = 0>
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(!has_valid_call_impl<CovFunc, Y &, X &>::value &&
+                               !has_valid_call_impl<CovFunc, X &, Y &>::value),
+                              int>::type = 0>
   std::vector<CallAndValue> get_trace(const X &, const Y &) const {
     return {{cov_func_.get_name(), "UNDEFINED"}};
   }
@@ -139,8 +139,8 @@ public:
 
   template <typename X, typename Y,
             typename std::enable_if<
-                has_defined_call_impl<SumOfCovarianceFunctions<LHS, RHS>, X &,
-                                      Y &>::value,
+                has_valid_call_impl<SumOfCovarianceFunctions<LHS, RHS>, X &,
+                                    Y &>::value,
                 int>::type = 0>
   std::string eval(const X &x, const Y &y) const {
     std::ostringstream oss;
@@ -150,8 +150,8 @@ public:
 
   template <typename X, typename Y,
             typename std::enable_if<
-                !has_defined_call_impl<SumOfCovarianceFunctions<LHS, RHS>, X &,
-                                       Y &>::value,
+                !has_valid_call_impl<SumOfCovarianceFunctions<LHS, RHS>, X &,
+                                     Y &>::value,
                 int>::type = 0>
   std::string eval(const X &, const Y &) const {
     return "UNDEFINED";
@@ -185,8 +185,8 @@ public:
 
   template <typename X, typename Y,
             typename std::enable_if<
-                has_defined_call_impl<ProductOfCovarianceFunctions<LHS, RHS>,
-                                      X &, Y &>::value,
+                has_valid_call_impl<ProductOfCovarianceFunctions<LHS, RHS>, X &,
+                                    Y &>::value,
                 int>::type = 0>
   std::string eval(const X &x, const Y &y) const {
     std::ostringstream oss;
@@ -196,8 +196,8 @@ public:
 
   template <typename X, typename Y,
             typename std::enable_if<
-                !has_defined_call_impl<ProductOfCovarianceFunctions<LHS, RHS>,
-                                       X &, Y &>::value,
+                !has_valid_call_impl<ProductOfCovarianceFunctions<LHS, RHS>,
+                                     X &, Y &>::value,
                 int>::type = 0>
   std::string eval(const X &, const Y &) const {
     return "UNDEFINED";

--- a/albatross/covariance_functions/covariance_function.h
+++ b/albatross/covariance_functions/covariance_function.h
@@ -118,7 +118,7 @@ public:
    */
   template <typename X, typename Y,
             typename std::enable_if<
-                has_defined_call_impl<Derived, X &, Y &>::value, int>::type = 0>
+                has_valid_call_impl<Derived, X &, Y &>::value, int>::type = 0>
   auto operator()(const X &x, const Y &y) const {
     return derived().call_impl_(x, y);
   }
@@ -127,11 +127,11 @@ public:
    * Use the symmetric property of covariance functions to find C(X, Y)
    * when only C(Y, X) is defined.
    */
-  template <typename X, typename Y,
-            typename std::enable_if<
-                (has_defined_call_impl<Derived, Y &, X &>::value &&
-                 !has_defined_call_impl<Derived, X &, Y &>::value),
-                int>::type = 0>
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(has_valid_call_impl<Derived, Y &, X &>::value &&
+                               !has_valid_call_impl<Derived, X &, Y &>::value),
+                              int>::type = 0>
   auto operator()(const X &x, const Y &y) const {
     return derived().call_impl_(y, x);
   }
@@ -141,7 +141,7 @@ public:
    */
   template <typename X,
             typename std::enable_if<
-                has_defined_call_impl<Derived, X &, X &>::value, int>::type = 0>
+                has_valid_call_impl<Derived, X &, X &>::value, int>::type = 0>
   double operator()(const X &x) const {
     return derived().call_impl_(x, x);
   }
@@ -151,7 +151,7 @@ public:
    */
   template <typename X,
             typename std::enable_if<
-                has_defined_call_impl<Derived, X &, X &>::value, int>::type = 0>
+                has_valid_call_impl<Derived, X &, X &>::value, int>::type = 0>
   Eigen::MatrixXd operator()(const std::vector<X> &xs) const {
     int n = static_cast<int>(xs.size());
     Eigen::MatrixXd C(n, n);
@@ -172,10 +172,9 @@ public:
   /*
    * Cross covariance between two vectors of (possibly) different types.
    */
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(has_defined_call_impl<Derived, X &, Y &>::value),
-                              int>::type = 0>
+  template <typename X, typename Y,
+            typename std::enable_if<
+                (has_valid_call_impl<Derived, X &, Y &>::value), int>::type = 0>
   Eigen::MatrixXd operator()(const std::vector<X> &xs,
                              const std::vector<Y> &ys) const {
     int m = static_cast<int>(xs.size());
@@ -197,11 +196,11 @@ public:
   /*
    * Use the symmetric property to compute the cross covariance.
    */
-  template <typename X, typename Y,
-            typename std::enable_if<
-                (has_defined_call_impl<Derived, Y &, X &>::value &&
-                 !has_defined_call_impl<Derived, X &, Y &>::value),
-                int>::type = 0>
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(has_valid_call_impl<Derived, Y &, X &>::value &&
+                               !has_valid_call_impl<Derived, X &, Y &>::value),
+                              int>::type = 0>
   Eigen::MatrixXd operator()(const std::vector<X> &xs,
                              const std::vector<Y> &ys) const {
     return this->operator()(ys, xs).transpose();
@@ -212,15 +211,15 @@ public:
    * with arguments that aren't supported.
    */
   template <typename X, typename std::enable_if<
-                            !has_defined_call_impl<Derived, X &, X &>::value,
+                            !has_valid_call_impl<Derived, X &, X &>::value,
                             int>::type = 0>
   double operator()(const X &x) const = delete; // see below for help debugging.
 
-  template <typename X, typename Y,
-            typename std::enable_if<
-                (!has_defined_call_impl<Derived, X &, Y &>::value &&
-                 !has_defined_call_impl<Derived, Y &, X &>::value),
-                int>::type = 0>
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(!has_valid_call_impl<Derived, X &, Y &>::value &&
+                               !has_valid_call_impl<Derived, Y &, X &>::value),
+                              int>::type = 0>
   double operator()(const X &x,
                     const Y &y) const = delete; // see below for help debugging.
                                                 /*

--- a/albatross/covariance_functions/covariance_function.h
+++ b/albatross/covariance_functions/covariance_function.h
@@ -209,26 +209,63 @@ public:
   /*
    * Stubs to catch the case where a covariance function was called
    * with arguments that aren't supported.
+   *
+   * If you encounter a deleted function error below it implies that you've
+   * attempted to call a covariance function with arguments X, Y that are
+   * undefined (or invalid) for the corresponding CovarianceFunction(s).
+   * The subsequent compiler errors should give you an indication of which
+   * types were attempted.
+   */
+
+  template <typename X, typename std::enable_if<
+                            (!has_valid_call_impl<Derived, X &, X &>::value &&
+                             !has_possible_call_impl<Derived, X &, X &>::value),
+                            int>::type = 0>
+  // There don't appear to be any call_impl_ methods with signature
+  // `double call_impl_(const X&, const X&) const`.
+  double operator()(const X &x) const =
+      delete; // No call_impl_.  See comments for help.
+
+  /*
+   * Stubs to catch the case where a covariance function was called
+   * with arguments that aren't supported.
    */
   template <typename X, typename std::enable_if<
-                            !has_valid_call_impl<Derived, X &, X &>::value,
+                            (!has_valid_call_impl<Derived, X &, X &>::value &&
+                             has_invalid_call_impl<Derived, X &, X &>::value),
                             int>::type = 0>
-  double operator()(const X &x) const = delete; // see below for help debugging.
+  // Here it seems there are no valid call_impl_ methods for these types
+  // but there are some invalid ones.  Be sure that the call_impl_ is
+  // defined in the form: `double call_impl_(const X&, const X&) const`.
+  double operator()(const X &x) const =
+      delete; // Invalid call_impl_.  See comments for help.
 
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(!has_valid_call_impl<Derived, X &, Y &>::value &&
-                               !has_valid_call_impl<Derived, Y &, X &>::value),
-                              int>::type = 0>
+  template <typename X, typename Y,
+            typename std::enable_if<
+                (!has_valid_call_impl<Derived, X &, Y &>::value &&
+                 !has_valid_call_impl<Derived, Y &, X &>::value) &&
+                    (!has_possible_call_impl<Derived, X &, Y &>::value &&
+                     !has_possible_call_impl<Derived, Y &, X &>::value),
+                int>::type = 0>
+  // There don't appear to be any call_impl_ methods with signature
+  // `double call_impl_(const X&, const Y&) const`.
   double operator()(const X &x,
-                    const Y &y) const = delete; // see below for help debugging.
-                                                /*
-                                                 * If you encounter a deleted function error here ^ it implies that you've
-                                                 * attempted to call a covariance function with arguments X, Y that are
-                                                 * undefined for the corresponding CovarianceFunction(s).  The subsequent
-                                                 * compiler
-                                                 * errors should give you an indication of which types were attempted.
-                                                 */
+                    const Y &y) const =
+      delete; // No call_impl_.  See comments for help.
+
+  template <typename X, typename Y,
+            typename std::enable_if<
+                (!has_valid_call_impl<Derived, X &, Y &>::value &&
+                 !has_valid_call_impl<Derived, Y &, X &>::value) &&
+                    (has_invalid_call_impl<Derived, X &, Y &>::value ||
+                     has_invalid_call_impl<Derived, Y &, X &>::value),
+                int>::type = 0>
+  // Here it seems there are no valid call_impl_ methods for these types
+  // but there are some invalid ones.  Be sure that the call_impl_ is
+  // defined in the form: `double call_impl_(const X&, const X&) const`.
+  double operator()(const X &x,
+                    const Y &y) const =
+      delete; // Invalid call_impl_.  See comments for help.
 
   CallTrace<Derived> call_trace() const;
 
@@ -277,10 +314,11 @@ public:
    * If both LHS and RHS have a valid call method for the types X and Y
    * this will return the sum of the two.
    */
-  template <typename X, typename Y,
-            typename std::enable_if<(has_call_operator<LHS, X &, Y &>::value &&
-                                     has_call_operator<RHS, X &, Y &>::value),
-                                    int>::type = 0>
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
+                               has_valid_call_impl<RHS, X &, Y &>::value),
+                              int>::type = 0>
   double call_impl_(const X &x, const Y &y) const {
     return this->lhs_(x, y) + this->rhs_(x, y);
   }
@@ -288,10 +326,11 @@ public:
   /*
    * If only LHS has a valid call method we ignore R.
    */
-  template <typename X, typename Y,
-            typename std::enable_if<(has_call_operator<LHS, X &, Y &>::value &&
-                                     !has_call_operator<RHS, X &, Y &>::value),
-                                    int>::type = 0>
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
+                               !has_valid_call_impl<RHS, X &, Y &>::value),
+                              int>::type = 0>
   double call_impl_(const X &x, const Y &y) const {
     return this->lhs_(x, y);
   }
@@ -299,10 +338,11 @@ public:
   /*
    * If only RHS has a valid call method we ignore L.
    */
-  template <typename X, typename Y,
-            typename std::enable_if<(!has_call_operator<LHS, X &, Y &>::value &&
-                                     has_call_operator<RHS, X &, Y &>::value),
-                                    int>::type = 0>
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(!has_valid_call_impl<LHS, X &, Y &>::value &&
+                               has_valid_call_impl<RHS, X &, Y &>::value),
+                              int>::type = 0>
   double call_impl_(const X &x, const Y &y) const {
     return this->rhs_(x, y);
   }
@@ -346,10 +386,11 @@ public:
    * If both LHS and RHS have a valid call method for the types X and Y
    * this will return the product of the two.
    */
-  template <typename X, typename Y,
-            typename std::enable_if<(has_call_operator<LHS, X &, Y &>::value &&
-                                     has_call_operator<RHS, X &, Y &>::value),
-                                    int>::type = 0>
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
+                               has_valid_call_impl<RHS, X &, Y &>::value),
+                              int>::type = 0>
   double call_impl_(const X &x, const Y &y) const {
     double output = this->lhs_(x, y);
     if (output != 0.) {
@@ -361,10 +402,11 @@ public:
   /*
    * If only LHS has a valid call method we ignore R.
    */
-  template <typename X, typename Y,
-            typename std::enable_if<(has_call_operator<LHS, X &, Y &>::value &&
-                                     !has_call_operator<RHS, X &, Y &>::value),
-                                    int>::type = 0>
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
+                               !has_valid_call_impl<RHS, X &, Y &>::value),
+                              int>::type = 0>
   double call_impl_(const X &x, const Y &y) const {
     return this->lhs_(x, y);
   }
@@ -372,10 +414,11 @@ public:
   /*
    * If only RHS has a valid call method we ignore L.
    */
-  template <typename X, typename Y,
-            typename std::enable_if<(!has_call_operator<LHS, X &, Y &>::value &&
-                                     has_call_operator<RHS, X &, Y &>::value),
-                                    int>::type = 0>
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(!has_valid_call_impl<LHS, X &, Y &>::value &&
+                               has_valid_call_impl<RHS, X &, Y &>::value),
+                              int>::type = 0>
   double call_impl_(const X &x, const Y &y) const {
     return this->rhs_(x, y);
   }

--- a/albatross/covariance_functions/scaling_function.h
+++ b/albatross/covariance_functions/scaling_function.h
@@ -93,8 +93,8 @@ public:
    */
   template <typename X, typename Y,
             typename std::enable_if<
-                (has_defined_call_impl<ScalingFunction, X &>::value &&
-                 has_defined_call_impl<ScalingFunction, Y &>::value),
+                (has_valid_call_impl<ScalingFunction, X &>::value &&
+                 has_valid_call_impl<ScalingFunction, Y &>::value),
                 int>::type = 0>
   double call_impl_(const X &x, const Y &y) const {
     return this->scaling_function_.call_impl_(x) *
@@ -106,8 +106,8 @@ public:
    */
   template <typename X, typename Y,
             typename std::enable_if<
-                (!has_defined_call_impl<ScalingFunction, X &>::value &&
-                 has_defined_call_impl<ScalingFunction, Y &>::value),
+                (!has_valid_call_impl<ScalingFunction, X &>::value &&
+                 has_valid_call_impl<ScalingFunction, Y &>::value),
                 int>::type = 0>
   double call_impl_(const X &, const Y &y) const {
     return this->scaling_function_.call_impl_(y);
@@ -115,8 +115,8 @@ public:
 
   template <typename X, typename Y,
             typename std::enable_if<
-                (has_defined_call_impl<ScalingFunction, X &>::value &&
-                 !has_defined_call_impl<ScalingFunction, Y &>::value),
+                (has_valid_call_impl<ScalingFunction, X &>::value &&
+                 !has_valid_call_impl<ScalingFunction, Y &>::value),
                 int>::type = 0>
   double call_impl_(const X &x, const Y &) const {
     return this->scaling_function_.call_impl_(x);

--- a/tests/test_covariance_function.cc
+++ b/tests/test_covariance_function.cc
@@ -85,7 +85,7 @@ TEST(test_covariance_function, test_operator_resolution) {
   EXPECT_FALSE(bool(has_call_operator<HasMultiple, Z, Z>::value));
 }
 
-TEST(test_covariance_function, test_vector_operator) {
+TEST(test_covariance_function, test_vector_operator_inspection) {
   EXPECT_TRUE(
       bool(has_call_operator<HasXY, std::vector<X>, std::vector<Y>>::value));
   EXPECT_TRUE(
@@ -110,19 +110,7 @@ TEST(test_covariance_function, test_vector_operator) {
 }
 
 TEST(test_covariance_function, test_covariance_matrix) {
-
   HasMultiple cov;
-
-  EXPECT_TRUE(bool(
-      has_call_operator<decltype(cov), std::vector<X>, std::vector<Y>>::value));
-  EXPECT_TRUE(bool(
-      has_call_operator<decltype(cov), std::vector<Y>, std::vector<X>>::value));
-  EXPECT_TRUE(bool(
-      has_call_operator<decltype(cov), std::vector<X>, std::vector<X>>::value));
-  EXPECT_TRUE(bool(
-      has_call_operator<decltype(cov), std::vector<Y>, std::vector<Y>>::value));
-  EXPECT_FALSE(bool(
-      has_call_operator<decltype(cov), std::vector<Z>, std::vector<Z>>::value));
 
   std::vector<X> xs = {{}, {}, {}};
   std::vector<Y> ys = {{}, {}};

--- a/tests/test_traits.cc
+++ b/tests/test_traits.cc
@@ -81,7 +81,7 @@ public:
   int call_impl_(const Z &, const Z &) const { return 1.; };
 };
 
-TEST(test_traits, test_has_valid_call_impl_) {
+TEST(test_traits, test_has_valid_call_impl) {
   EXPECT_TRUE(bool(has_valid_call_impl<HasPublicCallImpl, X, Y>::value));
   EXPECT_FALSE(bool(has_valid_call_impl<HasPublicCallImpl, Y, X>::value));
   EXPECT_TRUE(
@@ -94,6 +94,40 @@ TEST(test_traits, test_has_valid_call_impl_) {
       bool(has_valid_call_impl<HasMultiplePublicCallImpl, Z, Y>::value));
   EXPECT_FALSE(
       bool(has_valid_call_impl<HasMultiplePublicCallImpl, Z, Z>::value));
+}
+
+/*
+ * Here we test to make sure we can identify situations where
+ * call_impl_ has been defined but not necessarily properly.
+ */
+TEST(test_traits, test_has_possible_call_impl) {
+  EXPECT_TRUE(bool(has_possible_call_impl<HasPublicCallImpl, X, Y>::value));
+  EXPECT_FALSE(bool(has_possible_call_impl<HasPublicCallImpl, Y, X>::value));
+  EXPECT_TRUE(
+      bool(has_possible_call_impl<HasMultiplePublicCallImpl, X, X>::value));
+  EXPECT_TRUE(
+      bool(has_possible_call_impl<HasMultiplePublicCallImpl, Y, Y>::value));
+  EXPECT_TRUE(
+      bool(has_possible_call_impl<HasMultiplePublicCallImpl, Z, X>::value));
+  EXPECT_TRUE(
+      bool(has_possible_call_impl<HasMultiplePublicCallImpl, Z, Y>::value));
+  EXPECT_TRUE(
+      bool(has_possible_call_impl<HasMultiplePublicCallImpl, Z, Z>::value));
+}
+
+TEST(test_traits, test_has_invalid_call_impl) {
+  EXPECT_FALSE(bool(has_invalid_call_impl<HasPublicCallImpl, X, Y>::value));
+  EXPECT_FALSE(bool(has_invalid_call_impl<HasPublicCallImpl, Y, X>::value));
+  EXPECT_FALSE(
+      bool(has_invalid_call_impl<HasMultiplePublicCallImpl, X, X>::value));
+  EXPECT_FALSE(
+      bool(has_invalid_call_impl<HasMultiplePublicCallImpl, Y, Y>::value));
+  EXPECT_TRUE(
+      bool(has_invalid_call_impl<HasMultiplePublicCallImpl, Z, X>::value));
+  EXPECT_TRUE(
+      bool(has_invalid_call_impl<HasMultiplePublicCallImpl, Z, Y>::value));
+  EXPECT_TRUE(
+      bool(has_invalid_call_impl<HasMultiplePublicCallImpl, Z, Z>::value));
 }
 
 class ValidInOutSerializer {

--- a/tests/test_traits.cc
+++ b/tests/test_traits.cc
@@ -72,17 +72,28 @@ public:
   double call_impl_(const X &, const X &) const { return 1.; };
 
   double call_impl_(const Y &, const Y &) const { return 1.; };
+
+  // These are all invalid:
+  double call_impl_(const Z &, const X &) { return 1.; };
+
+  double call_impl_(Z &, const Y &) const { return 1.; };
+
+  int call_impl_(const Z &, const Z &) const { return 1.; };
 };
 
-TEST(test_traits, test_has_defined_call_impl_) {
-  EXPECT_TRUE(bool(has_defined_call_impl<HasPublicCallImpl, X, Y>::value));
-  EXPECT_FALSE(bool(has_defined_call_impl<HasPublicCallImpl, Y, X>::value));
+TEST(test_traits, test_has_valid_call_impl_) {
+  EXPECT_TRUE(bool(has_valid_call_impl<HasPublicCallImpl, X, Y>::value));
+  EXPECT_FALSE(bool(has_valid_call_impl<HasPublicCallImpl, Y, X>::value));
   EXPECT_TRUE(
-      bool(has_defined_call_impl<HasMultiplePublicCallImpl, X, X>::value));
+      bool(has_valid_call_impl<HasMultiplePublicCallImpl, X, X>::value));
   EXPECT_TRUE(
-      bool(has_defined_call_impl<HasMultiplePublicCallImpl, Y, Y>::value));
+      bool(has_valid_call_impl<HasMultiplePublicCallImpl, Y, Y>::value));
   EXPECT_FALSE(
-      bool(has_defined_call_impl<HasMultiplePublicCallImpl, X, Z>::value));
+      bool(has_valid_call_impl<HasMultiplePublicCallImpl, Z, X>::value));
+  EXPECT_FALSE(
+      bool(has_valid_call_impl<HasMultiplePublicCallImpl, Z, Y>::value));
+  EXPECT_FALSE(
+      bool(has_valid_call_impl<HasMultiplePublicCallImpl, Z, Z>::value));
 }
 
 class ValidInOutSerializer {


### PR DESCRIPTION
These changes are intended to give more valuable information when a `CovarianceFunction` is ill-formed.

In particular the addition of `has_possible_call_impl` in conjuction with `has_valid_call_impl` (formerly `has_defined_call_impl`) are used to create compiler errors when a CRTP `CovarianceFunction` is close to, but not quite, properly defined.

For example if we start with
```
class IllFormed : public CovarianceFunction<IllFormed> {
public:
  // valid
  double call_impl_(const X &, const X &) const { return 0.; };
  // invalid return type
  int call_impl_(const X &, const Y &) const { return 0; };
  // invalid arguments
  double call_impl_(Y &, const Y &) const { return 0.; };
};
```
Then use some test types,
```
  IllFormed cov;
  X x = {};
  Y y = {};
  Z z = {};
```
If we were to write `cov(x, x)` it will compile fine but if we use an invalid call such as, `cov(x, y)` we get:
```
error: use of deleted function ‘double albatross::CovarianceFunction<Derived>::operator()(const X&, const Y&) const [with X = albatross::X; Y = albatross::Y; typename std::enable_if<(((! albatross::has_valid_call_impl<Derived, X&, Y&>::value) && (! albatross::has_valid_call_impl<Derived, Y&, X&>::value)) && (albatross::has_invalid_call_impl<Derived, X&, Y&>::value || albatross::has_invalid_call_impl<Derived, Y&, X&>::value)), int>::type <anonymous> = 0; Derived = albatross::IllFormed]’
   cov(x, y);
           ^
In file included from ./albatross/covariance_functions/covariance_function.h:262:10: note: declared here
   double operator()(const X &, const Y &) const = delete; // Invalid call_impl_
```
as before if we try with a completely undefined function such as `cov(z, z)` we get a similar (but slightly different) error:
```
error: use of deleted function ‘double albatross::CovarianceFunction<Derived>::operator()(const X&, const Y&) const [with X = albatross::Z; Y = albatross::Z; typename std::enable_if<(((! albatross::has_valid_call_impl<Derived, X&, Y&>::value) && (! albatross::has_valid_call_impl<Derived, Y&, X&>::value)) && ((! albatross::has_possible_call_impl<Derived, X&, Y&>::value) && (! albatross::has_possible_call_impl<Derived, Y&, X&>::value))), int>::type <anonymous> = 0; Derived = albatross::IllFormed]’
   cov(z, z);
           ^
In file included from ./albatross/covariance_functions/covariance_function.h:250:10: note: declared here
   double operator()(const X &, const Y &) const = delete; // No call_impl_
```