### PR TITLE
ORI-392: Fix compile errors

### DIFF
--- a/albatross/core/declarations.h
+++ b/albatross/core/declarations.h
@@ -32,8 +32,8 @@ namespace albatross {
  * Model
  */
 template <typename FeatureType> class RegressionModel;
-template <typename FeatureType> class RegressionDataset;
-template <typename FeatureType> class RegressionFold;
+template <typename FeatureType> struct RegressionDataset;
+template <typename FeatureType> struct RegressionFold;
 template <typename FeatureType, typename FitType>
 class SerializableRegressionModel;
 
@@ -44,7 +44,7 @@ using RegressionModelCreator =
 /*
  * Distributions
  */
-template <typename CovarianceType> class Distribution;
+template <typename CovarianceType> struct Distribution;
 
 using JointDistribution = Distribution<Eigen::MatrixXd>;
 using DiagonalMatrixXd =


### PR DESCRIPTION
Getting compile errors around the forward declarations and their mismatch between struct and class:

[failure.txt](https://github.com/swift-nav/albatross/files/2903774/failure.txt)

Sync'd up the declarations and compile errors went away.