### PR TITLE
CRTP: ModelBase

### DIFF
--- a/albatross/core/fit_model.h
+++ b/albatross/core/fit_model.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CORE_FIT_H
+#define ALBATROSS_CORE_FIT_H
+
+namespace albatross {
+
+template <typename ModelType, typename Fit>
+class FitModel {
+
+  template <typename X, typename Y, typename Z>
+  friend class Prediction;
+
+ public:
+
+  static_assert(std::is_move_constructible<Fit>::value,
+                "Fit type must be move constructible to avoid unexpected copying.");
+
+  FitModel(const ModelType &model,
+           const Fit &&fit)
+      : model_(model), fit_(std::move(fit)) {}
+
+ public:
+
+  template <typename PredictFeatureType>
+  Prediction<ModelType, PredictFeatureType, Fit>
+  get_prediction(const std::vector<PredictFeatureType> &features) const {
+    return Prediction<ModelType, PredictFeatureType, Fit>(*this, features);
+  }
+
+  const ModelType &model_;
+  const Fit fit_;
+
+};
+
+}
+#endif

--- a/albatross/core/fit_model.h
+++ b/albatross/core/fit_model.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Swift Navigation Inc.
+ * Copyright (C) 2019 Swift Navigation Inc.
  * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must
@@ -10,27 +10,23 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifndef ALBATROSS_CORE_FIT_H
-#define ALBATROSS_CORE_FIT_H
+#ifndef ALBATROSS_CORE_FIT_MODEL_H
+#define ALBATROSS_CORE_FIT_MODEL_H
 
 namespace albatross {
 
 template <typename ModelType, typename Fit>
 class FitModel {
-
+ public:
   template <typename X, typename Y, typename Z>
   friend class Prediction;
-
- public:
 
   static_assert(std::is_move_constructible<Fit>::value,
                 "Fit type must be move constructible to avoid unexpected copying.");
 
   FitModel(const ModelType &model,
-           const Fit &&fit)
+           Fit &&fit)
       : model_(model), fit_(std::move(fit)) {}
-
- public:
 
   template <typename PredictFeatureType>
   Prediction<ModelType, PredictFeatureType, Fit>
@@ -38,7 +34,8 @@ class FitModel {
     return Prediction<ModelType, PredictFeatureType, Fit>(*this, features);
   }
 
-  const ModelType &model_;
+ private:
+  const ModelType model_;
   const Fit fit_;
 
 };

--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -53,7 +53,7 @@ template <typename ModelType> class ModelBase : public ParameterHandlingMixin {
   auto
   fit_(const std::vector<FeatureType> &features,
        const MarginalDistribution &targets) const {
-    const auto fit = derived().fit(features, targets);
+    auto fit = derived().fit(features, targets);
     return FitModel<ModelType, decltype(fit)>(derived(), std::move(fit));
   }
 

--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -13,266 +13,110 @@
 #ifndef ALBATROSS_CORE_MODEL_H
 #define ALBATROSS_CORE_MODEL_H
 
-#include "core/dataset.h"
-#include "core/indexing.h"
-#include "core/parameter_handling_mixin.h"
-#include "map_utils.h"
-#include "traits.h"
-#include <Eigen/Core>
-#include <cereal/archives/json.hpp>
-#include <map>
-#include <vector>
-
 namespace albatross {
 
-namespace detail {
-// This is effectively just a container that allows us to develop methods
-// which behave different conditional on the type of predictions desired.
-template <typename T> struct PredictTypeIdentity { typedef T type; };
-}
-
-// This can be used to make intentions more obvious when calling
-// predict variants for which you only want the mean.
-using PredictMeanOnly = Eigen::VectorXd;
 
 using Insights = std::map<std::string, std::string>;
 
-/*
- * A model that uses a single Feature to estimate the value of a double typed
- * target.
- */
-template <typename FeatureType>
-class RegressionModel : public ParameterHandlingMixin {
-public:
-  using Feature = FeatureType;
-  RegressionModel() : ParameterHandlingMixin(), has_been_fit_(){};
-  virtual ~RegressionModel(){};
+template <typename ModelType> class ModelBase : public ParameterHandlingMixin {
 
-  virtual bool operator==(const RegressionModel<FeatureType> &other) const {
-    // If the fit method has been called it's possible that some unknown
-    // class members may have been modified.  As such, if a model has been
-    // fit we fail hard to avoid possibly unexpected behavior.  Any
-    // implementation that wants a functional equality operator after
-    // having been fit will need to override this one.
-    assert(!has_been_fit());
-    return (get_name() == other.get_name() &&
-            get_params() == other.get_params() &&
-            has_been_fit() == other.has_been_fit());
-  }
+  template <typename X, typename Y, typename Z>
+  friend class Prediction;
 
-  /*
-   * Provides a wrapper around the implementation `fit_` which performs
-   * simple size checks and makes sure the fit method is called before
-   * predict.
-   */
-  void fit(const std::vector<FeatureType> &features,
-           const MarginalDistribution &targets) {
-    assert(features.size() > 0);
-    assert(features.size() == static_cast<std::size_t>(targets.size()));
-    has_been_fit_ = true;
-    insights_["input_feature_count"] = std::to_string(features.size());
-    fit_(features, targets);
-  }
+  template <typename T, typename FeatureType>
+  friend class fit_model_type;
 
-  /*
-   * Convenience function which assumes zero target covariance.
-   */
-  void fit(const std::vector<FeatureType> &features,
-           const Eigen::VectorXd &targets) {
-    return fit(features, MarginalDistribution(targets));
-  }
+  template <typename T, typename FitModelType>
+  friend struct fit_type_from_fit_model_type;
 
-  /*
-   * Convenience function which unpacks a dataset into features and targets.
-   */
-  void fit(const RegressionDataset<FeatureType> &dataset) {
-    return fit(dataset.features, dataset.targets);
-  }
+  template <typename T, typename FeatureType>
+  friend struct fit_type;
 
-  /*
-   * Similar to fit, this predict methods wrap the implementation `predict_*_`
-   * and makes simple checks to confirm the implementation is returning
-   * properly sized Distribution.
-   */
-  template <typename PredictType = JointDistribution>
-  PredictType predict(const std::vector<FeatureType> &features) const {
-    return predict(features, detail::PredictTypeIdentity<PredictType>());
-  }
-
-  template <typename PredictType = JointDistribution>
-  PredictType predict(const FeatureType &feature) const {
-    std::vector<FeatureType> features = {feature};
-    return predict<PredictType>(features);
-  }
-
-  template <typename PredictType = MarginalDistribution>
-  std::vector<PredictType>
-  cross_validated_predictions(const RegressionDataset<FeatureType> &dataset,
-                              const FoldIndexer &fold_indexer) {
-    return cross_validated_predictions_(
-        dataset, fold_indexer, detail::PredictTypeIdentity<PredictType>());
-  }
-
-  // Because cross validation can never properly produce a full
-  // joint distribution it is common to only use the marginal
-  // predictions, hence the different default from predict.
-  template <typename PredictType = MarginalDistribution>
-  std::vector<PredictType> cross_validated_predictions(
-      const std::vector<RegressionFold<FeatureType>> &folds) {
-    // Iteratively make predictions and assemble the output vector
-    std::vector<PredictType> predictions;
-    for (std::size_t i = 0; i < folds.size(); i++) {
-      fit(folds[i].train_dataset);
-      predictions.push_back(
-          predict<PredictType>(folds[i].test_dataset.features));
-    }
-    return predictions;
-  }
-
-  std::string pretty_string() const {
-    std::ostringstream ss;
-    ss << get_name() << std::endl;
-    ss << ParameterHandlingMixin::pretty_string();
-    return ss.str();
-  }
-
-  virtual bool has_been_fit() const { return has_been_fit_; }
-
-  virtual std::string get_name() const = 0;
-
-  virtual Insights get_insights() const { return insights_; }
-
-  virtual void add_insights(const Insights &insights) {
-    for (const auto &insight : insights) {
-      insights_[insight.first] = insight.second;
-    }
-  };
-
-  virtual std::unique_ptr<RegressionModel<FeatureType>>
-  ransac_model(double inlier_threshold, std::size_t min_inliers,
-               std::size_t random_sample_size, std::size_t max_iterations) {
-    static_assert(
-        is_complete<GenericRansac<void, FeatureType>>::value,
-        "ransac methods aren't complete yet, be sure you've included ransac.h");
-    return make_generic_ransac_model<FeatureType>(
-        this, inlier_threshold, min_inliers, random_sample_size, max_iterations,
-        leave_one_out_indexer<FeatureType>);
-  }
-
-  /*
-   * Here we define the serialization routines.  Note that while in most
-   * cases we could use the cereal method `serialize`, in this case we don't
-   * know for sure where the parameters are stored.  The
-   * GaussianProcessRegression
-   * model, for example, derives its parameters from its covariance function,
-   * so it's `params_` are actually empty.  As a result we need to use the
-   * save/load cereal variant and deal with parameters through the get/set
-   * interface.
-   */
-  template <class Archive> void save(Archive &archive) const {
-    auto params = get_params();
-    archive(cereal::make_nvp("parameters", params));
-    archive(cereal::make_nvp("has_been_fit", has_been_fit_));
-  }
-
-  template <class Archive> void load(Archive &archive) {
-    auto params = get_params();
-    archive(cereal::make_nvp("parameters", params));
-    archive(cereal::make_nvp("has_been_fit", has_been_fit_));
-    set_params(params);
-  }
-
-protected:
-  virtual void fit_(const std::vector<FeatureType> &features,
-                    const MarginalDistribution &targets) = 0;
-  /*
-   * Predict specializations
-   */
-
-  JointDistribution
-  predict(const std::vector<FeatureType> &features,
-          detail::PredictTypeIdentity<JointDistribution> &&) const {
-    assert(has_been_fit());
-    JointDistribution preds = predict_(features);
-    assert(static_cast<std::size_t>(preds.mean.size()) == features.size());
-    return preds;
-  }
-
-  MarginalDistribution
-  predict(const std::vector<FeatureType> &features,
-          detail::PredictTypeIdentity<MarginalDistribution> &&) const {
-    assert(has_been_fit());
-    MarginalDistribution preds = predict_marginal_(features);
-    assert(static_cast<std::size_t>(preds.mean.size()) == features.size());
-    return preds;
-  }
-
-  Eigen::VectorXd
-  predict(const std::vector<FeatureType> &features,
-          detail::PredictTypeIdentity<Eigen::VectorXd> &&) const {
-    assert(has_been_fit());
-    Eigen::VectorXd preds = predict_mean_(features);
-    assert(static_cast<std::size_t>(preds.size()) == features.size());
-    return preds;
-  }
-
-  /*
-   * Cross validation specializations
-   *
-   * Note the naming here uses a trailing underscore.  This is to avoid
-   * name hiding when implementing one of these methods in a derived
-   * class:
-   *
-   * https://stackoverflow.com/questions/1628768/why-does-an-overridden-function-in-the-derived-class-hide-other-overloads-of-the
-   */
-  virtual std::vector<JointDistribution> cross_validated_predictions_(
-      const RegressionDataset<FeatureType> &dataset,
-      const FoldIndexer &fold_indexer,
-      const detail::PredictTypeIdentity<JointDistribution> &) {
-    const auto folds = folds_from_fold_indexer(dataset, fold_indexer);
-    return cross_validated_predictions<JointDistribution>(folds);
-  }
-
-  virtual std::vector<MarginalDistribution> cross_validated_predictions_(
-      const RegressionDataset<FeatureType> &dataset,
-      const FoldIndexer &fold_indexer,
-      const detail::PredictTypeIdentity<MarginalDistribution> &) {
-    const auto folds = folds_from_fold_indexer(dataset, fold_indexer);
-    return cross_validated_predictions<MarginalDistribution>(folds);
-  }
-
-  virtual std::vector<Eigen::VectorXd> cross_validated_predictions_(
-      const RegressionDataset<FeatureType> &dataset,
-      const FoldIndexer &fold_indexer,
-      const detail::PredictTypeIdentity<PredictMeanOnly> &) {
-    const auto folds = folds_from_fold_indexer(dataset, fold_indexer);
-    return cross_validated_predictions<PredictMeanOnly>(folds);
-  }
-
-  virtual JointDistribution
-  predict_(const std::vector<FeatureType> &features) const = 0;
-
-  virtual MarginalDistribution
-  predict_marginal_(const std::vector<FeatureType> &features) const {
-    const auto full_distribution = predict_(features);
-    return MarginalDistribution(
-        full_distribution.mean,
-        full_distribution.covariance.diagonal().asDiagonal());
-  }
-
-  virtual Eigen::VectorXd
-  predict_mean_(const std::vector<FeatureType> &features) const {
-    const auto marginal_distribution = predict_marginal_(features);
-    return marginal_distribution.mean;
-  }
-
-  bool has_been_fit_;
+ private:
+  // Declaring these private makes it impossible to accidentally do things like:
+  //     class A : public ModelBase<B> {}
+  // or
+  //     using A = ModelBase<B>;
+  //
+  // which if unchecked can lead to some very strange behavior.
+  ModelBase() : insights_(){};
+  friend ModelType;
   Insights insights_;
+
+  /*
+   * Fit
+   */
+  template <
+      typename FeatureType,
+      typename std::enable_if<has_valid_fit<ModelType, FeatureType>::value,
+                              int>::type = 0>
+  auto
+  fit_(const std::vector<FeatureType> &features,
+       const MarginalDistribution &targets) const {
+    const auto fit = derived().fit(features, targets);
+    return FitModel<ModelType, decltype(fit)>(derived(), std::move(fit));
+  }
+
+  template <typename FeatureType,
+            typename std::enable_if<
+                    has_possible_fit<ModelType, FeatureType>::value &&
+                    !has_valid_fit<ModelType, FeatureType>::value,
+                int>::type = 0>
+  FitModel<ModelType, FeatureType>
+  fit_(const std::vector<FeatureType> &features,
+      const MarginalDistribution &targets) const = delete; // Invalid fit_impl_
+
+  template <typename FeatureType,
+            typename std::enable_if<
+                    !has_possible_fit<ModelType, FeatureType>::value &&
+                    !has_valid_fit<ModelType, FeatureType>::value,
+                int>::type = 0>
+  FitModel<ModelType, FeatureType>
+  fit_(const std::vector<FeatureType> &features,
+      const MarginalDistribution &targets) const = delete; // No fit_impl_ found.
+
+  template <typename PredictFeatureType, typename FitType, typename PredictType,
+            typename std::enable_if<
+                       has_valid_predict<ModelType, PredictFeatureType, FitType, PredictType>::value,
+                 int>::type = 0>
+  PredictType predict_(const std::vector<PredictFeatureType> &features,
+                       const FitType &fit,
+                       PredictTypeIdentity<PredictType> &&) const {
+    return derived().predict(features, fit, PredictTypeIdentity<PredictType>());
+  }
+
+  template <typename PredictFeatureType, typename FitType, typename PredictType,
+            typename std::enable_if<
+                       !has_valid_predict<ModelType, PredictFeatureType, FitType, PredictType>::value,
+                 int>::type = 0>
+  PredictType predict_(const std::vector<PredictFeatureType> &features,
+                       const FitType &fit,
+                       PredictTypeIdentity<PredictType> &&) const = delete; // No valid predict.
+
+  /*
+   * CRTP Helpers
+   */
+  ModelType &derived() { return *static_cast<ModelType *>(this); }
+  const ModelType &derived() const {
+    return *static_cast<const ModelType *>(this);
+  }
+
+public:
+
+  template <typename FeatureType>
+  auto
+  get_fit_model(const std::vector<FeatureType> &features,
+            const MarginalDistribution &targets) const {
+    return fit_(features, targets);
+  }
+
+  template <typename FeatureType>
+  auto
+  get_fit_model(const RegressionDataset<FeatureType> &dataset) const {
+    return fit_(dataset.features, dataset.targets);
+  }
+
 };
 
-template <typename FeatureType>
-using RegressionModelCreator =
-    std::function<std::unique_ptr<RegressionModel<FeatureType>>()>;
-} // namespace albatross
-
+}
 #endif

--- a/albatross/core/prediction.h
+++ b/albatross/core/prediction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Swift Navigation Inc.
+ * Copyright (C) 2019 Swift Navigation Inc.
  * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must

--- a/albatross/core/prediction.h
+++ b/albatross/core/prediction.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CORE_PREDICTION_H
+#define ALBATROSS_CORE_PREDICTION_H
+
+namespace albatross {
+
+// This is effectively just a container that allows us to develop methods
+// which behave different conditional on the type of predictions desired.
+template <typename T> struct PredictTypeIdentity { typedef T type; };
+
+template <typename ModelType, typename FeatureType, typename FitType>
+class Prediction {
+
+public:
+  Prediction(const FitModel<ModelType, FitType> &fit_model,
+             const std::vector<FeatureType> &features)
+      : fit_model_(fit_model), features_(features) {}
+
+  /*
+   * MEAN
+   */
+  template <
+      typename DummyType = FeatureType,
+      typename std::enable_if<
+          has_valid_predict_mean<ModelType, DummyType, FitType>::value, int>::type = 0>
+  Eigen::VectorXd mean() const {
+    static_assert(std::is_same<DummyType, FeatureType>::value,
+                  "never do prediction.mean<T>()");
+    return fit_model_.model_.predict_(features_, fit_model_.fit_, PredictTypeIdentity<Eigen::VectorXd>());
+  }
+
+  template <typename DummyType = FeatureType,
+            typename std::enable_if<
+                !has_valid_predict_mean<ModelType, DummyType, FitType>::value &&
+                 has_valid_predict_marginal<ModelType, DummyType, FitType>::value,
+                int>::type = 0>
+  Eigen::VectorXd mean() const {
+    static_assert(std::is_same<DummyType, FeatureType>::value,
+                  "never do prediction.mean<T>()");
+    return fit_model_.model_.predict_(features_, fit_model_.fit_, PredictTypeIdentity<MarginalDistribution>())
+        .mean;
+  }
+
+  template <typename DummyType = FeatureType,
+            typename std::enable_if<
+                !has_valid_predict_mean<ModelType, DummyType, FitType>::value &&
+                    !has_valid_predict_marginal<ModelType, DummyType, FitType>::value &&
+                    has_valid_predict_joint<ModelType, DummyType, FitType>::value,
+                int>::type = 0>
+  Eigen::VectorXd mean() const {
+    static_assert(std::is_same<DummyType, FeatureType>::value,
+                  "never do prediction.mean<T>()");
+    return fit_model_.model_.predict_(features_, fit_model_.fit_, PredictTypeIdentity<JointDistribution>())
+        .mean;
+  }
+
+  /*
+   * MARGINAL
+   */
+  template <typename DummyType = FeatureType,
+            typename std::enable_if<
+                has_valid_predict_marginal<ModelType, DummyType, FitType>::value,
+                int>::type = 0>
+  MarginalDistribution marginal() const {
+    static_assert(std::is_same<DummyType, FeatureType>::value,
+                  "never do prediction.marginal<T>()");
+    return fit_model_.model_.predict_(features_,
+                                      fit_model_.fit_,
+                           PredictTypeIdentity<MarginalDistribution>());
+  }
+
+  template <typename DummyType = FeatureType,
+            typename std::enable_if<
+                !has_valid_predict_marginal<ModelType, DummyType, FitType>::value &&
+                    has_valid_predict_joint<ModelType, DummyType, FitType>::value,
+                int>::type = 0>
+  MarginalDistribution marginal() const {
+    static_assert(std::is_same<DummyType, FeatureType>::value,
+                  "never do prediction.marginal<T>()");
+    const auto joint_pred =
+        fit_model_.model_.predict_(features_, fit_model_.fit_, PredictTypeIdentity<JointDistribution>());
+    if (joint_pred.has_covariance()) {
+      Eigen::VectorXd diag = joint_pred.covariance.diagonal();
+      return MarginalDistribution(joint_pred.mean, diag.asDiagonal());
+    } else {
+      return MarginalDistribution(joint_pred.mean);
+    }
+  }
+
+  /*
+   * JOINT
+   */
+  template <
+      typename DummyType = FeatureType,
+      typename std::enable_if<
+          has_valid_predict_joint<ModelType, DummyType, FitType>::value, int>::type = 0>
+  JointDistribution joint() const {
+    static_assert(std::is_same<DummyType, FeatureType>::value,
+                  "never do prediction.joint<T>()");
+    return fit_model_.model_.predict_(features_, fit_model_.fit_, PredictTypeIdentity<JointDistribution>());
+  }
+
+  /*
+   * CATCH FAILURE MODES
+   */
+  template <typename DummyType = FeatureType,
+            typename std::enable_if<
+                !has_valid_predict_mean<ModelType, DummyType, FitType>::value &&
+                    !has_valid_predict_marginal<ModelType, DummyType, FitType>::value &&
+                    !has_valid_predict_joint<ModelType, DummyType, FitType>::value,
+                int>::type = 0>
+  Eigen::VectorXd mean() const = delete; // No valid predict method found.
+
+  template <typename DummyType = FeatureType,
+            typename std::enable_if<
+                    !has_valid_predict_marginal<ModelType, DummyType, FitType>::value &&
+                    !has_valid_predict_joint<ModelType, DummyType, FitType>::value,
+                int>::type = 0>
+  Eigen::VectorXd marginal() const = delete; // No valid predict marginal method found.
+
+  template <typename DummyType = FeatureType,
+            typename std::enable_if<
+                    !has_valid_predict_joint<ModelType, DummyType, FitType>::value,
+                int>::type = 0>
+  Eigen::VectorXd joint() const = delete; // No valid predict joint method found.
+
+private:
+  const FitModel<ModelType, FitType> &fit_model_;
+  const std::vector<FeatureType> &features_;
+};
+
+}
+#endif

--- a/albatross/models/least_squares.h
+++ b/albatross/models/least_squares.h
@@ -13,21 +13,15 @@
 #ifndef ALBATROSS_MODELS_LEAST_SQUARES_H
 #define ALBATROSS_MODELS_LEAST_SQUARES_H
 
-#include "core/model_adapter.h"
-#include "core/serialize.h"
-#include <Eigen/Dense>
-#include <cmath>
-#include <gtest/gtest.h>
-#include <iostream>
-#include <random>
-
 namespace albatross {
 
-struct LeastSquaresFit {
+template <typename ImplType> class LeastSquares;
+
+template <typename ImplType> struct Fit<LeastSquares<ImplType>> {
   Eigen::VectorXd coefs;
 
-  bool operator==(const LeastSquaresFit &other) const {
-    return coefs == other.coefs;
+  bool operator==(const Fit &other) const {
+    return (coefs == other.coefs);
   }
 
   template <typename Archive> void serialize(Archive &archive) {
@@ -36,22 +30,22 @@ struct LeastSquaresFit {
 };
 
 /*
- * This model supports a family of RegressionModels which consist of
+ * This model supports a family of models which consist of
  * first creating a design matrix, A, then solving least squares.  Ie,
  *
  *   min_x |y - Ax|_2^2
  *
  * The FeatureType in this case is a single row from the design matrix.
  */
-class LeastSquaresRegression
-    : public SerializableRegressionModel<Eigen::VectorXd, LeastSquaresFit> {
+template <typename ImplType>
+class LeastSquares : public ModelBase<LeastSquares<ImplType>> {
 public:
-  LeastSquaresRegression(){};
-  std::string get_name() const override { return "least_squares"; };
+  using FitType = Fit<LeastSquares<ImplType>>;
 
-  LeastSquaresFit
-  serializable_fit_(const std::vector<Eigen::VectorXd> &features,
-                    const MarginalDistribution &targets) const override {
+  //  std::string get_name() const override { return "least_squares"; };
+
+  FitType fit(const std::vector<Eigen::VectorXd> &features,
+              const MarginalDistribution &targets) const {
     // The way this is currently implemented we assume all targets have the same
     // variance (or zero variance).
     assert(!targets.has_covariance());
@@ -62,36 +56,56 @@ public:
     for (int i = 0; i < m; i++) {
       A.row(i) = features[static_cast<std::size_t>(i)];
     }
-    // Solve for the coefficients using the QR decomposition.
-    LeastSquaresFit model_fit = {least_squares_solver(A, targets.mean)};
+
+    FitType model_fit = {least_squares_solver(A, targets.mean)};
     return model_fit;
   }
 
-protected:
-  Eigen::VectorXd
-  predict_mean_(const std::vector<Eigen::VectorXd> &features) const override {
+  template <typename FeatureType,
+            typename std::enable_if<
+                   has_valid_fit<ImplType, FeatureType>::value,
+                int>::type = 0>
+  FitType fit(const std::vector<FeatureType> &features,
+                    const MarginalDistribution &targets) const {
+    return impl().fit(features, targets);
+  }
+
+  JointDistribution predict(const std::vector<Eigen::VectorXd> &features,
+                            const FitType &least_squares_fit,
+                            PredictTypeIdentity<JointDistribution> &&) const {
     std::size_t n = features.size();
     Eigen::VectorXd mean(n);
     for (std::size_t i = 0; i < n; i++) {
       mean(static_cast<Eigen::Index>(i)) =
-          features[i].dot(this->model_fit_.coefs);
+          features[i].dot(least_squares_fit.coefs);
     }
-    return mean;
+    return JointDistribution(mean);
   }
 
-  JointDistribution
-  predict_(const std::vector<Eigen::VectorXd> &features) const override {
-    return JointDistribution(predict_mean_(features));
+  template <typename FeatureType, typename FitType, typename PredictType,
+            typename std::enable_if<
+                has_valid_predict<ImplType, FeatureType, FitType, PredictType>::value,
+                int>::type = 0>
+  PredictType predict(const std::vector<FeatureType> &features,
+                      const FitType &least_squares_fit,
+                      PredictTypeIdentity<PredictType> &&) const {
+    return impl().predict(features, least_squares_fit, PredictTypeIdentity<PredictType>());
   }
 
   /*
    * This lets you customize the least squares approach if need be,
    * default uses the QR decomposition.
    */
-  virtual Eigen::VectorXd least_squares_solver(const Eigen::MatrixXd &A,
-                                               const Eigen::VectorXd &b) const {
+  Eigen::VectorXd least_squares_solver(const Eigen::MatrixXd &A,
+                                       const Eigen::VectorXd &b) const {
     return A.colPivHouseholderQr().solve(b);
   }
+
+  /*
+   * CRTP Helpers
+   */
+  ImplType &impl() { return *static_cast<ImplType *>(this); }
+  const ImplType &impl() const { return *static_cast<const ImplType *>(this); }
 };
 
 /*
@@ -103,19 +117,40 @@ protected:
  * Setup like this the resulting least squares solve will represent
  * an offset and slope.
  */
-using LinearRegressionBase =
-    AdaptedRegressionModel<double, LeastSquaresRegression>;
-
-class LinearRegression : public LinearRegressionBase {
+class LinearRegression : public LeastSquares<LinearRegression> {
 
 public:
-  LinearRegression(){};
-  std::string get_name() const override { return "linear_regression"; };
+  //  std::string get_name() const { return "linear_regression"; };
 
-  Eigen::VectorXd convert_feature(const double &x) const override {
+  using Base = LeastSquares<LinearRegression>;
+
+  Eigen::VectorXd convert_feature(const double &f) const {
     Eigen::VectorXd converted(2);
-    converted << 1., x;
+    converted << 1., f;
     return converted;
+  }
+
+  std::vector<Eigen::VectorXd>
+  convert_features(const std::vector<double> &features) const {
+    std::vector<Eigen::VectorXd> output;
+    for (const auto &f : features) {
+      output.emplace_back(convert_feature(f));
+    }
+    return output;
+  }
+
+  Base::FitType fit(const std::vector<double> &features,
+           const MarginalDistribution &targets) const {
+    return Base::fit(convert_features(features),
+                     targets);
+  }
+
+  JointDistribution predict(const std::vector<double> &features,
+               const Base::FitType &least_squares_fit,
+               PredictTypeIdentity<JointDistribution> &&) const {
+    return Base::predict(convert_features(features),
+                         least_squares_fit,
+                         PredictTypeIdentity<JointDistribution>());
   }
 
   /*
@@ -124,18 +159,18 @@ public:
    * through the use of `base_class` we can make use of cereal's
    * polymorphic serialization.
    */
-  template <class Archive> void save(Archive &archive) const {
-    archive(cereal::make_nvp("linear_regression",
-                             cereal::base_class<LinearRegressionBase>(this)));
-  }
-
-  template <class Archive> void load(Archive &archive) {
-    archive(cereal::make_nvp("linear_regression",
-                             cereal::base_class<LinearRegressionBase>(this)));
-  }
+  //  template <class Archive> void save(Archive &archive) const {
+  //    archive(cereal::make_nvp("linear_regression",
+  //                             cereal::base_class<LinearRegressionBase>(this)));
+  //  }
+  //
+  //  template <class Archive> void load(Archive &archive) {
+  //    archive(cereal::make_nvp("linear_regression",
+  //                             cereal::base_class<LinearRegressionBase>(this)));
+  //  }
 };
 } // namespace albatross
 
-CEREAL_REGISTER_TYPE(albatross::LinearRegression);
+// CEREAL_REGISTER_TYPE(albatross::LinearRegression);
 
 #endif

--- a/albatross/models/least_squares.h
+++ b/albatross/models/least_squares.h
@@ -42,8 +42,6 @@ class LeastSquares : public ModelBase<LeastSquares<ImplType>> {
 public:
   using FitType = Fit<LeastSquares<ImplType>>;
 
-  //  std::string get_name() const override { return "least_squares"; };
-
   FitType fit(const std::vector<Eigen::VectorXd> &features,
               const MarginalDistribution &targets) const {
     // The way this is currently implemented we assume all targets have the same
@@ -120,8 +118,6 @@ public:
 class LinearRegression : public LeastSquares<LinearRegression> {
 
 public:
-  //  std::string get_name() const { return "linear_regression"; };
-
   using Base = LeastSquares<LinearRegression>;
 
   Eigen::VectorXd convert_feature(const double &f) const {
@@ -153,21 +149,6 @@ public:
                          PredictTypeIdentity<JointDistribution>());
   }
 
-  /*
-   * save/load methods are inherited from the SerializableRegressionModel,
-   * but by defining them here and explicitly showing the inheritence
-   * through the use of `base_class` we can make use of cereal's
-   * polymorphic serialization.
-   */
-  //  template <class Archive> void save(Archive &archive) const {
-  //    archive(cereal::make_nvp("linear_regression",
-  //                             cereal::base_class<LinearRegressionBase>(this)));
-  //  }
-  //
-  //  template <class Archive> void load(Archive &archive) {
-  //    archive(cereal::make_nvp("linear_regression",
-  //                             cereal::base_class<LinearRegressionBase>(this)));
-  //  }
 };
 } // namespace albatross
 

--- a/tests/mock_model.h
+++ b/tests/mock_model.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_TESTS_MOCK_MODEL_H
+#define ALBATROSS_TESTS_MOCK_MODEL_H
+
+namespace albatross {
+
+class MockModel;
+
+// A simple predictor which is effectively just an integer.
+struct MockFeature {
+  int value;
+
+  MockFeature() : value(){};
+  MockFeature(int v) : value(v){};
+
+  bool operator==(const MockFeature &other) const {
+    return value == other.value;
+  };
+
+  template <class Archive> void serialize(Archive &archive) {
+    archive(cereal::make_nvp("value", value));
+  }
+};
+
+struct ContainsMockFeature {
+  MockFeature mock;
+};
+
+template <>
+struct Fit<MockModel> {
+  std::map<int, double> train_data;
+
+  template <class Archive> void serialize(Archive &ar) {
+    ar(cereal::make_nvp("train_data", train_data));
+  };
+
+  bool operator==(const Fit &other) const {
+    return train_data == other.train_data;
+  };
+};
+
+/*
+ * A simple model which builds a map from MockPredict (aka, int)
+ * to a double value.
+ */
+class MockModel : public ModelBase<MockModel> {
+public:
+  ALBATROSS_DECLARE_PARAMS(foo, bar);
+
+  MockModel(double foo_ = 3.14159, double bar_ = sqrt(2.)) {
+    this->foo = {foo_, std::make_shared<GaussianPrior>(3., 2.)};
+    this->bar = {bar_, std::make_shared<PositivePrior>()};
+  };
+
+  //  std::string get_name() const override { return "mock_model"; };
+
+  //  template <typename Archive> void save(Archive &archive) const {
+  //    archive(
+  //        cereal::base_class<SerializableRegressionModel<MockFeature,
+  //        MockFit>>(
+  //            this));
+  //  }
+  //
+  //  template <typename Archive> void load(Archive &archive) {
+  //    archive(
+  //        cereal::base_class<SerializableRegressionModel<MockFeature,
+  //        MockFit>>(
+  //            this));
+  //  }
+
+  Fit<MockModel> fit(const std::vector<MockFeature> &features,
+                     const MarginalDistribution &targets) const {
+    int n = static_cast<int>(features.size());
+    Eigen::VectorXd predictions(n);
+    Fit<MockModel> model_fit;
+    for (int i = 0; i < n; i++) {
+      model_fit.train_data[features[static_cast<std::size_t>(i)].value] =
+          targets.mean[i];
+    }
+    return model_fit;
+  }
+
+  // looks up the prediction in the map
+  Eigen::VectorXd predict(const std::vector<MockFeature> &features,
+                          const Fit<MockModel> &fit,
+                          PredictTypeIdentity<Eigen::VectorXd> &&) const {
+    int n = static_cast<int>(features.size());
+    Eigen::VectorXd predictions(n);
+
+    for (int i = 0; i < n; i++) {
+      int index = features[static_cast<std::size_t>(i)].value;
+      predictions[i] = fit.train_data.find(index)->second;
+    }
+
+    return predictions;
+  }
+
+  // convert before predicting
+  Eigen::VectorXd predict(const std::vector<ContainsMockFeature> &features,
+                          const Fit<MockModel> &fit,
+                          PredictTypeIdentity<Eigen::VectorXd> &&) const {
+    std::vector<MockFeature> mock_features;
+    for (const auto &f : features) {
+      mock_features.push_back(f.mock);
+    }
+    return predict(mock_features, fit, PredictTypeIdentity<Eigen::VectorXd>());
+  }
+};
+
+static inline RegressionDataset<MockFeature>
+mock_training_data(const int n = 10) {
+  std::vector<MockFeature> features;
+  Eigen::VectorXd targets(n);
+  for (int i = 0; i < n; i++) {
+    features.push_back(MockFeature(i));
+    targets[i] = static_cast<double>(i + n);
+  }
+  return RegressionDataset<MockFeature>(features, targets);
+}
+}
+
+#endif


### PR DESCRIPTION
This change replaces the `RegressionModel<FeatureType` virtual inheritance approach with a CRTP style `ModelBase<ModelType>` approach.

This is absolutely not going to pass tests and may contain declarations to parts of the implementation that don't exist yet.  But should give a representative idea of the changes.

My general philosophy on this process is that I'd like to make a first pass through this refactor which will let us successfully reproduce all the existing behavior in `albatross`.  I'd then like to (re)integrate it with our projects and then loop back and put some finishing touches and/or extend functionality in a second pass.  I'll break the first pass into smallish commits (like this one) in which I'm primarily hoping to avoid some design decisions that could lead to dead ends or add tech debt without focusing so much on edge cases.

A top level summary is this.  With the existing version of `albatross` models could be used along these lines:
```
template <typename FeatureType>
void print_mean_prediction(RegressionModel<FeatureType> &model,
                                             RegressionDataset<FeatureType> &dataset) {
    model.fit(dataset);
    const auto pred = model.template predict<MarginalDistribution>(dataset.features);
    std::cout << pred.mean.norm() << std::endl;
}
```
You would now do:
```
template <typename FeatureType, typename ModelType>
void print_mean_prediction(ModelBase<ModelType> &model,
                                             RegressionDataset<FeatureType> &dataset) {
    const auto fit_model = model.get_fit_model(dataset);
    const auto pred = get_prediction(dataset.features).marginal();
    std::cout << pred.mean.norm() << std::endl;
}
```
I would recommend glancing at `ModelBase` first to get a sense of how that's wired together, then looking at how it was used in `LeastSquares` and subsequently extended in `LinearRegression`.