### PR TITLE
CRTP: Tuning

### DIFF
--- a/albatross/tune.h
+++ b/albatross/tune.h
@@ -13,14 +13,10 @@
 #ifndef ALBATROSS_TUNE_H
 #define ALBATROSS_TUNE_H
 
-#include "core/model.h"
-#include "evaluate.h"
-#include "nlopt.hpp"
-#include "tuning_metrics.h"
-#include <map>
-#include <vector>
-
 namespace albatross {
+
+template <typename ModelType, typename MetricType, class FeatureType>
+struct ModelTuner;
 
 inline std::string to_string(const nlopt::result result) {
   std::map<nlopt::result, std::string> result_strings = {
@@ -38,41 +34,96 @@ inline std::string to_string(const nlopt::result result) {
   return result_strings[result];
 }
 
-template <class FeatureType> struct TuneModelConfig {
-  RegressionModelCreator<FeatureType> model_creator;
+/*
+ * This function API is defined by nlopt, when an optimization algorithm
+ * requires the gradient nlopt expects that the grad argument gets
+ * modified inside this function.  The TuneModelConfig which holds
+ * any information about which functions to call etc, needs to be passed
+ * in through a void pointer.
+ */
+template <typename ModelType, typename MetricType, typename FeatureType>
+double objective_function(const std::vector<double> &x,
+                          std::vector<double> &grad, void *void_tune_config) {
+  if (!grad.empty()) {
+    throw std::invalid_argument("The algorithm being used by nlopt requires"
+                                "a gradient but one isn't available.");
+  }
+
+  const ModelTuner<ModelType, MetricType, FeatureType> config =
+      *static_cast<ModelTuner<ModelType, MetricType, FeatureType> *>(
+          void_tune_config);
+
+  ModelType model(config.model);
+  model.set_tunable_params_values(x);
+
+  if (!model.params_are_valid()) {
+    config.output_stream << "Invalid Parameters:" << std::endl;
+    config.output_stream << pretty_param_details(model.get_params())
+                         << std::endl;
+    assert(false);
+  }
+
+  std::vector<double> metrics;
+  for (std::size_t i = 0; i < config.datasets.size(); i++) {
+    metrics.push_back(config.metric(config.datasets[i], model));
+  }
+  double metric = config.aggregator(metrics);
+
+  if (std::isnan(metric)) {
+    metric = INFINITY;
+  }
+  config.output_stream << "-------------------" << std::endl;
+  config.output_stream << model.pretty_string() << std::endl;
+  config.output_stream << "objective: " << metric << std::endl;
+  config.output_stream << "-------------------" << std::endl;
+  return metric;
+}
+
+template <typename ModelType, typename MetricType, class FeatureType>
+struct ModelTuner {
+  ModelType model;
+  MetricType metric;
   std::vector<RegressionDataset<FeatureType>> datasets;
-  TuningMetric<FeatureType> metric;
   TuningMetricAggregator aggregator;
   std::ostream &output_stream;
   nlopt::opt optimizer;
 
-  TuneModelConfig(const RegressionModelCreator<FeatureType> &model_creator_,
-                  const RegressionDataset<FeatureType> &dataset_,
-                  const TuningMetric<FeatureType> &metric_,
-                  const TuningMetricAggregator &aggregator_ = mean_aggregator,
-                  std::ostream &output_stream_ = std::cout)
-      : model_creator(model_creator_), datasets({dataset_}), metric(metric_),
+  ModelTuner(const ModelType &model_, const MetricType &metric_,
+             const std::vector<RegressionDataset<FeatureType>> &datasets_,
+             const TuningMetricAggregator &aggregator_,
+             std::ostream &output_stream_)
+      : model(model_), metric(metric_), datasets(datasets_),
         aggregator(aggregator_), output_stream(output_stream_), optimizer() {
-    set_default_optimizer();
+    initialize_optimizer();
   };
 
-  TuneModelConfig(const RegressionModelCreator<FeatureType> &model_creator_,
-                  const std::vector<RegressionDataset<FeatureType>> &datasets_,
-                  const TuningMetric<FeatureType> &metric_,
-                  const TuningMetricAggregator &aggregator_ = mean_aggregator,
-                  std::ostream &output_stream_ = std::cout)
-      : model_creator(model_creator_), datasets(datasets_), metric(metric_),
-        aggregator(aggregator_), output_stream(output_stream_), optimizer() {
-    set_default_optimizer();
-  };
+  ParameterStore tune() {
+    auto x = model.get_tunable_parameters().values;
+
+    assert(x.size());
+    optimizer.set_min_objective(
+        objective_function<ModelType, MetricType, FeatureType>, (void *)this);
+    double minf;
+    nlopt::result result = optimizer.optimize(x, minf);
+
+    // Tell the user what the final parameters were.
+    model.set_tunable_params_values(x);
+    output_stream << "==================" << std::endl;
+    output_stream << "TUNED MODEL PARAMS" << std::endl;
+    output_stream << "nlopt termination code: " << to_string(result)
+                  << std::endl;
+    output_stream << "==================" << std::endl;
+    output_stream << model.pretty_string() << std::endl;
+
+    return model.get_params();
+  }
 
   void
-  set_default_optimizer(const nlopt::algorithm &algorithm = nlopt::LN_PRAXIS) {
+  initialize_optimizer(const nlopt::algorithm &algorithm = nlopt::LN_PRAXIS) {
     // The various algorithms in nlopt are coded by the first two characters.
     // In this case LN stands for local, gradient free.
-    auto m = model_creator();
+    auto tunable_params = model.get_tunable_parameters();
 
-    auto tunable_params = m->get_tunable_parameters();
     optimizer = nlopt::opt(algorithm, (unsigned)tunable_params.values.size());
     optimizer.set_ftol_abs(1e-8);
     optimizer.set_ftol_rel(1e-6);
@@ -86,74 +137,24 @@ template <class FeatureType> struct TuneModelConfig {
   }
 };
 
-/*
- * This function API is defined by nlopt, when an optimization algorithm
- * requires the gradient nlopt expects that the grad argument gets
- * modified inside this function.  The TuneModelConfig which holds
- * any information about which functions to call etc, needs to be passed
- * in through a void pointer.
- */
-template <class FeatureType>
-double objective_function(const std::vector<double> &x,
-                          std::vector<double> &grad, void *void_tune_config) {
-  if (!grad.empty()) {
-    throw std::invalid_argument("The algorithm being used by nlopt requires"
-                                "a gradient but one isn't available.");
-  }
-
-  const TuneModelConfig<FeatureType> config =
-      *static_cast<TuneModelConfig<FeatureType> *>(void_tune_config);
-
-  const auto model = config.model_creator();
-
-  model->set_tunable_params_values(x);
-
-  if (!model->params_are_valid()) {
-    config.output_stream << "Invalid Parameters:" << std::endl;
-    config.output_stream << pretty_param_details(model->get_params())
-                         << std::endl;
-    assert(false);
-  }
-
-  std::vector<double> metrics;
-  for (std::size_t i = 0; i < config.datasets.size(); i++) {
-    metrics.push_back(config.metric(config.datasets[i], model.get()));
-  }
-  double metric = config.aggregator(metrics);
-
-  if (std::isnan(metric)) {
-    metric = INFINITY;
-  }
-  config.output_stream << "-------------------" << std::endl;
-  config.output_stream << model->pretty_string() << std::endl;
-  config.output_stream << "objective: " << metric << std::endl;
-  config.output_stream << "-------------------" << std::endl;
-  return metric;
+template <typename ModelType, typename MetricType, typename FeatureType>
+auto get_tuner(const ModelType &model, const MetricType &metric,
+               const std::vector<RegressionDataset<FeatureType>> &datasets,
+               const TuningMetricAggregator &aggregator = mean_aggregator,
+               std::ostream &output_stream = std::cout) {
+  return ModelTuner<ModelType, MetricType, FeatureType>(
+      model, metric, datasets, aggregator, output_stream);
 }
 
-template <class FeatureType>
-ParameterStore
-tune_regression_model(const TuneModelConfig<FeatureType> &config) {
-
-  const auto example_model = config.model_creator();
-  auto x = example_model->get_tunable_parameters().values;
-
-  assert(x.size());
-  nlopt::opt opt = config.optimizer;
-  opt.set_min_objective(objective_function<FeatureType>, (void *)&config);
-  double minf;
-  nlopt::result result = opt.optimize(x, minf);
-
-  // Tell the user what the final parameters were.
-  example_model->set_tunable_params_values(x);
-  config.output_stream << "==================" << std::endl;
-  config.output_stream << "TUNED MODEL PARAMS" << std::endl;
-  config.output_stream << "nlopt termination code: " << to_string(result)
-                       << std::endl;
-  config.output_stream << "==================" << std::endl;
-  config.output_stream << example_model->pretty_string() << std::endl;
-
-  return example_model->get_params();
+template <typename ModelType, typename MetricType, typename FeatureType>
+auto get_tuner(const ModelType &model, const MetricType &metric,
+               const RegressionDataset<FeatureType> &dataset,
+               const TuningMetricAggregator &aggregator = mean_aggregator,
+               std::ostream &output_stream = std::cout) {
+  std::vector<RegressionDataset<FeatureType>> datasets;
+  datasets.emplace_back(dataset);
+  return get_tuner(model, metric, datasets, aggregator, output_stream);
 }
+
 } // namespace albatross
 #endif

--- a/albatross/tuning_metrics.h
+++ b/albatross/tuning_metrics.h
@@ -13,52 +13,7 @@
 #ifndef ALBATROSS_TUNING_METRICS_H
 #define ALBATROSS_TUNING_METRICS_H
 
-#include "core/model.h"
-#include "core/serialize.h"
-#include "evaluate.h"
-#include "models/gp.h"
-#include <map>
-#include <vector>
-
 namespace albatross {
-
-template <typename FeatureType>
-using TuningMetric = std::function<double(
-    const RegressionDataset<FeatureType> &, RegressionModel<FeatureType> *)>;
-
-template <typename FeatureType, typename SubFeatureType = FeatureType>
-inline double gp_nll(const RegressionDataset<FeatureType> &dataset,
-                     RegressionModel<FeatureType> *model) {
-  using SerializableGP =
-      SerializableRegressionModel<FeatureType,
-                                  GaussianProcessFit<SubFeatureType>>;
-  SerializableGP *gp_model = static_cast<SerializableGP *>(model);
-  gp_model->fit(dataset);
-  GaussianProcessFit<SubFeatureType> model_fit = gp_model->get_fit();
-
-  double nll =
-      negative_log_likelihood(dataset.targets.mean, model_fit.train_ldlt);
-  nll -= model->prior_log_likelihood();
-  return nll;
-}
-
-inline double loo_nll(const RegressionDataset<double> &dataset,
-                      RegressionModel<double> *model) {
-  auto loo_indexer = leave_one_out_indexer(dataset);
-  EvaluationMetric<JointDistribution> nll =
-      evaluation_metrics::negative_log_likelihood;
-  double prior_nll = model->prior_log_likelihood();
-  return cross_validated_scores(nll, dataset, loo_indexer, model).sum() -
-         prior_nll;
-}
-
-inline double loo_rmse(const RegressionDataset<double> &dataset,
-                       RegressionModel<double> *model) {
-  auto loo_indexer = leave_one_out_indexer(dataset);
-  EvaluationMetric<Eigen::VectorXd> rmse =
-      evaluation_metrics::root_mean_square_error;
-  return cross_validated_scores(rmse, dataset, loo_indexer, model).mean();
-}
 
 using TuningMetricAggregator =
     std::function<double(const std::vector<double> &metrics)>;
@@ -74,6 +29,44 @@ inline double mean_aggregator(const std::vector<double> &metrics) {
   mean /= static_cast<double>(metrics.size());
   return mean;
 }
+
+struct GaussianProcessLikelihoodTuningMetric {
+
+  template <typename FeatureType, typename CovFunc, typename GPImplType>
+  double
+  operator()(const RegressionDataset<FeatureType> &dataset,
+             const GaussianProcessBase<CovFunc, GPImplType> &model) const {
+    const auto gp_fit = model.fit(dataset).get_fit();
+    double nll =
+        negative_log_likelihood(dataset.targets.mean, gp_fit.train_ldlt);
+    nll -= model.prior_log_likelihood();
+    return nll;
+  }
+};
+
+struct LeaveOneOutLikelihood {
+
+  template <typename FeatureType, typename ModelType>
+  double operator()(const RegressionDataset<FeatureType> &dataset,
+                    const ModelBase<ModelType> &model) const {
+    NegativeLogLikelihood<JointDistribution> nll;
+    LeaveOneOut loo;
+    const auto scores = model.cross_validate().scores(nll, dataset, loo);
+    double data_nll = scores.sum();
+    double prior_nll = model.prior_log_likelihood();
+    return data_nll + prior_nll;
+  }
+};
+
+struct LeaveOneOutRMSE {
+  template <typename FeatureType, typename ModelType>
+  double operator()(const RegressionDataset<FeatureType> &dataset,
+                    const ModelBase<ModelType> &model) const {
+    RootMeanSquareError rmse;
+    LeaveOneOut loo;
+    return model.cross_validate().scores(rmse, dataset, loo).mean();
+  }
+};
 
 } // namespace albatross
 #endif

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -10,112 +10,110 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include "covariance_functions/covariance_functions.h"
-#include "evaluate.h"
-#include "models/gp.h"
-#include "test_utils.h"
-#include "tune.h"
 #include <gtest/gtest.h>
+
+#include "Tune"
+#include "test_models.h"
 
 namespace albatross {
 
 TEST(test_tune, test_single_dataset) {
-  auto dataset = make_toy_linear_data();
+  const MakeGaussianProcess test_case;
+  auto dataset = test_case.get_dataset();
+  auto model = test_case.get_model();
 
-  auto model_creator = toy_gaussian_process;
-
-  TuningMetric<double> metric = loo_nll;
+  LeaveOneOutLikelihood loo_nll;
   std::ostringstream output_stream;
-  TuneModelConfig<double> config(model_creator, dataset, metric,
-                                 albatross::mean_aggregator, output_stream);
-  config.optimizer.set_maxeval(20);
-  auto params = tune_regression_model(config);
+  auto tuner =
+      get_tuner(model, loo_nll, dataset, mean_aggregator, output_stream);
+  tuner.optimizer.set_maxeval(20);
+  auto params = tuner.tune();
+
+  NegativeLogLikelihood<JointDistribution> nll;
+  LeaveOneOut loo;
+  const auto scores = model.cross_validate().scores(nll, dataset, loo);
+
+  model.set_params(params);
+  const auto scores_post_tuning =
+      model.cross_validate().scores(nll, dataset, loo);
+
+  EXPECT_LT(scores_post_tuning.mean(), scores.mean());
 }
 
 TEST(test_tune, test_with_prior_bounds) {
   // Here we create a situation where tuning should hit a few
   // invalid parameters which will result in a NAN objective
   // function and we want to make sure the tuning recovers.
-  auto dataset = make_toy_linear_data();
+  const MakeGaussianProcess test_case;
+  auto dataset = test_case.get_dataset();
+  auto model = test_case.get_model();
 
-  auto model_with_prior = [] {
-    auto model_creator = toy_gaussian_process;
-    auto model = model_creator();
-    for (const auto &pair : model->get_params()) {
-      Parameter param = {1.e-8, std::make_shared<PositivePrior>()};
-      model->set_param(pair.first, param);
-    }
-    return model;
-  };
+  for (const auto &pair : model.get_params()) {
+    Parameter param = {1.e-8, std::make_shared<PositivePrior>()};
+    model.set_param(pair.first, param);
+  }
 
-  TuningMetric<double> metric = loo_nll;
+  LeaveOneOutLikelihood loo_nll;
   std::ostringstream output_stream;
-  TuneModelConfig<double> config(model_with_prior, dataset, metric,
-                                 albatross::mean_aggregator, output_stream);
-  config.optimizer.set_maxeval(20);
-  auto params = tune_regression_model(config);
-  auto m = model_with_prior();
-  m->set_params(params);
-  EXPECT_TRUE(m->params_are_valid());
+  auto tuner =
+      get_tuner(model, loo_nll, dataset, mean_aggregator, output_stream);
+  tuner.optimizer.set_maxeval(20);
+  auto params = tuner.tune();
+
+  model.set_params(params);
+  EXPECT_TRUE(model.params_are_valid());
 }
 
 TEST(test_tune, test_with_prior) {
-  // Here we create a situation where tuning should hit a few
-  // invalid parameters which will result in a NAN objective
-  // function and we want to make sure the tuning recovers.
-  auto dataset = make_toy_linear_data();
+  const MakeGaussianProcess test_case;
+  auto dataset = test_case.get_dataset();
+  auto model_no_priors = test_case.get_model();
 
-  auto model_with_prior = [] {
-    auto model_creator = toy_gaussian_process;
-    auto model = model_creator();
-    for (const auto &pair : model->get_params()) {
-      model->set_prior(pair.first, std::make_shared<GaussianPrior>(
-                                       pair.second.value + 0.1, 0.001));
-    }
-    auto param_names = map_keys(model->get_params());
-    model->set_prior(param_names[0], std::make_shared<FixedPrior>());
-    return model;
-  };
+  auto model_with_priors = test_case.get_model();
+  for (const auto &pair : model_with_priors.get_params()) {
+    model_with_priors.set_prior(
+        pair.first,
+        std::make_shared<GaussianPrior>(pair.second.value + 0.1, 0.001));
+  }
+  auto param_names = map_keys(model_with_priors.get_params());
+  model_with_priors.set_prior(param_names[0], std::make_shared<FixedPrior>());
 
-  // Tune with a prior
-  TuningMetric<double> metric = loo_nll;
+  LeaveOneOutLikelihood loo_nll;
   std::ostringstream output_stream;
-  TuneModelConfig<double> config(model_with_prior, dataset, metric,
-                                 albatross::mean_aggregator, output_stream);
-  config.optimizer.set_maxeval(20);
-  auto params = tune_regression_model(config);
+  auto tuner = get_tuner(model_with_priors, loo_nll, dataset, mean_aggregator,
+                         output_stream);
+  tuner.optimizer.set_maxeval(20);
+  auto params = tuner.tune();
 
-  // Tune without a prior
-  TuneModelConfig<double> config_no_prior(toy_gaussian_process, dataset, metric,
-                                          albatross::mean_aggregator,
-                                          output_stream);
-  config_no_prior.optimizer.set_maxeval(20);
-  auto params_no_prior = tune_regression_model(config_no_prior);
+  auto tuner_no_priors = get_tuner(model_no_priors, loo_nll, dataset,
+                                   mean_aggregator, output_stream);
+  tuner_no_priors.optimizer.set_maxeval(20);
+  auto params_no_prior = tuner.tune();
 
-  // Make sure tuning to the prior results in parameters that are
-  // more likely.
-  auto m = model_with_prior();
-  m->set_params(params);
-  double ll_with_prior = m->prior_log_likelihood();
+  model_with_priors.set_params(params);
+  double ll_with_prior = model_with_priors.prior_log_likelihood();
 
   for (const auto &pair : params_no_prior) {
-    m->set_param(pair.first, pair.second.value);
+    model_with_priors.set_param(pair.first, pair.second.value);
   }
-  EXPECT_GT(ll_with_prior, m->prior_log_likelihood());
+  EXPECT_GT(ll_with_prior, model_with_priors.prior_log_likelihood());
 }
 
 TEST(test_tune, test_multiple_datasets) {
+  const MakeGaussianProcess test_case;
+  auto model_no_priors = test_case.get_model();
+
   auto one_dataset = make_toy_linear_data(2., 4., 0.2);
   auto another_dataset = make_toy_linear_data(1., 5., 0.1);
   std::vector<RegressionDataset<double>> datasets = {one_dataset,
                                                      another_dataset};
-  auto model_creator = toy_gaussian_process;
-  TuningMetric<double> metric = loo_nll;
+
+  LeaveOneOutLikelihood loo_nll;
   std::ostringstream output_stream;
-  TuneModelConfig<double> config(model_creator, datasets, metric,
-                                 albatross::mean_aggregator, output_stream);
-  config.optimizer.set_maxeval(20);
-  auto params = tune_regression_model(config);
+  auto tuner = get_tuner(model_no_priors, loo_nll, datasets, mean_aggregator,
+                         output_stream);
+  tuner.optimizer.set_maxeval(20);
+  auto params = tuner.tune();
 }
 
 } // namespace albatross


### PR DESCRIPTION
Modifies the tuning scripts to work with the new model design.

The largest difference was switching the `TuneModelConfig` to become a `ModelTuner` which now contains the logic that actually runs tuning.  The new syntax looks like:

```
auto tuner = get_tuner(model, metric, dataset);
tuner.optimizer.set_maxeval(100);
auto params = tuner.tune();
```

instead of:
```
TuneModelConfig<double> config(model_creator, dataset, metric);
config.optimizer.set_maxeval(100);
auto params = tune_regression_model(config);
```

