### PR TITLE
CRTP: Traits

### DIFF
--- a/albatross/cereal/traits.h
+++ b/albatross/cereal/traits.h
@@ -18,7 +18,7 @@
 namespace albatross {
 
 /*
- * This little trick was borrowed from cereal, you an think of it as
+ * This little trick was borrowed from cereal, you can think of it as
  * a function that will always return false ... but that doesn't
  * get resolved until template instantiation, which when combined
  * with a static assert let's you include a static assert that

--- a/albatross/cereal/traits.h
+++ b/albatross/cereal/traits.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CEREAL_TRAITS_H
+#define ALBATROSS_CEREAL_TRAITS_H
+
+#include "cereal/details/traits.hpp"
+
+namespace albatross {
+
+/*
+ * This little trick was borrowed from cereal, you an think of it as
+ * a function that will always return false ... but that doesn't
+ * get resolved until template instantiation, which when combined
+ * with a static assert let's you include a static assert that
+ * only triggers with a particular template parameter is used.
+ */
+template <class T> struct delay_static_assert : std::false_type {};
+
+/*
+ * The following helper functions let you inspect a type and cereal Archive
+ * and determine if the type has a valid serialization method for that Archive
+ * type.
+ */
+template <typename X, typename Archive> class valid_output_serializer {
+  template <typename T>
+  static typename std::enable_if<
+      1 == cereal::traits::detail::count_output_serializers<T, Archive>::value,
+      std::true_type>::type
+  test(int);
+  template <typename T> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<X>(0))::value;
+};
+
+template <typename X, typename Archive> class valid_input_serializer {
+  template <typename T>
+  static typename std::enable_if<
+      1 == cereal::traits::detail::count_input_serializers<T, Archive>::value,
+      std::true_type>::type
+  test(int);
+  template <typename T> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<X>(0))::value;
+};
+
+template <typename X, typename Archive> class valid_in_out_serializer {
+  template <typename T>
+  static typename std::enable_if<valid_input_serializer<T, Archive>::value &&
+                                     valid_output_serializer<T, Archive>::value,
+                                 std::true_type>::type
+  test(int);
+  template <typename T> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<X>(0))::value;
+};
+}
+
+#endif

--- a/albatross/core/traits.h
+++ b/albatross/core/traits.h
@@ -13,218 +13,7 @@
 #ifndef ALBATROSS_CORE_TRAITS_H
 #define ALBATROSS_CORE_TRAITS_H
 
-#include "cereal/details/traits.hpp"
-#include "core/declarations.h"
-#include <utility>
-
 namespace albatross {
-
-/*
- * This little trick was borrowed from cereal, you an think of it as
- * a function that will always return false ... but that doesn't
- * get resolved until template instantiation, which when combined
- * with a static assert let's you include a static assert that
- * only triggers with a particular template parameter is used.
- */
-template <class T> struct delay_static_assert : std::false_type {};
-
-/*
- * In CovarianceFunction we frequently inspect for definitions of
- * call_impl_ which MUST be defined for const references to objects
- * (so that repeated covariance matrix evaluations return the same thing
- *  and so the computations are not repeatedly copying.)
- * This type conversion utility will turn a type `T` into `const T&`
- */
-template <class T> struct call_impl_arg_type {
-  typedef
-      typename std::add_lvalue_reference<typename std::add_const<T>::type>::type
-          type;
-};
-
-/*
- * This determines whether or not a class has a method defined for,
- *   `operator() (const X &x, const Y &y, const Z &z, ...)`
- * The result of the inspection gets stored in the member `value`.
- */
-template <typename T, typename... Args> class has_call_operator {
-
-  template <typename C,
-            typename = decltype(std::declval<C>()(
-                std::declval<typename call_impl_arg_type<Args>::type>()...))>
-  static std::true_type test(C *);
-  template <typename> static std::false_type test(...);
-
-public:
-  static constexpr bool value = decltype(test<T>(0))::value;
-};
-
-/*
- * This determines whether or not a class has a method defined for,
- *   `double call_impl_(const X &x, const Y &y, const Z &z, ...)`
- * The result of the inspection gets stored in the member `value`.
- */
-template <typename T, typename... Args> class has_valid_call_impl {
-
-  template <typename C>
-  static typename std::is_same<
-      decltype(std::declval<const C>().call_impl_(
-          std::declval<typename call_impl_arg_type<Args>::type>()...)),
-      double>::type
-  test(C *);
-  template <typename> static std::false_type test(...);
-
-public:
-  static constexpr bool value = decltype(test<T>(0))::value;
-};
-
-/*
- * This determines whether or not a class has a method defined for
- * something close to, but not quite, a valid call_impl_.  For example
- * if a class has:
- *   double call_impl_(const X x)
- * or
- *   double call_impl_(X &x)
- * or
- *   int call_impl_(const X &x)
- * those are nearly correct but the required `const X &x` in which
- * case this trait can be used to warn the user.
- */
-template <typename T, typename... Args> class has_possible_call_impl {
-  template <typename C, typename = decltype(std::declval<C>().call_impl_(
-                            std::declval<Args &>()...))>
-  static std::true_type test(int);
-  template <typename C> static std::false_type test(...);
-
-public:
-  static constexpr bool value = decltype(test<T>(0))::value;
-};
-
-template <typename T, typename... Args> class has_invalid_call_impl {
-public:
-  static constexpr bool value = (has_possible_call_impl<T, Args...>::value &&
-                                 !has_valid_call_impl<T, Args...>::value);
-};
-
-/*
- * This determines whether or not a class, T, has a member,
- *   `T.name_`
- * The result of the inspection gets stored in the member `value`.
- */
-template <typename T> class has_name_ {
-  template <typename C, typename = decltype(std::declval<C>().name_)>
-  static std::true_type test(int);
-  template <typename C> static std::false_type test(...);
-
-public:
-  static constexpr bool value = decltype(test<T>(0))::value;
-};
-
-/*
- * Inspects T to see if it has a class level type called FitType,
- * the result is returned in ::value.
- */
-template <typename T> class has_fit_type {
-  template <typename C, typename = typename C::FitType>
-  static std::true_type test(int);
-  template <typename C> static std::false_type test(...);
-
-public:
-  static constexpr bool value = decltype(test<T>(0))::value;
-};
-
-/*
- * One way to tell the difference between a RegressionModel
- * and a SerializableRegressionModel is by inspecting for a
- * FitType.
- */
-template <typename T> using is_serializable_regression_model = has_fit_type<T>;
-
-/*
- * This traits helper class defines `::type` to be `T::FitType`
- * if a type with that name has been defined for T and will
- * otherwise be `void`.
- */
-template <typename T> class fit_type_or_void {
-  template <typename C, typename = typename C::FitType>
-  static typename C::FitType test(int);
-  template <typename C> static void test(...);
-
-public:
-  typedef decltype(test<T>(0)) type;
-};
-
-/*
- * Helper function for enable_if and is_serializable_regression_model
- */
-template <typename X, typename T>
-using enable_if_serializable =
-    std::enable_if<is_serializable_regression_model<X>::value, T>;
-
-/*
- * Will result in substitution failure if X is not serializable and
- * otherwise resolves to X::FitType.
- */
-template <typename X>
-using fit_type_if_serializable =
-    typename enable_if_serializable<X,
-                                    typename fit_type_or_void<X>::type>::type;
-
-/*
- * The following helper functions let you inspect a type and cereal Archive
- * and determine if the type has a valid serialization method for that Archive
- * type.
- */
-template <typename X, typename Archive> class valid_output_serializer {
-  template <typename T>
-  static typename std::enable_if<
-      1 == cereal::traits::detail::count_output_serializers<T, Archive>::value,
-      std::true_type>::type
-  test(int);
-  template <typename T> static std::false_type test(...);
-
-public:
-  static constexpr bool value = decltype(test<X>(0))::value;
-};
-
-template <typename X, typename Archive> class valid_input_serializer {
-  template <typename T>
-  static typename std::enable_if<
-      1 == cereal::traits::detail::count_input_serializers<T, Archive>::value,
-      std::true_type>::type
-  test(int);
-  template <typename T> static std::false_type test(...);
-
-public:
-  static constexpr bool value = decltype(test<X>(0))::value;
-};
-
-template <typename X, typename Archive> class valid_in_out_serializer {
-  template <typename T>
-  static typename std::enable_if<valid_input_serializer<T, Archive>::value &&
-                                     valid_output_serializer<T, Archive>::value,
-                                 std::true_type>::type
-  test(int);
-  template <typename T> static std::false_type test(...);
-
-public:
-  static constexpr bool value = decltype(test<X>(0))::value;
-};
-
-/*
- * This helper function takes a model and decides which base class it extends
- * by inspecting whether or not the ModelType has a FitType.
- */
-template <typename FeatureType, typename ModelType>
-class choose_regression_model_implementation {
-  template <typename C, typename = typename C::FitType>
-  static SerializableRegressionModel<FeatureType, typename C::FitType> *
-  test(int);
-
-  template <typename C> static RegressionModel<FeatureType> *test(...);
-
-public:
-  typedef typename std::remove_pointer<decltype(test<ModelType>(0))>::type type;
-};
 
 /*
  * Checks if a class type is complete by using sizeof.
@@ -241,40 +30,153 @@ public:
 };
 
 /*
- * This set of trait logic checks if a type has any call_impl_ method
- * implemented (including private methods) by hijacking name hiding.
- * Namely if a derived class overloads a method the base methods will
- * be hidden.  So by starting with a base class with a known method
- * then extending that class you can determine if the derived class
- * included any other methods with that name.
- *
- * https://stackoverflow.com/questions/1628768/why-does-an-overridden-function-in-the-derived-class-hide-other-overloads-of-the
+ * This determines whether or not a class, T, has a method,
+ *   `std::string T.name() const`
  */
-namespace detail {
-
-struct DummyType {};
-
-struct BaseWithPublicCallImpl {
-  // This method will be accessible in `MultiInherit` only if
-  // the class U doesn't contain any methods with the same name.
-  double call_impl_(const DummyType &) const { return -1.; }
-};
-
-template <typename U>
-struct MultiInherit : public U, public BaseWithPublicCallImpl {};
-}
-
-template <typename U> class has_any_call_impl {
-  template <typename T>
-  static typename std::enable_if<
-      has_valid_call_impl<detail::MultiInherit<T>, detail::DummyType>::value,
-      std::false_type>::type
+template <typename T> class has_name {
+  template <typename C, typename ReturnType = decltype(std::declval<const C>().name())>
+  static
+  typename std::enable_if<std::is_same<std::string, ReturnType>::value, std::true_type>::type
   test(int);
-  template <typename T> static std::true_type test(...);
+
+  template <typename C> static std::false_type test(...);
 
 public:
-  static constexpr bool value = decltype(test<U>(0))::value;
+  static constexpr bool value = decltype(test<T>(0))::value;
 };
+
+/*
+ * Like std::is_base_of<T, U> except compares the first template parameter.  Ie,
+ *
+ *  first_template_param_is_base_of<C<T, X>, C<U, Y>>::value == is_base_of<T, U>::value
+ */
+template <typename T, typename U>
+struct first_template_param_is_base_of : public std::false_type {};
+
+template <template <typename, typename> class Base, typename T, typename U, typename P, typename Q>
+struct first_template_param_is_base_of<Base<T, P>, Base<U, Q>>
+    : public std::is_base_of<T, U> {};
+
+
+struct is_valid_fit_type_dummy_type {};
+
+/*
+ * A valid fit for a ModelType is defined as Fit<AnyBaseOfModelType, AnyFeatureType>.
+ */
+template <typename ModelType, typename FitType>
+struct is_valid_fit_type
+    : public first_template_param_is_base_of<FitType, Fit<ModelType, is_valid_fit_type_dummy_type>> {};
+
+/*
+ * This determines whether or not a class (T) has a method defined for,
+ *   `Fit<U, FeatureType> fit(const std::vector<FeatureType>&,
+ *                            const MarginalDistribution &)`
+ * where U is a base of T.
+ */
+template <typename T, typename FeatureType> class has_valid_fit {
+  template <typename C,
+            typename FitType = decltype(std::declval<const C>().fit(
+                std::declval<const std::vector<FeatureType> &>(),
+                std::declval<const MarginalDistribution &>()))>
+  static typename is_valid_fit_type<T, FitType>::type test(C *);
+  template <typename> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+/*
+ * This determines whether or not a class (T) has a method defined for,
+ *   `Anything fit(std::vector<FeatureType>&,
+ *                 MarginalDistribution &)`
+ */
+template <typename T, typename FeatureType> class has_possible_fit {
+  template <typename C, typename = decltype(std::declval<C>().fit(
+                            std::declval<std::vector<FeatureType> &>(),
+                            std::declval<MarginalDistribution &>()))>
+  static std::true_type test(C *);
+  template <typename> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+/*
+ * Determines which object would be returned from a call to:
+ *
+ *   T::get_fit_model(features, targets);
+ */
+template <typename T, typename FeatureType> class fit_model_type {
+  template <typename C,
+            typename FitModelType = decltype(std::declval<const C>().get_fit_model(
+                std::declval<const std::vector<FeatureType> &>(),
+                std::declval<const MarginalDistribution &>()))>
+  static FitModelType test(C *);
+  template <typename> static void test(...);
+
+public:
+
+  typedef decltype(test<T>(0)) type;
+};
+
+
+/*
+ * fit_type
+ *
+ * Determines which Fit specialization will be returned if you
+ * call ModelType::fit.
+ */
+template <typename ModelType, typename FeatureType, int = 0>
+struct fit_type {
+  typedef void type;
+};
+
+template <typename ModelType, typename FeatureType, typename FitType>
+struct fit_type<FitModel<ModelType, FitType>, FeatureType> {
+  typedef FitType type;
+};
+
+
+template <typename M, typename F>
+struct fit_type<M, F> : public fit_type<typename fit_model_type<M, F>::type, F> {
+};
+
+
+/*
+ * A valid predict method has a signature that looks like:
+ *
+ *   PredictType predict(const std::vector<FeatureType> &,
+ *                       const FitType &,
+ *                       const PredictTypeIdentity<PredictType>) const;
+ *
+ */
+template <typename T, typename FeatureType, typename FitType, typename PredictType>
+class has_valid_predict {
+  template <typename C,
+            typename ReturnType = decltype(std::declval<const C>().predict(
+                std::declval<const std::vector<FeatureType> &>(),
+                std::declval<const FitType &>(),
+                std::declval<PredictTypeIdentity<PredictType>>()))>
+  static typename std::enable_if<std::is_same<PredictType, ReturnType>::value,
+                                 std::true_type>::type
+  test(C *);
+  template <typename> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+template <typename T, typename FeatureType, typename FitType>
+using has_valid_predict_mean =
+    has_valid_predict<T, FeatureType, FitType, Eigen::VectorXd>;
+
+template <typename T, typename FeatureType, typename FitType>
+using has_valid_predict_marginal =
+    has_valid_predict<T, FeatureType, FitType, MarginalDistribution>;
+
+template <typename T, typename FeatureType, typename FitType>
+using has_valid_predict_joint =
+    has_valid_predict<T, FeatureType, FitType, JointDistribution>;
 
 } // namespace albatross
 

--- a/albatross/covariance_functions/call_trace.h
+++ b/albatross/covariance_functions/call_trace.h
@@ -160,7 +160,7 @@ public:
   template <typename X, typename Y>
   std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
     std::vector<CallAndValue> calls;
-    calls.push_back({SumOfCovarianceFunctions<LHS, RHS>().name_, eval(x, y)});
+    calls.push_back({SumOfCovarianceFunctions<LHS, RHS>().name(), eval(x, y)});
 
     std::vector<CallAndValue> lhs_calls =
         CallTrace<LHS>(this->cov_func_.lhs_).get_trace(x, y);
@@ -207,7 +207,7 @@ public:
   std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
     std::vector<CallAndValue> calls;
     calls.push_back(
-        {ProductOfCovarianceFunctions<LHS, RHS>().name_, eval(x, y)});
+        {ProductOfCovarianceFunctions<LHS, RHS>().name(), eval(x, y)});
 
     std::vector<CallAndValue> lhs_calls =
         CallTrace<LHS>(this->cov_func_.lhs_).get_trace(x, y);

--- a/albatross/covariance_functions/covariance_function.h
+++ b/albatross/covariance_functions/covariance_function.h
@@ -13,13 +13,6 @@
 #ifndef ALBATROSS_COVARIANCE_FUNCTIONS_COVARIANCE_FUNCTION_H
 #define ALBATROSS_COVARIANCE_FUNCTIONS_COVARIANCE_FUNCTION_H
 
-#include "../core/traits.h"
-#include "core/parameter_macros.h"
-#include "map_utils.h"
-#include <Eigen/Core>
-#include <Eigen/Dense>
-#include <iostream>
-
 namespace albatross {
 
 template <typename X, typename Y> class SumOfCovarianceFunctions;
@@ -96,12 +89,21 @@ public:
                 "\n\t\t..."
                 "\n\t}\n");
 
-  std::string get_name() const {
-    static_assert(has_name_<Derived>::value, "A public member `std::string "
-                                             "name_` must be defined for all "
-                                             "covariance functions");
-    return derived().name_;
-  };
+  template <typename DummyType = Derived,
+            typename std::enable_if<!has_name<DummyType>::value, int>::type = 0>
+  std::string get_name() {
+    static_assert(std::is_same<DummyType, Derived>::value,
+                  "never do covariance_function.get_name<T>()");
+    return typeid(Derived).name();
+  }
+
+  template <typename DummyType = Derived,
+            typename std::enable_if<has_name<DummyType>::value, int>::type = 0>
+  std::string get_name() {
+    static_assert(std::is_same<DummyType, Derived>::value,
+                  "never do covariance_function.get_name<T>()");
+    return derived().name();
+  }
 
   std::string pretty_string() const {
     std::ostringstream ss;
@@ -289,14 +291,14 @@ template <class LHS, class RHS>
 class SumOfCovarianceFunctions
     : public CovarianceFunction<SumOfCovarianceFunctions<LHS, RHS>> {
 public:
-  SumOfCovarianceFunctions() : lhs_(), rhs_() {
-    name_ = "(" + lhs_.name_ + "+" + rhs_.name_ + ")";
-  };
+  SumOfCovarianceFunctions() : lhs_(), rhs_() {};
 
   SumOfCovarianceFunctions(const LHS &lhs, const RHS &rhs)
-      : lhs_(lhs), rhs_(rhs) {
-    SumOfCovarianceFunctions();
-  };
+      : lhs_(lhs), rhs_(rhs) {};
+
+  std::string name() const {
+    return "(" + lhs_.name() + "+" + rhs_.name() + ")";
+  }
 
   ParameterStore get_params() const {
     return map_join(lhs_.get_params(), rhs_.get_params());
@@ -347,8 +349,6 @@ public:
     return this->rhs_(x, y);
   }
 
-  std::string name_;
-
 protected:
   LHS lhs_;
   RHS rhs_;
@@ -362,13 +362,15 @@ template <class LHS, class RHS>
 class ProductOfCovarianceFunctions
     : public CovarianceFunction<ProductOfCovarianceFunctions<LHS, RHS>> {
 public:
-  ProductOfCovarianceFunctions() : lhs_(), rhs_() {
-    name_ = "(" + lhs_.name_ + "*" + rhs_.name_ + ")";
-  };
+  ProductOfCovarianceFunctions() : lhs_(), rhs_() {};
   ProductOfCovarianceFunctions(const LHS &lhs, const RHS &rhs)
       : lhs_(lhs), rhs_(rhs) {
     ProductOfCovarianceFunctions();
   };
+
+  std::string name() const {
+    return "(" + lhs_.name() + "*" + rhs_.name() + ")";
+  }
 
   ParameterStore get_params() const {
     return map_join(lhs_.get_params(), rhs_.get_params());
@@ -422,8 +424,6 @@ public:
   double call_impl_(const X &x, const Y &y) const {
     return this->rhs_(x, y);
   }
-
-  std::string name_;
 
 protected:
   LHS lhs_;

--- a/albatross/covariance_functions/noise.h
+++ b/albatross/covariance_functions/noise.h
@@ -13,8 +13,6 @@
 #ifndef ALBATROSS_COVARIANCE_FUNCTIONS_NOISE_H
 #define ALBATROSS_COVARIANCE_FUNCTIONS_NOISE_H
 
-#include "covariance_function.h"
-
 constexpr double default_sigma_noise = 0.1;
 
 namespace albatross {
@@ -22,7 +20,7 @@ namespace albatross {
 template <typename Observed>
 class IndependentNoise : public CovarianceFunction<IndependentNoise<Observed>> {
 public:
-  IndependentNoise(double sigma_noise = 0.1) : name_("independent_noise") {
+  IndependentNoise(double sigma_noise = 0.1) {
     sigma_independent_noise = {sigma_noise,
                                std::make_shared<NonNegativePrior>()};
   };
@@ -31,7 +29,7 @@ public:
 
   ~IndependentNoise(){};
 
-  std::string get_name() const { return "independent_noise"; }
+  std::string name() const { return "independent_noise"; }
 
   /*
    * This will create a scaled identity matrix, but only between
@@ -44,7 +42,6 @@ public:
       return 0.;
     }
   }
-  std::string name_;
 };
 } // namespace albatross
 

--- a/albatross/covariance_functions/polynomials.h
+++ b/albatross/covariance_functions/polynomials.h
@@ -13,8 +13,6 @@
 #ifndef ALBATROSS_COVARIANCE_FUNCTIONS_POLYNOMIALS_H
 #define ALBATROSS_COVARIANCE_FUNCTIONS_POLYNOMIALS_H
 
-#include "covariance_function.h"
-
 namespace albatross {
 
 constexpr double default_sigma = 100.;
@@ -32,13 +30,17 @@ struct ConstantTerm {};
  */
 class Constant : public CovarianceFunction<Constant> {
 public:
-  Constant(double sigma_constant_ = default_sigma) : name_("constant") {
+  Constant(double sigma_constant_ = default_sigma) {
     sigma_constant = {sigma_constant_, std::make_shared<NonNegativePrior>()};
   };
 
   ALBATROSS_DECLARE_PARAMS(sigma_constant);
 
   ~Constant(){};
+
+  std::string name() const {
+    return "constant";
+  }
 
   template <typename X>
   std::vector<ConstantTerm>
@@ -58,8 +60,6 @@ public:
                     const Y &y __attribute__((unused))) const {
     return sigma_constant.value * sigma_constant.value;
   }
-
-  const std::string name_;
 };
 
 template <int order>
@@ -71,8 +71,11 @@ public:
       param_names_[i] = param_name;
       this->params_[param_name] = {sigma, std::make_shared<NonNegativePrior>()};
     }
-    name_ = "polynomial_" + std::to_string(order);
   };
+
+  std::string name() const {
+    return "polynomial_" + std::to_string(order);
+  }
 
   ~Polynomial(){};
 
@@ -85,8 +88,6 @@ public:
     }
     return cov;
   }
-
-  std::string name_;
 
 private:
   std::map<int, std::string> param_names_;

--- a/albatross/covariance_functions/radial.h
+++ b/albatross/covariance_functions/radial.h
@@ -13,11 +13,6 @@
 #ifndef ALBATROSS_COVARIANCE_FUNCTIONS_RADIAL_H
 #define ALBATROSS_COVARIANCE_FUNCTIONS_RADIAL_H
 
-#include <sstream>
-
-#include "covariance_function.h"
-#include "distance_metrics.h"
-
 constexpr double default_length_scale = 100000.;
 constexpr double default_radial_sigma = 10.;
 
@@ -50,15 +45,16 @@ public:
 
   SquaredExponential(double length_scale_ = default_length_scale,
                      double sigma_squared_exponential_ = default_radial_sigma)
-      : distance_metric_(), name_() {
+      : distance_metric_() {
     squared_exponential_length_scale = {length_scale_,
                                         std::make_shared<PositivePrior>()};
     sigma_squared_exponential = {sigma_squared_exponential_,
                                  std::make_shared<NonNegativePrior>()};
-    std::ostringstream oss;
-    oss << "squared_exponential[" << this->distance_metric_.get_name() << "]";
-    name_ = oss.str();
   };
+
+  std::string name() const {
+    return "squared_exponential[" << this->distance_metric_.name() << "]";
+  }
 
   // This operator is only defined when the distance metric is also defined.
   template <typename X,
@@ -73,7 +69,6 @@ public:
   }
 
   DistanceMetricType distance_metric_;
-  std::string name_;
 };
 
 inline double exponential_covariance(double distance, double length_scale,
@@ -92,15 +87,16 @@ public:
 
   Exponential(double length_scale_ = default_length_scale,
               double sigma_exponential_ = default_radial_sigma)
-      : distance_metric_(), name_() {
+      : distance_metric_() {
     exponential_length_scale = {length_scale_,
                                 std::make_shared<PositivePrior>()};
     sigma_exponential = {sigma_exponential_,
                          std::make_shared<NonNegativePrior>()};
-    std::ostringstream oss;
-    oss << "exponential[" << this->distance_metric_.get_name() << "]";
-    name_ = oss.str();
   };
+
+  std::string name() const {
+    return "exponential[" << this->distance_metric_.get_name() << "]";
+  }
 
   ~Exponential(){};
 
@@ -116,7 +112,6 @@ public:
   }
 
   DistanceMetricType distance_metric_;
-  std::string name_;
 };
 
 } // namespace albatross

--- a/albatross/covariance_functions/scaling_function.h
+++ b/albatross/covariance_functions/scaling_function.h
@@ -13,15 +13,11 @@
 #ifndef ALBATROSS_COVARIANCE_FUNCTIONS_SCALING_FUNCTION_H
 #define ALBATROSS_COVARIANCE_FUNCTIONS_SCALING_FUNCTION_H
 
-#include "covariance_function.h"
-#include <sstream>
-#include <utility>
-
 namespace albatross {
 
 class ScalingFunction : public ParameterHandlingMixin {
 public:
-  virtual std::string get_name() const = 0;
+  virtual std::string name() const = 0;
 
   // A scaling function should also implement calls
   // for whichever types it is intended to scale using
@@ -62,13 +58,13 @@ public:
 template <typename ScalingFunction>
 class ScalingTerm : public CovarianceFunction<ScalingTerm<ScalingFunction>> {
 public:
-  ScalingTerm() : name_(), scaling_function_() {
-    name_ = scaling_function_.get_name();
-  };
+  ScalingTerm() : scaling_function_() {};
 
-  ScalingTerm(const ScalingFunction &func) : name_(), scaling_function_(func) {
-    name_ = scaling_function_.get_name();
-  };
+  ScalingTerm(const ScalingFunction &func) : scaling_function_(func) {};
+
+  std::string name() const {
+    return scaling_function_.name();
+  }
 
   void set_params(const ParameterStore &params) {
     scaling_function_.set_params(params);
@@ -121,8 +117,6 @@ public:
   double call_impl_(const X &x, const Y &) const {
     return this->scaling_function_.call_impl_(x);
   }
-
-  std::string name_;
 
 private:
   ScalingFunction scaling_function_;

--- a/albatross/covariance_functions/traits.h
+++ b/albatross/covariance_functions/traits.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_COVARIANCE_FUNCTIONS_TRAITS_H
+#define ALBATROSS_COVARIANCE_FUNCTIONS_TRAITS_H
+
+namespace albatross {
+
+/*
+ * In CovarianceFunction we frequently inspect for definitions of
+ * call_impl_ which MUST be defined for const references to objects
+ * (so that repeated covariance matrix evaluations return the same thing
+ *  and so the computations are not repeatedly copying.)
+ * This type conversion utility will turn a type `T` into `const T&`
+ */
+template <class T> struct call_impl_arg_type {
+  typedef
+      typename std::add_lvalue_reference<typename std::add_const<T>::type>::type
+          type;
+};
+
+/*
+ * This determines whether or not a class has a method defined for,
+ *   `operator() (const X &x, const Y &y, const Z &z, ...)`
+ * The result of the inspection gets stored in the member `value`.
+ */
+template <typename T, typename... Args> class has_call_operator {
+
+  template <typename C,
+            typename = decltype(std::declval<C>()(
+                std::declval<typename call_impl_arg_type<Args>::type>()...))>
+  static std::true_type test(C *);
+  template <typename> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+/*
+ * This determines whether or not a class has a method defined for,
+ *   `double call_impl_(const X &x, const Y &y, const Z &z, ...)`
+ * The result of the inspection gets stored in the member `value`.
+ */
+template <typename T, typename... Args> class has_valid_call_impl {
+
+  template <typename C>
+  static typename std::is_same<
+      decltype(std::declval<const C>().call_impl_(
+          std::declval<typename call_impl_arg_type<Args>::type>()...)),
+      double>::type
+  test(C *);
+  template <typename> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+/*
+ * This determines whether or not a class has a method defined for
+ * something close to, but not quite, a valid call_impl_.  For example
+ * if a class has:
+ *   double call_impl_(const X x)
+ * or
+ *   double call_impl_(X &x)
+ * or
+ *   int call_impl_(const X &x)
+ * those are nearly correct but the required `const X &x` in which
+ * case this trait can be used to warn the user.
+ */
+template <typename T, typename... Args> class has_possible_call_impl {
+  template <typename C, typename = decltype(std::declval<C>().call_impl_(
+                            std::declval<Args &>()...))>
+  static std::true_type test(int);
+  template <typename C> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+template <typename T, typename... Args> class has_invalid_call_impl {
+public:
+  static constexpr bool value = (has_possible_call_impl<T, Args...>::value &&
+                                 !has_valid_call_impl<T, Args...>::value);
+};
+
+/*
+ * This set of trait logic checks if a type has any call_impl_ method
+ * implemented (including private methods) by hijacking name hiding.
+ * Namely if a derived class overloads a method the base methods will
+ * be hidden.  So by starting with a base class with a known method
+ * then extending that class you can determine if the derived class
+ * included any other methods with that name.
+ *
+ * https://stackoverflow.com/questions/1628768/why-does-an-overridden-function-in-the-derived-class-hide-other-overloads-of-the
+ */
+namespace detail {
+
+struct DummyType {};
+
+struct BaseWithPublicCallImpl {
+  // This method will be accessible in `MultiInherit` only if
+  // the class U doesn't contain any methods with the same name.
+  double call_impl_(const DummyType &) const { return -1.; }
+};
+
+template <typename U>
+struct MultiInheritCallImpl : public U, public BaseWithPublicCallImpl {};
+}
+
+template <typename U> class has_any_call_impl {
+  template <typename T>
+  static typename std::enable_if<
+      has_valid_call_impl<detail::MultiInheritCallImpl<T>,
+                          detail::DummyType>::value,
+      std::false_type>::type
+  test(int);
+  template <typename T> static std::true_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<U>(0))::value;
+};
+}
+
+#endif

--- a/tests/test_traits_cereal.cc
+++ b/tests/test_traits_cereal.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "cereal/traits.h"
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+struct NullArchive {};
+
+class ValidInOutSerializer {
+public:
+  template <typename Archive> void serialize(Archive &){};
+};
+
+class ValidSaveLoadSerializer {
+public:
+  template <typename Archive> void save(Archive &) const {};
+
+  template <typename Archive> void load(Archive &){};
+};
+
+class ValidInSerializer {
+public:
+  template <typename Archive> void load(Archive &){};
+};
+
+class ValidOutSerializer {
+public:
+  template <typename Archive> void save(Archive &) const {};
+};
+
+class InValidInOutSerializer {};
+
+TEST(test_traits_cereal, test_valid_in_out_serializer) {
+  EXPECT_TRUE(
+      bool(valid_in_out_serializer<ValidInOutSerializer, NullArchive>::value));
+  EXPECT_TRUE(bool(
+      valid_in_out_serializer<ValidSaveLoadSerializer, NullArchive>::value));
+  EXPECT_FALSE(
+      bool(valid_in_out_serializer<ValidInSerializer, NullArchive>::value));
+  EXPECT_FALSE(
+      bool(valid_in_out_serializer<ValidOutSerializer, NullArchive>::value));
+  EXPECT_FALSE(bool(
+      valid_in_out_serializer<InValidInOutSerializer, NullArchive>::value));
+}
+
+TEST(test_traits_cereal, test_valid_input_serializer) {
+  EXPECT_TRUE(
+      bool(valid_input_serializer<ValidInOutSerializer, NullArchive>::value));
+  EXPECT_TRUE(bool(
+      valid_input_serializer<ValidSaveLoadSerializer, NullArchive>::value));
+  EXPECT_TRUE(
+      bool(valid_input_serializer<ValidInSerializer, NullArchive>::value));
+  EXPECT_FALSE(
+      bool(valid_input_serializer<ValidOutSerializer, NullArchive>::value));
+  EXPECT_FALSE(
+      bool(valid_input_serializer<InValidInOutSerializer, NullArchive>::value));
+}
+
+TEST(test_traits_cereal, test_valid_output_serializer) {
+  EXPECT_TRUE(
+      bool(valid_output_serializer<ValidInOutSerializer, NullArchive>::value));
+  EXPECT_TRUE(bool(
+      valid_output_serializer<ValidSaveLoadSerializer, NullArchive>::value));
+  EXPECT_FALSE(
+      bool(valid_output_serializer<ValidInSerializer, NullArchive>::value));
+  EXPECT_TRUE(
+      bool(valid_output_serializer<ValidOutSerializer, NullArchive>::value));
+  EXPECT_FALSE(bool(
+      valid_output_serializer<InValidInOutSerializer, NullArchive>::value));
+}
+
+} // namespace albatross

--- a/tests/test_traits_core.cc
+++ b/tests/test_traits_core.cc
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "Core"
+
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+struct X {};
+struct Y {};
+struct Z {};
+
+class HasValidFitImpl : public ModelBase<HasValidFitImpl> {
+public:
+  Fit<HasValidFitImpl, X> fit(const std::vector<X> &,
+                           const MarginalDistribution &) const {
+    return {};
+  };
+};
+
+class HasWrongReturnTypeFitImpl : public ModelBase<HasWrongReturnTypeFitImpl> {
+public:
+  Fit<X, X> fit(const std::vector<X> &, const MarginalDistribution &) const {
+    return {};
+  };
+};
+
+class HasNonConstFitImpl : public ModelBase<HasNonConstFitImpl> {
+public:
+  Fit<HasNonConstFitImpl, X> fit(const std::vector<X> &,
+                                 const MarginalDistribution &) {
+    return {};
+  };
+};
+
+class HasNonConstArgsFitImpl : public ModelBase<HasNonConstFitImpl> {
+public:
+  Fit<HasNonConstArgsFitImpl, X> fit(std::vector<X> &,
+                                        const MarginalDistribution &) const {
+    return {};
+  };
+
+  Fit<HasNonConstArgsFitImpl, X> fit(const std::vector<X> &,
+                                        MarginalDistribution &) const {
+    return {};
+  };
+
+  Fit<HasNonConstArgsFitImpl, X> fit(std::vector<X> &,
+                                        MarginalDistribution &) const {
+    return {};
+  };
+};
+
+class HasProtectedValidFitImpl : public ModelBase<HasNonConstFitImpl> {
+protected:
+  Fit<HasProtectedValidFitImpl, X> fit(const std::vector<X> &,
+                                          const MarginalDistribution &) const {
+    return {};
+  };
+};
+
+class HasPrivateValidFitImpl : public ModelBase<HasPrivateValidFitImpl>  {
+private:
+  Fit<HasPrivateValidFitImpl, X> fit(const std::vector<X> &,
+                                        const MarginalDistribution &) const {
+    return {};
+  };
+};
+
+class HasValidAndInvalidFitImpl : public ModelBase<HasValidAndInvalidFitImpl> {
+public:
+  Fit<HasValidAndInvalidFitImpl, X> fit(const std::vector<X> &,
+                                        const MarginalDistribution &) const {
+    return {};
+  };
+
+  Fit<HasValidAndInvalidFitImpl, X> fit(const std::vector<X> &,
+                                        const MarginalDistribution &) {
+    return {};
+  };
+};
+
+class HasValidXYFitImpl : public ModelBase<HasValidXYFitImpl> {
+public:
+  Fit<HasValidXYFitImpl, X> fit(const std::vector<X> &,
+                                const MarginalDistribution &) const {
+    return {};
+  };
+
+  Fit<HasValidXYFitImpl, Y> fit(const std::vector<Y> &,
+                                      const MarginalDistribution &) const {
+    return {};
+  };
+};
+
+class HasNoFitImpl {};
+
+TEST(test_traits_core, test_has_valid_fit) {
+  EXPECT_TRUE(bool(has_valid_fit<HasValidFitImpl, X>::value));
+  EXPECT_FALSE(bool(has_valid_fit<HasWrongReturnTypeFitImpl, X>::value));
+  EXPECT_FALSE(bool(has_valid_fit<HasNonConstFitImpl, X>::value));
+  EXPECT_FALSE(bool(has_valid_fit<HasNonConstArgsFitImpl, X>::value));
+  EXPECT_FALSE(bool(has_valid_fit<HasProtectedValidFitImpl, X>::value));
+  EXPECT_FALSE(bool(has_valid_fit<HasPrivateValidFitImpl, X>::value));
+  EXPECT_TRUE(bool(has_valid_fit<HasValidAndInvalidFitImpl, X>::value));
+  EXPECT_TRUE(bool(has_valid_fit<HasValidXYFitImpl, X>::value));
+  EXPECT_TRUE(bool(has_valid_fit<HasValidXYFitImpl, Y>::value));
+  EXPECT_FALSE(bool(has_valid_fit<HasNoFitImpl, X>::value));
+  //  EXPECT_TRUE(bool(has_valid_fit<HasInheritedFitImpl, Y>::value));
+}
+
+TEST(test_traits_core, test_has_possible_fit_impl) {
+  EXPECT_TRUE(bool(has_possible_fit<HasValidFitImpl, X>::value));
+  EXPECT_TRUE(bool(has_possible_fit<HasWrongReturnTypeFitImpl, X>::value));
+  EXPECT_TRUE(bool(has_possible_fit<HasNonConstFitImpl, X>::value));
+  EXPECT_TRUE(bool(has_possible_fit<HasNonConstArgsFitImpl, X>::value));
+  EXPECT_FALSE(bool(has_possible_fit<HasProtectedValidFitImpl, X>::value));
+  EXPECT_FALSE(bool(has_possible_fit<HasPrivateValidFitImpl, X>::value));
+  EXPECT_TRUE(bool(has_possible_fit<HasValidAndInvalidFitImpl, X>::value));
+  EXPECT_TRUE(bool(has_possible_fit<HasValidXYFitImpl, X>::value));
+  EXPECT_TRUE(bool(has_possible_fit<HasValidXYFitImpl, Y>::value));
+  EXPECT_FALSE(bool(has_possible_fit<HasNoFitImpl, X>::value));
+}
+
+TEST(test_traits_core, test_fit_type) {
+  EXPECT_TRUE(bool(std::is_same<Z, fit_type<FitModel<X, Z>, Y>::type>::value));
+  EXPECT_TRUE(bool(std::is_same<Fit<HasValidFitImpl, X>,
+                                fit_type<HasValidFitImpl, X>::type>::value));
+  EXPECT_TRUE(bool(std::is_same<Fit<HasValidXYFitImpl, X>,
+                                fit_type<HasValidXYFitImpl, X>::type>::value));
+  EXPECT_TRUE(bool(std::is_same<Fit<HasValidXYFitImpl, Y>,
+                                fit_type<HasValidXYFitImpl, Y>::type>::value));
+}
+
+template <typename T>
+struct Base {};
+
+struct Derived : public Base<Derived> {};
+
+TEST(test_traits_core, test_is_valid_fit_type) {
+  EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Derived, X>>::value));
+  EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Derived, Y>>::value));
+  EXPECT_TRUE(bool(is_valid_fit_type<Base<Derived>, Fit<Base<Derived>, X>>::value));
+  EXPECT_TRUE(bool(is_valid_fit_type<Base<Derived>, Fit<Base<Derived>, Y>>::value));
+  // If a Derived class which inherits from Base<Derived> has a fit
+  // which returns Fit<Base<Derived>> consider that a valid fit type.
+  EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Base<Derived>, X>>::value));
+  EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Base<Derived>, Y>>::value));
+  // However a fit_impl which returns
+  EXPECT_FALSE(bool(is_valid_fit_type<Base<Derived>, Fit<Derived, X>>::value));
+  EXPECT_FALSE(bool(is_valid_fit_type<Base<Derived>, Fit<Derived, Y>>::value));
+}
+
+template <typename T>
+struct Adaptable;
+
+template <typename T, typename FeatureType>
+struct Fit<Adaptable<T>, FeatureType> {};
+
+template <typename ImplType>
+struct Adaptable : public ModelBase<Adaptable<ImplType>> {
+
+  Fit<Adaptable<ImplType>, X> fit(const std::vector<X> &,
+                                   const MarginalDistribution &) const {
+    return Fit<Adaptable<ImplType>, X>();
+  }
+
+  /*
+   * This forwards on `fit` definitions from the implementing class
+   * to this class so it can be picked up by ModelBase.
+   */
+  template <typename FeatureType,
+            typename std::enable_if<
+                       has_valid_fit<ImplType, FeatureType>::value,
+                                   int>::type = 0>
+  auto fit(const std::vector<FeatureType> &features,
+                                   const MarginalDistribution &targets) const {
+    return impl().fit(features, targets);
+  }
+
+  /*
+   * CRTP Helpers
+   */
+  ImplType &impl() { return *static_cast<ImplType *>(this); }
+  const ImplType &impl() const { return *static_cast<const ImplType *>(this); }
+
+};
+
+struct Extended : public Adaptable<Extended> {
+
+  using Base = Adaptable<Extended>;
+
+  auto fit(const std::vector<Y> &,
+                 const MarginalDistribution &targets) const {
+    std::vector<X> xs = {{}};
+    return Base::fit(xs, targets);
+  }
+
+  Z predict(const std::vector<Y> &,
+            const Fit<Adaptable<Extended>, X> &,
+            PredictTypeIdentity<Z>) const {
+    return {};
+  }
+
+};
+
+TEST(test_traits_core, test_adaptable_fit_type) {
+  EXPECT_TRUE(bool(std::is_base_of<Fit<Adaptable<Extended>, X>,
+                   fit_type<Extended, Y>::type>::value));
+  EXPECT_TRUE(bool(std::is_base_of<Fit<Adaptable<Extended>, X>,
+                   fit_type<Extended, X>::type>::value));
+  EXPECT_TRUE(bool(has_valid_predict<Extended, Y, Fit<Adaptable<Extended>, X>, Z>::value));
+}
+
+TEST(test_traits_core, test_adaptable_has_valid_fit) {
+  EXPECT_FALSE(bool(has_valid_fit<Extended, X>::value));
+  EXPECT_TRUE(bool(has_valid_fit<Extended, Y>::value));
+  EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Extended, X>>::value));
+  EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Extended, Y>>::value));
+  EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Adaptable<Extended>, X>>::value));
+  EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Adaptable<Extended>, Y>>::value));
+}
+
+/*
+ * Predict Traits
+ */
+class HasMeanPredictImpl {
+public:
+  Eigen::VectorXd predict(const std::vector<X> &,
+                          const Fit<HasMeanPredictImpl> &,
+                           PredictTypeIdentity<Eigen::VectorXd>) const {
+    return Eigen::VectorXd::Zero(0);
+  }
+};
+
+class HasMarginalPredictImpl {
+public:
+  MarginalDistribution
+  predict(const std::vector<X> &,
+           const Fit<HasMarginalPredictImpl> &,
+           PredictTypeIdentity<MarginalDistribution>) const {
+    const auto mean = Eigen::VectorXd::Zero(0);
+    return MarginalDistribution(mean);
+  }
+};
+
+class HasJointPredictImpl {
+public:
+  JointDistribution predict(const std::vector<X> &,
+                             const Fit<HasJointPredictImpl> &,
+                             PredictTypeIdentity<JointDistribution>) const {
+    const auto mean = Eigen::VectorXd::Zero(0);
+    return JointDistribution(mean);
+  }
+};
+
+class HasAllPredictImpls {
+public:
+  Eigen::VectorXd predict(const std::vector<X> &,
+                           const Fit<HasAllPredictImpls> &,
+                           PredictTypeIdentity<Eigen::VectorXd>) const {
+    return Eigen::VectorXd::Zero(0);
+  }
+
+  MarginalDistribution
+  predict(const std::vector<X> &,
+           const Fit<HasAllPredictImpls> &,
+           PredictTypeIdentity<MarginalDistribution>) const {
+    const auto mean = Eigen::VectorXd::Zero(0);
+    return MarginalDistribution(mean);
+  }
+
+  JointDistribution predict(const std::vector<X> &,
+                             const Fit<HasAllPredictImpls> &,
+                             PredictTypeIdentity<JointDistribution>) const {
+    const auto mean = Eigen::VectorXd::Zero(0);
+    return JointDistribution(mean);
+  }
+};
+
+TEST(test_traits_core, test_has_valid_predict_impl) {
+
+
+
+  EXPECT_TRUE(bool(has_valid_predict_mean<HasMeanPredictImpl, X, Fit<HasMeanPredictImpl>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_predict_marginal<HasMarginalPredictImpl, X, Fit<HasMarginalPredictImpl>>::value));
+  EXPECT_TRUE(bool(has_valid_predict_joint<HasJointPredictImpl, X, Fit<HasJointPredictImpl>>::value));
+  EXPECT_TRUE(bool(has_valid_predict_mean<HasAllPredictImpls, X, Fit<HasAllPredictImpls>>::value));
+  EXPECT_TRUE(bool(has_valid_predict_marginal<HasAllPredictImpls, X, Fit<HasAllPredictImpls>>::value));
+  EXPECT_TRUE(bool(has_valid_predict_joint<HasAllPredictImpls, X, Fit<HasAllPredictImpls>>::value));
+}
+
+class HasName {
+public:
+  std::string name() const {return "name";};
+};
+
+class HasNoName {};
+
+TEST(test_traits_covariance, test_has_name) {
+  EXPECT_TRUE(bool(has_name<HasName>::value));
+  EXPECT_FALSE(bool(has_name<HasNoName>::value));
+}
+
+
+} // namespace albatross

--- a/tests/test_traits_core.cc
+++ b/tests/test_traits_core.cc
@@ -16,6 +16,11 @@
 
 namespace albatross {
 
+TEST(test_traits_core, test_is_vector) {
+  EXPECT_TRUE(bool(is_vector<std::vector<double>>::value));
+  EXPECT_FALSE(bool(is_vector<double>::value));
+}
+
 struct X {};
 struct Y {};
 struct Z {};
@@ -23,7 +28,7 @@ struct Z {};
 class HasValidFitImpl : public ModelBase<HasValidFitImpl> {
 public:
   Fit<HasValidFitImpl, X> fit(const std::vector<X> &,
-                           const MarginalDistribution &) const {
+                              const MarginalDistribution &) const {
     return {};
   };
 };
@@ -46,17 +51,17 @@ public:
 class HasNonConstArgsFitImpl : public ModelBase<HasNonConstFitImpl> {
 public:
   Fit<HasNonConstArgsFitImpl, X> fit(std::vector<X> &,
-                                        const MarginalDistribution &) const {
+                                     const MarginalDistribution &) const {
     return {};
   };
 
   Fit<HasNonConstArgsFitImpl, X> fit(const std::vector<X> &,
-                                        MarginalDistribution &) const {
+                                     MarginalDistribution &) const {
     return {};
   };
 
   Fit<HasNonConstArgsFitImpl, X> fit(std::vector<X> &,
-                                        MarginalDistribution &) const {
+                                     MarginalDistribution &) const {
     return {};
   };
 };
@@ -64,15 +69,15 @@ public:
 class HasProtectedValidFitImpl : public ModelBase<HasNonConstFitImpl> {
 protected:
   Fit<HasProtectedValidFitImpl, X> fit(const std::vector<X> &,
-                                          const MarginalDistribution &) const {
+                                       const MarginalDistribution &) const {
     return {};
   };
 };
 
-class HasPrivateValidFitImpl : public ModelBase<HasPrivateValidFitImpl>  {
+class HasPrivateValidFitImpl : public ModelBase<HasPrivateValidFitImpl> {
 private:
   Fit<HasPrivateValidFitImpl, X> fit(const std::vector<X> &,
-                                        const MarginalDistribution &) const {
+                                     const MarginalDistribution &) const {
     return {};
   };
 };
@@ -98,7 +103,7 @@ public:
   };
 
   Fit<HasValidXYFitImpl, Y> fit(const std::vector<Y> &,
-                                      const MarginalDistribution &) const {
+                                const MarginalDistribution &) const {
     return {};
   };
 };
@@ -140,18 +145,25 @@ TEST(test_traits_core, test_fit_type) {
                                 fit_type<HasValidXYFitImpl, X>::type>::value));
   EXPECT_TRUE(bool(std::is_same<Fit<HasValidXYFitImpl, Y>,
                                 fit_type<HasValidXYFitImpl, Y>::type>::value));
+  EXPECT_TRUE(
+      bool(std::is_same<Fit<HasValidAndInvalidFitImpl, X>,
+                        fit_type<HasValidAndInvalidFitImpl, X>::type>::value));
+  //  EXPECT_FALSE(
+  //      bool(std::is_same<Fit<HasPrivateValidFitImpl, X>,
+  //                        fit_type<HasPrivateValidFitImpl, X>::type>::value));
 }
 
-template <typename T>
-struct Base {};
+template <typename T> struct Base {};
 
 struct Derived : public Base<Derived> {};
 
 TEST(test_traits_core, test_is_valid_fit_type) {
   EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Derived, X>>::value));
   EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Derived, Y>>::value));
-  EXPECT_TRUE(bool(is_valid_fit_type<Base<Derived>, Fit<Base<Derived>, X>>::value));
-  EXPECT_TRUE(bool(is_valid_fit_type<Base<Derived>, Fit<Base<Derived>, Y>>::value));
+  EXPECT_TRUE(
+      bool(is_valid_fit_type<Base<Derived>, Fit<Base<Derived>, X>>::value));
+  EXPECT_TRUE(
+      bool(is_valid_fit_type<Base<Derived>, Fit<Base<Derived>, Y>>::value));
   // If a Derived class which inherits from Base<Derived> has a fit
   // which returns Fit<Base<Derived>> consider that a valid fit type.
   EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Base<Derived>, X>>::value));
@@ -161,8 +173,7 @@ TEST(test_traits_core, test_is_valid_fit_type) {
   EXPECT_FALSE(bool(is_valid_fit_type<Base<Derived>, Fit<Derived, Y>>::value));
 }
 
-template <typename T>
-struct Adaptable;
+template <typename T> struct Adaptable;
 
 template <typename T, typename FeatureType>
 struct Fit<Adaptable<T>, FeatureType> {};
@@ -171,7 +182,7 @@ template <typename ImplType>
 struct Adaptable : public ModelBase<Adaptable<ImplType>> {
 
   Fit<Adaptable<ImplType>, X> fit(const std::vector<X> &,
-                                   const MarginalDistribution &) const {
+                                  const MarginalDistribution &) const {
     return Fit<Adaptable<ImplType>, X>();
   }
 
@@ -180,11 +191,10 @@ struct Adaptable : public ModelBase<Adaptable<ImplType>> {
    * to this class so it can be picked up by ModelBase.
    */
   template <typename FeatureType,
-            typename std::enable_if<
-                       has_valid_fit<ImplType, FeatureType>::value,
-                                   int>::type = 0>
+            typename std::enable_if<has_valid_fit<ImplType, FeatureType>::value,
+                                    int>::type = 0>
   auto fit(const std::vector<FeatureType> &features,
-                                   const MarginalDistribution &targets) const {
+           const MarginalDistribution &targets) const {
     return impl().fit(features, targets);
   }
 
@@ -193,33 +203,33 @@ struct Adaptable : public ModelBase<Adaptable<ImplType>> {
    */
   ImplType &impl() { return *static_cast<ImplType *>(this); }
   const ImplType &impl() const { return *static_cast<const ImplType *>(this); }
-
 };
 
 struct Extended : public Adaptable<Extended> {
 
   using Base = Adaptable<Extended>;
 
-  auto fit(const std::vector<Y> &,
-                 const MarginalDistribution &targets) const {
+  auto fit(const std::vector<Y> &, const MarginalDistribution &targets) const {
     std::vector<X> xs = {{}};
     return Base::fit(xs, targets);
   }
 
-  Z predict(const std::vector<Y> &,
-            const Fit<Adaptable<Extended>, X> &,
+  Z predict(const std::vector<Y> &, const Fit<Adaptable<Extended>, X> &,
             PredictTypeIdentity<Z>) const {
     return {};
   }
+};
 
+struct OtherExtended : public Adaptable<OtherExtended> {
 };
 
 TEST(test_traits_core, test_adaptable_fit_type) {
   EXPECT_TRUE(bool(std::is_base_of<Fit<Adaptable<Extended>, X>,
-                   fit_type<Extended, Y>::type>::value));
+                                   fit_type<Extended, Y>::type>::value));
   EXPECT_TRUE(bool(std::is_base_of<Fit<Adaptable<Extended>, X>,
-                   fit_type<Extended, X>::type>::value));
-  EXPECT_TRUE(bool(has_valid_predict<Extended, Y, Fit<Adaptable<Extended>, X>, Z>::value));
+                                   fit_type<Extended, X>::type>::value));
+  EXPECT_TRUE(bool(
+      has_valid_predict<Extended, Y, Fit<Adaptable<Extended>, X>, Z>::value));
 }
 
 TEST(test_traits_core, test_adaptable_has_valid_fit) {
@@ -227,8 +237,14 @@ TEST(test_traits_core, test_adaptable_has_valid_fit) {
   EXPECT_TRUE(bool(has_valid_fit<Extended, Y>::value));
   EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Extended, X>>::value));
   EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Extended, Y>>::value));
-  EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Adaptable<Extended>, X>>::value));
-  EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Adaptable<Extended>, Y>>::value));
+  EXPECT_TRUE(
+      bool(is_valid_fit_type<Extended, Fit<Adaptable<Extended>, X>>::value));
+  EXPECT_TRUE(
+      bool(is_valid_fit_type<Extended, Fit<Adaptable<Extended>, Y>>::value));
+  EXPECT_FALSE(
+      bool(is_valid_fit_type<OtherExtended, Fit<Adaptable<Extended>, Y>>::value));
+  EXPECT_FALSE(
+      bool(is_valid_fit_type<Extended, Fit<Adaptable<OtherExtended>, Y>>::value));
 }
 
 /*
@@ -238,7 +254,7 @@ class HasMeanPredictImpl {
 public:
   Eigen::VectorXd predict(const std::vector<X> &,
                           const Fit<HasMeanPredictImpl> &,
-                           PredictTypeIdentity<Eigen::VectorXd>) const {
+                          PredictTypeIdentity<Eigen::VectorXd>) const {
     return Eigen::VectorXd::Zero(0);
   }
 };
@@ -246,9 +262,8 @@ public:
 class HasMarginalPredictImpl {
 public:
   MarginalDistribution
-  predict(const std::vector<X> &,
-           const Fit<HasMarginalPredictImpl> &,
-           PredictTypeIdentity<MarginalDistribution>) const {
+  predict(const std::vector<X> &, const Fit<HasMarginalPredictImpl> &,
+          PredictTypeIdentity<MarginalDistribution>) const {
     const auto mean = Eigen::VectorXd::Zero(0);
     return MarginalDistribution(mean);
   }
@@ -257,8 +272,8 @@ public:
 class HasJointPredictImpl {
 public:
   JointDistribution predict(const std::vector<X> &,
-                             const Fit<HasJointPredictImpl> &,
-                             PredictTypeIdentity<JointDistribution>) const {
+                            const Fit<HasJointPredictImpl> &,
+                            PredictTypeIdentity<JointDistribution>) const {
     const auto mean = Eigen::VectorXd::Zero(0);
     return JointDistribution(mean);
   }
@@ -267,22 +282,21 @@ public:
 class HasAllPredictImpls {
 public:
   Eigen::VectorXd predict(const std::vector<X> &,
-                           const Fit<HasAllPredictImpls> &,
-                           PredictTypeIdentity<Eigen::VectorXd>) const {
+                          const Fit<HasAllPredictImpls> &,
+                          PredictTypeIdentity<Eigen::VectorXd>) const {
     return Eigen::VectorXd::Zero(0);
   }
 
   MarginalDistribution
-  predict(const std::vector<X> &,
-           const Fit<HasAllPredictImpls> &,
-           PredictTypeIdentity<MarginalDistribution>) const {
+  predict(const std::vector<X> &, const Fit<HasAllPredictImpls> &,
+          PredictTypeIdentity<MarginalDistribution>) const {
     const auto mean = Eigen::VectorXd::Zero(0);
     return MarginalDistribution(mean);
   }
 
   JointDistribution predict(const std::vector<X> &,
-                             const Fit<HasAllPredictImpls> &,
-                             PredictTypeIdentity<JointDistribution>) const {
+                            const Fit<HasAllPredictImpls> &,
+                            PredictTypeIdentity<JointDistribution>) const {
     const auto mean = Eigen::VectorXd::Zero(0);
     return JointDistribution(mean);
   }
@@ -290,20 +304,36 @@ public:
 
 TEST(test_traits_core, test_has_valid_predict_impl) {
 
+  EXPECT_TRUE(bool(has_valid_predict_mean<HasMeanPredictImpl, X,
+                                          Fit<HasMeanPredictImpl>>::value));
+  EXPECT_FALSE(bool(has_valid_predict_marginal<HasMeanPredictImpl, X, Fit<HasMeanPredictImpl>>::value));
+  EXPECT_FALSE(bool(has_valid_predict_joint<HasMeanPredictImpl, X, Fit<HasMeanPredictImpl>>::value));
 
 
-  EXPECT_TRUE(bool(has_valid_predict_mean<HasMeanPredictImpl, X, Fit<HasMeanPredictImpl>>::value));
   EXPECT_TRUE(
-      bool(has_valid_predict_marginal<HasMarginalPredictImpl, X, Fit<HasMarginalPredictImpl>>::value));
-  EXPECT_TRUE(bool(has_valid_predict_joint<HasJointPredictImpl, X, Fit<HasJointPredictImpl>>::value));
-  EXPECT_TRUE(bool(has_valid_predict_mean<HasAllPredictImpls, X, Fit<HasAllPredictImpls>>::value));
-  EXPECT_TRUE(bool(has_valid_predict_marginal<HasAllPredictImpls, X, Fit<HasAllPredictImpls>>::value));
-  EXPECT_TRUE(bool(has_valid_predict_joint<HasAllPredictImpls, X, Fit<HasAllPredictImpls>>::value));
+      bool(has_valid_predict_marginal<HasMarginalPredictImpl, X,
+                                      Fit<HasMarginalPredictImpl>>::value));
+  EXPECT_FALSE(bool(has_valid_predict_mean<HasMarginalPredictImpl, X, Fit<HasMarginalPredictImpl>>::value));
+  EXPECT_FALSE(bool(has_valid_predict_joint<HasMarginalPredictImpl, X, Fit<HasMarginalPredictImpl>>::value));
+
+
+  EXPECT_TRUE(bool(has_valid_predict_joint<HasJointPredictImpl, X,
+                                           Fit<HasJointPredictImpl>>::value));
+  EXPECT_FALSE(bool(has_valid_predict_mean<HasJointPredictImpl, X, Fit<HasJointPredictImpl>>::value));
+  EXPECT_FALSE(bool(has_valid_predict_marginal<HasJointPredictImpl, X, Fit<HasJointPredictImpl>>::value));
+
+
+  EXPECT_TRUE(bool(has_valid_predict_mean<HasAllPredictImpls, X,
+                                          Fit<HasAllPredictImpls>>::value));
+  EXPECT_TRUE(bool(has_valid_predict_marginal<HasAllPredictImpls, X,
+                                              Fit<HasAllPredictImpls>>::value));
+  EXPECT_TRUE(bool(has_valid_predict_joint<HasAllPredictImpls, X,
+                                           Fit<HasAllPredictImpls>>::value));
 }
 
 class HasName {
 public:
-  std::string name() const {return "name";};
+  std::string name() const { return "name"; };
 };
 
 class HasNoName {};
@@ -312,6 +342,5 @@ TEST(test_traits_covariance, test_has_name) {
   EXPECT_TRUE(bool(has_name<HasName>::value));
   EXPECT_FALSE(bool(has_name<HasNoName>::value));
 }
-
 
 } // namespace albatross

--- a/tests/test_traits_covariance_functions.cc
+++ b/tests/test_traits_covariance_functions.cc
@@ -10,10 +10,20 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include "core/traits.h"
+#include "CovarianceFunctions"
+
 #include <gtest/gtest.h>
 
 namespace albatross {
+
+class Complete {};
+
+class Incomplete;
+
+TEST(test_traits_covariance, test_is_complete) {
+  EXPECT_TRUE(bool(is_complete<Complete>::value));
+  EXPECT_FALSE(bool(is_complete<Incomplete>::value));
+}
 
 struct X {};
 struct Y {};
@@ -35,7 +45,7 @@ class HasPrivateCallOperator {
 
 class HasNoCallOperator {};
 
-TEST(test_traits, test_has_call_operator) {
+TEST(test_traits_covariance, test_has_call_operator) {
   EXPECT_TRUE(bool(has_call_operator<HasPublicCallOperator, X, Y>::value));
   EXPECT_FALSE(bool(has_call_operator<HasPrivateCallOperator, X, Y>::value));
   EXPECT_FALSE(bool(has_call_operator<HasProtectedCallOperator, X, Y>::value));
@@ -58,7 +68,7 @@ class HasPrivateCallImpl {
 
 class HasNoCallImpl {};
 
-TEST(test_traits, test_has_any_call_impl_) {
+TEST(test_traits_covariance, test_has_any_call_impl_) {
   EXPECT_TRUE(bool(has_any_call_impl<HasPublicCallImpl>::value));
   EXPECT_TRUE(bool(has_any_call_impl<HasProtectedCallImpl>::value));
   EXPECT_TRUE(bool(has_any_call_impl<HasPrivateCallImpl>::value));
@@ -81,7 +91,7 @@ public:
   int call_impl_(const Z &, const Z &) const { return 1.; };
 };
 
-TEST(test_traits, test_has_valid_call_impl) {
+TEST(test_traits_covariance, test_has_valid_call_impl) {
   EXPECT_TRUE(bool(has_valid_call_impl<HasPublicCallImpl, X, Y>::value));
   EXPECT_FALSE(bool(has_valid_call_impl<HasPublicCallImpl, Y, X>::value));
   EXPECT_TRUE(
@@ -100,7 +110,7 @@ TEST(test_traits, test_has_valid_call_impl) {
  * Here we test to make sure we can identify situations where
  * call_impl_ has been defined but not necessarily properly.
  */
-TEST(test_traits, test_has_possible_call_impl) {
+TEST(test_traits_covariance, test_has_possible_call_impl) {
   EXPECT_TRUE(bool(has_possible_call_impl<HasPublicCallImpl, X, Y>::value));
   EXPECT_FALSE(bool(has_possible_call_impl<HasPublicCallImpl, Y, X>::value));
   EXPECT_TRUE(
@@ -115,7 +125,7 @@ TEST(test_traits, test_has_possible_call_impl) {
       bool(has_possible_call_impl<HasMultiplePublicCallImpl, Z, Z>::value));
 }
 
-TEST(test_traits, test_has_invalid_call_impl) {
+TEST(test_traits_covariance, test_has_invalid_call_impl) {
   EXPECT_FALSE(bool(has_invalid_call_impl<HasPublicCallImpl, X, Y>::value));
   EXPECT_FALSE(bool(has_invalid_call_impl<HasPublicCallImpl, Y, X>::value));
   EXPECT_FALSE(
@@ -128,75 +138,6 @@ TEST(test_traits, test_has_invalid_call_impl) {
       bool(has_invalid_call_impl<HasMultiplePublicCallImpl, Z, Y>::value));
   EXPECT_TRUE(
       bool(has_invalid_call_impl<HasMultiplePublicCallImpl, Z, Z>::value));
-}
-
-class ValidInOutSerializer {
-public:
-  template <typename Archive> void serialize(Archive &){};
-};
-
-class ValidSaveLoadSerializer {
-public:
-  template <typename Archive> void save(Archive &) const {};
-
-  template <typename Archive> void load(Archive &){};
-};
-
-class ValidInSerializer {
-public:
-  template <typename Archive> void load(Archive &){};
-};
-
-class ValidOutSerializer {
-public:
-  template <typename Archive> void save(Archive &) const {};
-};
-
-class InValidInOutSerializer {};
-
-TEST(test_traits, test_valid_in_out_serializer) {
-  EXPECT_TRUE(bool(valid_in_out_serializer<ValidInOutSerializer, X>::value));
-  EXPECT_TRUE(bool(valid_in_out_serializer<ValidSaveLoadSerializer, X>::value));
-  EXPECT_FALSE(bool(valid_in_out_serializer<ValidInSerializer, X>::value));
-  EXPECT_FALSE(bool(valid_in_out_serializer<ValidOutSerializer, X>::value));
-  EXPECT_FALSE(bool(valid_in_out_serializer<InValidInOutSerializer, X>::value));
-}
-
-TEST(test_traits, test_valid_input_serializer) {
-  EXPECT_TRUE(bool(valid_input_serializer<ValidInOutSerializer, X>::value));
-  EXPECT_TRUE(bool(valid_input_serializer<ValidSaveLoadSerializer, X>::value));
-  EXPECT_TRUE(bool(valid_input_serializer<ValidInSerializer, X>::value));
-  EXPECT_FALSE(bool(valid_input_serializer<ValidOutSerializer, X>::value));
-  EXPECT_FALSE(bool(valid_input_serializer<InValidInOutSerializer, X>::value));
-}
-
-TEST(test_traits, test_valid_output_serializer) {
-  EXPECT_TRUE(bool(valid_output_serializer<ValidInOutSerializer, X>::value));
-  EXPECT_TRUE(bool(valid_output_serializer<ValidSaveLoadSerializer, X>::value));
-  EXPECT_FALSE(bool(valid_output_serializer<ValidInSerializer, X>::value));
-  EXPECT_TRUE(bool(valid_output_serializer<ValidOutSerializer, X>::value));
-  EXPECT_FALSE(bool(valid_output_serializer<InValidInOutSerializer, X>::value));
-}
-
-class Complete {};
-
-class Incomplete;
-
-TEST(test_traits, test_is_complete) {
-  EXPECT_TRUE(bool(is_complete<Complete>::value));
-  EXPECT_FALSE(bool(is_complete<Incomplete>::value));
-}
-
-class HasName {
-public:
-  std::string name_;
-};
-
-class HasNoName {};
-
-TEST(test_traits, test_has_name) {
-  EXPECT_TRUE(bool(has_name_<HasName>::value));
-  EXPECT_FALSE(bool(has_name_<HasNoName>::value));
 }
 
 } // namespace albatross


### PR DESCRIPTION
This change breaks up `traits.h` into several application specific traits files: `core/traits.h`, `covariance_functions/traits.h` and `cereal/traits.h`.  And breaks up `test_traits.cc` respectively.  The bulk of this change is a result of the moves and adding tests, but `core/traits.h` has changed substantially.  

Namely, I've added the following traits:  `first_template_param_is_base_of`, `is_valid_fit_type`, `has_valid_fit`, `has_possible_fit`, `fit_model_type`, `fit_type` and `has_valid_predict`.

These are already being used in `ModelBase`, `FitModel` and `Predictions`, look there for example usage.