### PR TITLE
CRTP Inheritance Question

### DIFF
--- a/sandbox/feature_conversion.cc
+++ b/sandbox/feature_conversion.cc
@@ -1,0 +1,76 @@
+#include <iostream>
+
+namespace albatross {
+
+struct X {int value;};
+struct Y {int value;};
+
+template <typename ModelType> class ModelBase {
+
+public:
+
+  template <typename T>
+  X convert_(const T &feature) {
+    return derived().convert_(feature);
+  }
+
+  template <typename FeatureType>
+  typename std::enable_if<has_possible_fit_impl<ModelType, FeatureType>::value, void>::type
+  fit(const FeatureType &feature) {
+    derived().fit_(feature);
+  }
+
+  template <typename FeatureType, typename OtherType>
+  typename std::enable_if<has_possible_fit_impl<ModelType, FeatureType>::value, void>::type
+  fit(const OtherType &other) {
+    FeatureType feature = derived().convert_(other);
+    fit(feature);
+  }
+
+  /*
+   * CRTP Helpers
+   */
+  ModelType &derived() { return *static_cast<ModelType *>(this); }
+  const ModelType &derived() const {
+    return *static_cast<const ModelType *>(this);
+  }
+};
+
+template <typename Derived>
+class Middle : public ModelBase<Derived> {
+public:
+
+  void fit_(const X &feature) {
+    std::cout << "Middle.fit_(X) : " << feature.value << std::endl;
+  }
+
+};
+
+class Adapted : public Middle<Adapted> {
+public:
+
+  X convert_(const Y &feature) const {
+    std::cout << "Adapted.convert_(Y) : " << feature.value << std::endl;
+    return {feature.value};
+  }
+
+};
+
+}
+
+int main()
+{
+  using namespace albatross;
+
+  Adapted m;
+
+  X x = {1};
+  m.fit(x);
+
+  Y y = {2};
+  m.fit<X>(y);
+  // I'd really like to be able to do:
+  //  m.fit(y);
+
+  return 0;
+}

--- a/sandbox/feature_conversion.cc
+++ b/sandbox/feature_conversion.cc
@@ -21,13 +21,6 @@ public:
     derived().fit_(feature);
   }
 
-  template <typename FeatureType, typename OtherType>
-  typename std::enable_if<has_possible_fit_impl<ModelType, FeatureType>::value, void>::type
-  fit(const OtherType &other) {
-    FeatureType feature = derived().convert_(other);
-    fit(feature);
-  }
-
   /*
    * CRTP Helpers
    */
@@ -37,34 +30,34 @@ public:
   }
 };
 
-template <typename Derived>
-class Middle : public ModelBase<Middle<Derived>> {
-public:
+void middle_fit(const X feature) {
+  std::cout << "middle_fit(X) : " << feature.value << std::endl;
+}
 
-  template <typename T>
-  X convert_(const T &feature) {
-    return derived().convert_(feature);
-  }
+class Middle {
+public:
 
   void fit_(const X &feature) {
     std::cout << "Middle.fit_(X) : " << feature.value << std::endl;
   }
 
-  /*
-   * CRTP Helpers
-   */
-  Derived &derived() { return *static_cast<Derived *>(this); }
-  const Derived &derived() const {
-    return *static_cast<const Derived *>(this);
-  }
 };
 
-class Adapted : public Middle<Adapted> {
+class Adapted : public ModelBase<Adapted> {
 public:
 
-  X convert_(const Y &feature) const {
-    std::cout << "Adapted.convert_(Y) : " << feature.value << std::endl;
-    return {feature.value};
+  void fit_(const X &feature) {
+    std::cout << "Adapted.fit_(X) : " << feature.value << std::endl;
+    middle_fit(feature);
+  }
+
+  X convert_feature(const Y &y) {
+    return {y.value};
+  }
+
+  void fit_(const Y &feature) {
+    std::cout << "Adapted.fit_(Y) : " << feature.value << std::endl;
+    fit_(convert_feature(feature));
   }
 
 };
@@ -81,7 +74,7 @@ int main()
   m.fit(x);
 
   Y y = {2};
-  m.fit<X>(y);
+  m.fit(y);
   // I'd really like to be able to do:
   //  m.fit(y);
 


### PR DESCRIPTION
This PR contains three different options that I've managed to get working each of which allow us to reuse some logic from a different class, effectively inheritance but not always as I'll describe below.

It's probably easiest to start with the first commit, understand it, then look at diffs between the subsequent commits to see what changed.  The summary is:

I want to be able to create a model for some standard algorithm (Gaussian Processes, Least Squares, ...) but I want those models to be extensible.  A good example is probably `LeastSquares`.

```
class LeastSquares : public ModelBase<LeastSquaresRegression> {
public:

  void fit_(const std::vector<Eigen::VectorXd> &features,
                const MarginalDistribution &targets) const {
    // Build the design matrix
    int m = static_cast<int>(features.size());
    int n = static_cast<int>(features[0].size());
    Eigen::MatrixXd A(m, n);
    for (int i = 0; i < m; i++) {
      A.row(i) = features[static_cast<std::size_t>(i)];
    }
    this->model_fit = {least_squares_solver(A, targets.mean)};
  }
}
```
There ^ we have a `LeastSquares` class which when given features which consist of row vectors in a design matrix it can perform least squares to estimate the coefficients.  It uses the CRTP `ModelBase` class (see below) to introduce functionality based on which `fit_` methods are defined.  This `LeastSquares` class is useful if you already have the rows of the design matrix, but often that's not the case and you instead need to build the design matrix from something else.  Take `LinearRegression` as an example,
```
class LinearRegression : public LeastSquares<LinearRegression> {

public:
  Eigen::VectorXd convert_feature(const double &feature) const {
    Eigen::VectorXd converted(2);
    converted << 1., feature;
    return converted;
  }

  void fit_(const std::vector<double> &features,
                    const MarginalDistribution &targets) const {
    std::vector<Eigen::VectorXd> rows;
    for (std::size_t i = 0; i < features.size(); ++i) {
        rows.push_back(convert_feature(features[i]));
    }
    fit_(rows, targets);
  }

}
```
If that worked (which it doesn't) we could then call `fit` which would first convert the features, then use the `LeastSquares` class to produce the fit.

## Question
Now for the question: "How do we best organize CRTP classes to allow for this sort of shared functionality".

Here's a great summary of the problem and a couple options [outlied here](https://www.fluentcpp.com/2018/05/22/how-to-transform-a-hierarchy-of-virtual-methods-into-a-crtp/)

### Option 1: Cascading Inheritance
If `A` is the base class (`ModelBase`), `B` is the middle class (`LeastSquares`) and `C` is the final class (`'LinearRegression`) then we have can do something like:

```
template <typename Derived>
class A {};

template <typename Derived>
class B : public A<B<Derived>> {};

class C : public B<C> {};
```
This approach let's `A` inspect `B` and `B` inspect `C` so we can achieve what we need, but there are a few cons.  This means that `A` is not the sole class in charge of performing CRTP style inspection and extension.  See the link above for an example, but it effectively means that `A` needs to deal with all possible implementations of `B` and `B` needs to deal with all possible implementations of `C`.  This sort of nested structure would make the `LeastSquares` class difficult to implement and would require redundant (and complicated) code shared between a `LeastSquares` class and a `GaussianProcess` class which each wanted to allow for subsequent specialization of which feature types are supported.

See [commit c89563aab3f5](https://github.com/swift-nav/albatross/commit/c89563aab3f57bdf46d6a2abfc79b56c4bcbd0e2).

### Option 2: Transferred Inheritance
In this case we would have:
```
template <typename Derived>
class A {};

template <typename Derived>
class B : public A<Derived> {};

class C : public B<C> {};
```
Note that `B` now inherits from `A<Derived>` not `A<B<Derived>>`.  This is nice because it let's all the CRTP inspection happen inside `A` which now has full access to `Derived`.  The downside is that we loose a bit of safety, having `B` inherit from `A<C>` is a bit strange.  As you can see in the code examples in option 1 I had a safety catch which prevented that sort of (often accidental) inheritance.

See [commit e0414deec34](https://github.com/swift-nav/albatross/commit/e0414deec3477706497e2693e7c6db2ff7eba2b8).

### Option 3:  No inheritance
Avoid inheritance all together.
```
template <typename Derived>
class A {};

class B : public A<B> {};

class C : public A<C> {};
```
Here both `B` and `C` are straight forward CRTP classes.  The plus side here is a much simpler structure, the downside is that if we want `C` to behave like `B` but with some extra functionality it would need to duplicate all functions available in `B`.  If done right that could happen by calling a bunch of free functions ... but it could still involve quite a bit of boiler plate and make the final step in using these models less approachable.

See [commit ae408c85579](https://github.com/swift-nav/albatross/commit/ae408c8557920f86b727be43ba7f37efac4dfbd3)

### Option 4
Any ideas?

## Model Base

The CRTP base class `ModelBase` looks something like:

```
template <typename ModelType> class ModelBase {
private:
  // This is nice to have because it makes sure you don't
  // accidentally do something like:
  //     class A : public ModelBase<B>
  ModelBase() {};
  friend ModelType;

public:

  template <typename FeatureType>
  typename std::enable_if<has_possible_fit_impl<ModelType, FeatureType>::value, void>::type
  fit(const FeatureType &feature) {
    derived().fit_(feature);
  }

  /*
   * CRTP Helpers
   */
  ModelType &derived() { return *static_cast<ModelType *>(this); }
  const ModelType &derived() const {
    return *static_cast<const ModelType *>(this);
  }
};
```