### PR TITLE
CRTP: Serialization

### DIFF
--- a/albatross/core/fit_model.h
+++ b/albatross/core/fit_model.h
@@ -23,10 +23,17 @@ public:
       std::is_move_constructible<Fit>::value,
       "Fit type must be move constructible to avoid unexpected copying.");
 
+  FitModel(){};
+
   FitModel(const ModelType &model, const Fit &fit) = delete;
 
   FitModel(const ModelType &model, Fit &&fit)
       : model_(model), fit_(std::move(fit)) {}
+
+  template <class Archive> void serialize(Archive &archive) {
+    archive(cereal::make_nvp("model", model_));
+    archive(cereal::make_nvp("fit", fit_));
+  }
 
   template <typename PredictFeatureType>
   Prediction<ModelType, PredictFeatureType, Fit>
@@ -37,9 +44,13 @@ public:
 
   Fit get_fit() const { return fit_; }
 
+  bool operator==(const FitModel &other) const {
+    return (model_ == other.model_ && fit_ == other.fit_);
+  }
+
 private:
-  const ModelType model_;
-  const Fit fit_;
+  ModelType model_;
+  Fit fit_;
 };
 }
 #endif

--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -92,6 +92,24 @@ private:
   }
 
 public:
+  template <class Archive> void save(Archive &archive) const {
+    archive(cereal::make_nvp("params", derived().get_params()));
+    archive(cereal::make_nvp("insights", insights_));
+  }
+
+  template <class Archive> void load(Archive &archive) {
+    ParameterStore params;
+    archive(cereal::make_nvp("params", params));
+    derived().set_params(params);
+    archive(cereal::make_nvp("insights", insights_));
+  }
+
+  bool operator==(const ModelType &other) const {
+    return (derived().get_params() == other.get_params() &&
+            derived().get_name() == other.get_name() &&
+            derived().insights_ == other.insights_);
+  }
+
   template <typename DummyType = ModelType,
             typename std::enable_if<!has_name<DummyType>::value, int>::type = 0>
   std::string get_name() {

--- a/albatross/models/ransac.h
+++ b/albatross/models/ransac.h
@@ -165,7 +165,13 @@ struct Fit<Ransac<ModelType, MetricType>, FeatureType> {
 
   using FitModelType = typename fit_model_type<ModelType, FeatureType>::type;
 
+  Fit(){};
+
   Fit(const FitModelType &fit_model_) : fit_model(fit_model_){};
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::make_nvp("fit_model", fit_model));
+  }
 
   FitModelType fit_model;
 };
@@ -176,6 +182,8 @@ struct Fit<Ransac<ModelType, MetricType>, FeatureType> {
 template <typename ModelType, typename MetricType>
 class Ransac : public ModelBase<Ransac<ModelType, MetricType>> {
 public:
+  Ransac(){};
+
   Ransac(const ModelType &sub_model, const MetricType &metric,
          double inlier_threshold, std::size_t min_inliers,
          std::size_t random_sample_size, std::size_t max_iterations)
@@ -225,6 +233,19 @@ public:
                       PredictTypeIdentity<PredictType> &&) const {
     return ransac_fit_.fit_model.get_prediction(features)
         .template get<PredictType>();
+  }
+
+  // Hide any inherited save/load methods.
+  void save() const;
+  void load();
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::make_nvp("sub_model", sub_model_));
+    archive(cereal::make_nvp("metric", metric_));
+    archive(cereal::make_nvp("inlier_threshold", inlier_threshold_));
+    archive(cereal::make_nvp("min_inliers", min_inliers_));
+    archive(cereal::make_nvp("random_sample_size", random_sample_size_));
+    archive(cereal::make_nvp("max_iterations", max_iterations_));
   }
 
   ModelType sub_model_;


### PR DESCRIPTION
This enables things like:
```
  const auto fit_model = model.get_fit_model(dataset);
  // Serialize it
  std::ostringstream os;
  {
    cereal::JSONOutputArchive oarchive(os);
    oarchive(fit_model);
  }
  // Deserialize it.
  std::istringstream is(os.str());
  decltype(fit_model) deserialized;
  {
    cereal::JSONInputArchive iarchive(is);
    iarchive(deserialized);
  }
  fit_model == deserialized;
```
Same with `model.ransac().get_fit_model(dataset)`;

Note: I'm going to add versions to the serialization, but I'm keeping that for a subsequent PR to avoid merging issues in PRs I have lined up already.