### PR TITLE
CRTP: Rename

### DIFF
--- a/albatross/core/fit_model.h
+++ b/albatross/core/fit_model.h
@@ -37,7 +37,7 @@ public:
 
   template <typename PredictFeatureType>
   Prediction<ModelType, PredictFeatureType, Fit>
-  get_prediction(const std::vector<PredictFeatureType> &features) const {
+  predict(const std::vector<PredictFeatureType> &features) const {
     return Prediction<ModelType, PredictFeatureType, Fit>(model_, fit_,
                                                           features);
   }

--- a/albatross/core/model.h
+++ b/albatross/core/model.h
@@ -40,10 +40,11 @@ private:
   template <typename FeatureType,
             typename std::enable_if<
                 has_valid_fit<ModelType, FeatureType>::value, int>::type = 0>
-  auto fit_(const std::vector<FeatureType> &features,
+  auto _fit(const std::vector<FeatureType> &features,
             const MarginalDistribution &targets) const {
-    auto fit = derived().fit(features, targets);
-    return FitModel<ModelType, decltype(fit)>(derived(), std::move(fit));
+    auto fit_output = derived()._fit_impl(features, targets);
+    return FitModel<ModelType, decltype(fit_output)>(derived(),
+                                                     std::move(fit_output));
   }
 
   template <
@@ -51,7 +52,7 @@ private:
       typename std::enable_if<has_possible_fit<ModelType, FeatureType>::value &&
                                   !has_valid_fit<ModelType, FeatureType>::value,
                               int>::type = 0>
-  void fit_(const std::vector<FeatureType> &features,
+  void _fit(const std::vector<FeatureType> &features,
             const MarginalDistribution &targets) const = delete; // Invalid fit
 
   template <typename FeatureType,
@@ -60,7 +61,7 @@ private:
                     !has_valid_fit<ModelType, FeatureType>::value,
                 int>::type = 0>
   void
-  fit_(const std::vector<FeatureType> &features,
+  _fit(const std::vector<FeatureType> &features,
        const MarginalDistribution &targets) const = delete; // No fit found.
 
   template <
@@ -69,9 +70,10 @@ private:
                                                 FitType, PredictType>::value,
                               int>::type = 0>
   PredictType predict_(const std::vector<PredictFeatureType> &features,
-                       const FitType &fit,
+                       const FitType &fit_,
                        PredictTypeIdentity<PredictType> &&) const {
-    return derived().predict(features, fit, PredictTypeIdentity<PredictType>());
+    return derived()._predict_impl(features, fit_,
+                                   PredictTypeIdentity<PredictType>());
   }
 
   template <
@@ -123,14 +125,14 @@ public:
   }
 
   template <typename FeatureType>
-  auto get_fit_model(const std::vector<FeatureType> &features,
-                     const MarginalDistribution &targets) const {
-    return fit_(features, targets);
+  auto fit(const std::vector<FeatureType> &features,
+           const MarginalDistribution &targets) const {
+    return _fit(features, targets);
   }
 
   template <typename FeatureType>
-  auto get_fit_model(const RegressionDataset<FeatureType> &dataset) const {
-    return fit_(dataset.features, dataset.targets);
+  auto fit(const RegressionDataset<FeatureType> &dataset) const {
+    return _fit(dataset.features, dataset.targets);
   }
 
   CrossValidation<ModelType> cross_validate() const;

--- a/albatross/core/traits.h
+++ b/albatross/core/traits.h
@@ -78,14 +78,15 @@ struct is_valid_fit_type
 
 /*
  * This determines whether or not a class (T) has a method defined for,
- *   `Fit<U, FeatureType> fit(const std::vector<FeatureType>&,
+ *   `Fit<U, FeatureType> _fit_impl(const std::vector<FeatureType>&,
  *                            const MarginalDistribution &)`
  * where U is a base of T.
  */
 template <typename T, typename FeatureType> class has_valid_fit {
-  template <typename C, typename FitType = decltype(std::declval<const C>().fit(
-                            std::declval<const std::vector<FeatureType> &>(),
-                            std::declval<const MarginalDistribution &>()))>
+  template <typename C,
+            typename FitType = decltype(std::declval<const C>()._fit_impl(
+                std::declval<const std::vector<FeatureType> &>(),
+                std::declval<const MarginalDistribution &>()))>
   static typename is_valid_fit_type<T, FitType>::type test(C *);
   template <typename> static std::false_type test(...);
 
@@ -95,11 +96,11 @@ public:
 
 /*
  * This determines whether or not a class (T) has a method defined for,
- *   `Anything fit(std::vector<FeatureType>&,
+ *   `Anything _fit_impl(std::vector<FeatureType>&,
  *                 MarginalDistribution &)`
  */
 template <typename T, typename FeatureType> class has_possible_fit {
-  template <typename C, typename = decltype(std::declval<C>().fit(
+  template <typename C, typename = decltype(std::declval<C>()._fit_impl(
                             std::declval<std::vector<FeatureType> &>(),
                             std::declval<MarginalDistribution &>()))>
   static std::true_type test(C *);
@@ -112,14 +113,13 @@ public:
 /*
  * Determines which object would be returned from a call to:
  *
- *   T::get_fit_model(features, targets);
+ *   T::fit(features, targets);
  */
 template <typename T, typename FeatureType> class fit_model_type {
-  template <
-      typename C,
-      typename FitModelType = decltype(std::declval<const C>().get_fit_model(
-          std::declval<const std::vector<FeatureType> &>(),
-          std::declval<const MarginalDistribution &>()))>
+  template <typename C,
+            typename FitModelType = decltype(std::declval<const C>().fit(
+                std::declval<const std::vector<FeatureType> &>(),
+                std::declval<const MarginalDistribution &>()))>
   static FitModelType test(C *);
   template <typename> static void test(...);
 
@@ -149,18 +149,19 @@ struct fit_type<M, F>
 /*
  * A valid predict method has a signature that looks like:
  *
- *   PredictType predict(const std::vector<FeatureType> &,
+ *   PredictType _predict_impl(const std::vector<FeatureType> &,
  *                       const FitType &,
  *                       const PredictTypeIdentity<PredictType>) const;
  */
 template <typename T, typename FeatureType, typename FitType,
           typename PredictType>
 class has_valid_predict {
-  template <typename C,
-            typename ReturnType = decltype(std::declval<const C>().predict(
-                std::declval<const std::vector<FeatureType> &>(),
-                std::declval<const FitType &>(),
-                std::declval<PredictTypeIdentity<PredictType>>()))>
+  template <
+      typename C,
+      typename ReturnType = decltype(std::declval<const C>()._predict_impl(
+          std::declval<const std::vector<FeatureType> &>(),
+          std::declval<const FitType &>(),
+          std::declval<PredictTypeIdentity<PredictType>>()))>
   static typename std::enable_if<std::is_same<PredictType, ReturnType>::value,
                                  std::true_type>::type
   test(C *);

--- a/albatross/covariance_functions/covariance_function.h
+++ b/albatross/covariance_functions/covariance_function.h
@@ -31,7 +31,7 @@ template <typename Derived> class CallTrace;
  *
  *     std::string get_name() const {return "my_cov_func";}
  *
- *     double call_impl_(const X &x, const X &y) const {
+ *     double _call_impl(const X &x, const X &y) const {
  *       return covariance_between_x_and_y(x, y);
  *     }
  *
@@ -45,11 +45,11 @@ template <typename Derived> class CallTrace;
  *     virtual std::string get_name() const = 0;
  *
  *     template <typename X, typename Y=X>
- *     double call_impl_(const X &x, const Y &y) const = 0;
+ *     double _call_impl(const X &x, const Y &y) const = 0;
  *
  *     template <typename X, typename Y=X>
  *     double operator()(const X &x, const Y &y) const {
- *       return this->call_impl_(x, y);
+ *       return this->_call_impl(x, y);
  *     }
  *
  *   }
@@ -59,7 +59,7 @@ template <typename Derived> class CallTrace;
  * never compile.
  *
  * This is where CRTP comes in handy.  To write a new CovarianceFunction you
- * need to provide `call_impl_` functions for any pair of types you'd like to
+ * need to provide `_call_impl(` functions for any pair of types you'd like to
  * have defined.  The CovarianceFunction CRTP base class is then capable of
  * detecting which methods are required at compile time and creating the
  * corresponding operator() methods.  This also makes it possible to compose
@@ -85,7 +85,7 @@ public:
                 "implies you aren't using CRTP.  Implementations "
                 "of a CovarianceFunction should look something like:\n"
                 "\n\tclass Foo : public CovarianceFunction<Foo> {"
-                "\n\t\tdouble call_impl_(const X &x, const Y &y) const;"
+                "\n\t\tdouble _call_impl(const X &x, const Y &y) const;"
                 "\n\t\t..."
                 "\n\t}\n");
 
@@ -122,7 +122,7 @@ public:
             typename std::enable_if<
                 has_valid_call_impl<Derived, X &, Y &>::value, int>::type = 0>
   auto operator()(const X &x, const Y &y) const {
-    return derived().call_impl_(x, y);
+    return derived()._call_impl(x, y);
   }
 
   /*
@@ -135,7 +135,7 @@ public:
                                !has_valid_call_impl<Derived, X &, Y &>::value),
                               int>::type = 0>
   auto operator()(const X &x, const Y &y) const {
-    return derived().call_impl_(y, x);
+    return derived()._call_impl(y, x);
   }
 
   /*
@@ -145,7 +145,7 @@ public:
             typename std::enable_if<
                 has_valid_call_impl<Derived, X &, X &>::value, int>::type = 0>
   double operator()(const X &x) const {
-    return derived().call_impl_(x, x);
+    return derived()._call_impl(x, x);
   }
 
   /*
@@ -223,10 +223,10 @@ public:
                             (!has_valid_call_impl<Derived, X &, X &>::value &&
                              !has_possible_call_impl<Derived, X &, X &>::value),
                             int>::type = 0>
-  // There don't appear to be any call_impl_ methods with signature
-  // `double call_impl_(const X&, const X&) const`.
+  // There don't appear to be any _call_impl( methods with signature
+  // `double _call_impl(const X&, const X&) const`.
   double operator()(const X &x) const =
-      delete; // No call_impl_.  See comments for help.
+      delete; // No _call_impl(.  See comments for help.
 
   /*
    * Stubs to catch the case where a covariance function was called
@@ -236,11 +236,11 @@ public:
                             (!has_valid_call_impl<Derived, X &, X &>::value &&
                              has_invalid_call_impl<Derived, X &, X &>::value),
                             int>::type = 0>
-  // Here it seems there are no valid call_impl_ methods for these types
-  // but there are some invalid ones.  Be sure that the call_impl_ is
-  // defined in the form: `double call_impl_(const X&, const X&) const`.
+  // Here it seems there are no valid _call_impl( methods for these types
+  // but there are some invalid ones.  Be sure that the _call_impl( is
+  // defined in the form: `double _call_impl(const X&, const X&) const`.
   double operator()(const X &x) const =
-      delete; // Invalid call_impl_.  See comments for help.
+      delete; // Invalid _call_impl(.  See comments for help.
 
   template <typename X, typename Y,
             typename std::enable_if<
@@ -249,11 +249,11 @@ public:
                     (!has_possible_call_impl<Derived, X &, Y &>::value &&
                      !has_possible_call_impl<Derived, Y &, X &>::value),
                 int>::type = 0>
-  // There don't appear to be any call_impl_ methods with signature
-  // `double call_impl_(const X&, const Y&) const`.
+  // There don't appear to be any _call_impl( methods with signature
+  // `double _call_impl(const X&, const Y&) const`.
   double operator()(const X &x,
                     const Y &y) const =
-      delete; // No call_impl_.  See comments for help.
+      delete; // No _call_impl(.  See comments for help.
 
   template <typename X, typename Y,
             typename std::enable_if<
@@ -262,12 +262,12 @@ public:
                     (has_invalid_call_impl<Derived, X &, Y &>::value ||
                      has_invalid_call_impl<Derived, Y &, X &>::value),
                 int>::type = 0>
-  // Here it seems there are no valid call_impl_ methods for these types
-  // but there are some invalid ones.  Be sure that the call_impl_ is
-  // defined in the form: `double call_impl_(const X&, const X&) const`.
+  // Here it seems there are no valid _call_impl( methods for these types
+  // but there are some invalid ones.  Be sure that the _call_impl( is
+  // defined in the form: `double _call_impl(const X&, const X&) const`.
   double operator()(const X &x,
                     const Y &y) const =
-      delete; // Invalid call_impl_.  See comments for help.
+      delete; // Invalid _call_impl(.  See comments for help.
 
   CallTrace<Derived> call_trace() const;
 
@@ -321,7 +321,7 @@ public:
       typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
                                has_valid_call_impl<RHS, X &, Y &>::value),
                               int>::type = 0>
-  double call_impl_(const X &x, const Y &y) const {
+  double _call_impl(const X &x, const Y &y) const {
     return this->lhs_(x, y) + this->rhs_(x, y);
   }
 
@@ -333,7 +333,7 @@ public:
       typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
                                !has_valid_call_impl<RHS, X &, Y &>::value),
                               int>::type = 0>
-  double call_impl_(const X &x, const Y &y) const {
+  double _call_impl(const X &x, const Y &y) const {
     return this->lhs_(x, y);
   }
 
@@ -345,7 +345,7 @@ public:
       typename std::enable_if<(!has_valid_call_impl<LHS, X &, Y &>::value &&
                                has_valid_call_impl<RHS, X &, Y &>::value),
                               int>::type = 0>
-  double call_impl_(const X &x, const Y &y) const {
+  double _call_impl(const X &x, const Y &y) const {
     return this->rhs_(x, y);
   }
 
@@ -393,7 +393,7 @@ public:
       typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
                                has_valid_call_impl<RHS, X &, Y &>::value),
                               int>::type = 0>
-  double call_impl_(const X &x, const Y &y) const {
+  double _call_impl(const X &x, const Y &y) const {
     double output = this->lhs_(x, y);
     if (output != 0.) {
       output *= this->rhs_(x, y);
@@ -409,7 +409,7 @@ public:
       typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
                                !has_valid_call_impl<RHS, X &, Y &>::value),
                               int>::type = 0>
-  double call_impl_(const X &x, const Y &y) const {
+  double _call_impl(const X &x, const Y &y) const {
     return this->lhs_(x, y);
   }
 
@@ -421,7 +421,7 @@ public:
       typename std::enable_if<(!has_valid_call_impl<LHS, X &, Y &>::value &&
                                has_valid_call_impl<RHS, X &, Y &>::value),
                               int>::type = 0>
-  double call_impl_(const X &x, const Y &y) const {
+  double _call_impl(const X &x, const Y &y) const {
     return this->rhs_(x, y);
   }
 

--- a/albatross/covariance_functions/covariance_function.h
+++ b/albatross/covariance_functions/covariance_function.h
@@ -91,7 +91,7 @@ public:
 
   template <typename DummyType = Derived,
             typename std::enable_if<!has_name<DummyType>::value, int>::type = 0>
-  std::string get_name() {
+  std::string get_name() const {
     static_assert(std::is_same<DummyType, Derived>::value,
                   "never do covariance_function.get_name<T>()");
     return typeid(Derived).name();
@@ -99,7 +99,7 @@ public:
 
   template <typename DummyType = Derived,
             typename std::enable_if<has_name<DummyType>::value, int>::type = 0>
-  std::string get_name() {
+  std::string get_name() const {
     static_assert(std::is_same<DummyType, Derived>::value,
                   "never do covariance_function.get_name<T>()");
     return derived().name();
@@ -297,7 +297,7 @@ public:
       : lhs_(lhs), rhs_(rhs){};
 
   std::string name() const {
-    return "(" + lhs_.name() + "+" + rhs_.name() + ")";
+    return "(" + lhs_.get_name() + "+" + rhs_.get_name() + ")";
   }
 
   ParameterStore get_params() const {
@@ -369,7 +369,7 @@ public:
   };
 
   std::string name() const {
-    return "(" + lhs_.name() + "*" + rhs_.name() + ")";
+    return "(" + lhs_.get_name() + "*" + rhs_.get_name() + ")";
   }
 
   ParameterStore get_params() const {

--- a/albatross/covariance_functions/noise.h
+++ b/albatross/covariance_functions/noise.h
@@ -35,7 +35,7 @@ public:
    * This will create a scaled identity matrix, but only between
    * two different observations defined by the Observed type.
    */
-  double call_impl_(const Observed &x, const Observed &y) const {
+  double _call_impl(const Observed &x, const Observed &y) const {
     if (x == y) {
       return sigma_independent_noise.value * sigma_independent_noise.value;
     } else {

--- a/albatross/covariance_functions/polynomials.h
+++ b/albatross/covariance_functions/polynomials.h
@@ -54,7 +54,7 @@ public:
    * so you can move one if you move the rest the same amount.
    */
   template <typename X, typename Y>
-  double call_impl_(const X &x __attribute__((unused)),
+  double _call_impl(const X &x __attribute__((unused)),
                     const Y &y __attribute__((unused))) const {
     return sigma_constant.value * sigma_constant.value;
   }
@@ -75,7 +75,7 @@ public:
 
   ~Polynomial(){};
 
-  double call_impl_(const double &x, const double &y) const {
+  double _call_impl(const double &x, const double &y) const {
     double cov = 0.;
     for (int i = 0; i < order + 1; i++) {
       const double sigma = this->get_param_value(param_names_.at(i));

--- a/albatross/covariance_functions/radial.h
+++ b/albatross/covariance_functions/radial.h
@@ -53,7 +53,7 @@ public:
   };
 
   std::string name() const {
-    return "squared_exponential[" << this->distance_metric_.name() << "]";
+    return "squared_exponential[" + this->distance_metric_.get_name() + "]";
   }
 
   // This operator is only defined when the distance metric is also defined.
@@ -95,7 +95,7 @@ public:
   };
 
   std::string name() const {
-    return "exponential[" << this->distance_metric_.get_name() << "]";
+    return "exponential[" + this->distance_metric_.get_name() + "]";
   }
 
   ~Exponential(){};

--- a/albatross/covariance_functions/radial.h
+++ b/albatross/covariance_functions/radial.h
@@ -61,7 +61,7 @@ public:
             typename std::enable_if<
                 has_call_operator<DistanceMetricType, X &, X &>::value,
                 int>::type = 0>
-  double call_impl_(const X &x, const X &y) const {
+  double _call_impl(const X &x, const X &y) const {
     double distance = this->distance_metric_(x, y);
     return squared_exponential_covariance(
         distance, squared_exponential_length_scale.value,
@@ -105,7 +105,7 @@ public:
             typename std::enable_if<
                 has_call_operator<DistanceMetricType, X &, X &>::value,
                 int>::type = 0>
-  double call_impl_(const X &x, const X &y) const {
+  double _call_impl(const X &x, const X &y) const {
     double distance = this->distance_metric_(x, y);
     return exponential_covariance(distance, exponential_length_scale.value,
                                   sigma_exponential.value);

--- a/albatross/covariance_functions/scaling_function.h
+++ b/albatross/covariance_functions/scaling_function.h
@@ -17,7 +17,7 @@ namespace albatross {
 
 class ScalingFunction : public ParameterHandlingMixin {
 public:
-  virtual std::string name() const = 0;
+  virtual std::string get_name() const = 0;
 
   // A scaling function should also implement calls
   // for whichever types it is intended to scale using
@@ -62,7 +62,7 @@ public:
 
   ScalingTerm(const ScalingFunction &func) : scaling_function_(func){};
 
-  std::string name() const { return scaling_function_.name(); }
+  std::string get_name() const { return scaling_function_.get_name(); }
 
   void set_params(const ParameterStore &params) {
     scaling_function_.set_params(params);

--- a/albatross/covariance_functions/scaling_function.h
+++ b/albatross/covariance_functions/scaling_function.h
@@ -22,7 +22,7 @@ public:
   // A scaling function should also implement calls
   // for whichever types it is intended to scale using
   // the signature:
-  //   double call_impl_(const X &x) const;
+  //   double _call_impl(const X &x) const;
 };
 
 /*
@@ -90,9 +90,9 @@ public:
                 (has_valid_call_impl<ScalingFunction, X &>::value &&
                  has_valid_call_impl<ScalingFunction, Y &>::value),
                 int>::type = 0>
-  double call_impl_(const X &x, const Y &y) const {
-    return this->scaling_function_.call_impl_(x) *
-           this->scaling_function_.call_impl_(y);
+  double _call_impl(const X &x, const Y &y) const {
+    return this->scaling_function_._call_impl(x) *
+           this->scaling_function_._call_impl(y);
   }
 
   /*
@@ -103,8 +103,8 @@ public:
                 (!has_valid_call_impl<ScalingFunction, X &>::value &&
                  has_valid_call_impl<ScalingFunction, Y &>::value),
                 int>::type = 0>
-  double call_impl_(const X &, const Y &y) const {
-    return this->scaling_function_.call_impl_(y);
+  double _call_impl(const X &, const Y &y) const {
+    return this->scaling_function_._call_impl(y);
   }
 
   template <typename X, typename Y,
@@ -112,8 +112,8 @@ public:
                 (has_valid_call_impl<ScalingFunction, X &>::value &&
                  !has_valid_call_impl<ScalingFunction, Y &>::value),
                 int>::type = 0>
-  double call_impl_(const X &x, const Y &) const {
-    return this->scaling_function_.call_impl_(x);
+  double _call_impl(const X &x, const Y &) const {
+    return this->scaling_function_._call_impl(x);
   }
 
 private:

--- a/albatross/covariance_functions/traits.h
+++ b/albatross/covariance_functions/traits.h
@@ -17,7 +17,7 @@ namespace albatross {
 
 /*
  * In CovarianceFunction we frequently inspect for definitions of
- * call_impl_ which MUST be defined for const references to objects
+ * _call_impl( which MUST be defined for const references to objects
  * (so that repeated covariance matrix evaluations return the same thing
  *  and so the computations are not repeatedly copying.)
  * This type conversion utility will turn a type `T` into `const T&`
@@ -47,14 +47,14 @@ public:
 
 /*
  * This determines whether or not a class has a method defined for,
- *   `double call_impl_(const X &x, const Y &y, const Z &z, ...)`
+ *   `double _call_impl(const X &x, const Y &y, const Z &z, ...)`
  * The result of the inspection gets stored in the member `value`.
  */
 template <typename T, typename... Args> class has_valid_call_impl {
 
   template <typename C>
   static typename std::is_same<
-      decltype(std::declval<const C>().call_impl_(
+      decltype(std::declval<const C>()._call_impl(
           std::declval<typename call_impl_arg_type<Args>::type>()...)),
       double>::type
   test(C *);
@@ -66,18 +66,18 @@ public:
 
 /*
  * This determines whether or not a class has a method defined for
- * something close to, but not quite, a valid call_impl_.  For example
+ * something close to, but not quite, a valid _call_impl(.  For example
  * if a class has:
- *   double call_impl_(const X x)
+ *   double _call_impl(const X x)
  * or
- *   double call_impl_(X &x)
+ *   double _call_impl(X &x)
  * or
- *   int call_impl_(const X &x)
+ *   int _call_impl(const X &x)
  * those are nearly correct but the required `const X &x` in which
  * case this trait can be used to warn the user.
  */
 template <typename T, typename... Args> class has_possible_call_impl {
-  template <typename C, typename = decltype(std::declval<C>().call_impl_(
+  template <typename C, typename = decltype(std::declval<C>()._call_impl(
                             std::declval<Args &>()...))>
   static std::true_type test(int);
   template <typename C> static std::false_type test(...);
@@ -87,13 +87,14 @@ public:
 };
 
 template <typename T, typename... Args> class has_invalid_call_impl {
+
 public:
   static constexpr bool value = (has_possible_call_impl<T, Args...>::value &&
                                  !has_valid_call_impl<T, Args...>::value);
 };
 
 /*
- * This set of trait logic checks if a type has any call_impl_ method
+ * This set of trait logic checks if a type has any _call_impl( method
  * implemented (including private methods) by hijacking name hiding.
  * Namely if a derived class overloads a method the base methods will
  * be hidden.  So by starting with a base class with a known method
@@ -109,7 +110,7 @@ struct DummyType {};
 struct BaseWithPublicCallImpl {
   // This method will be accessible in `MultiInherit` only if
   // the class U doesn't contain any methods with the same name.
-  double call_impl_(const DummyType &) const { return -1.; }
+  double _call_impl(const DummyType &) const { return -1.; }
 };
 
 template <typename U>

--- a/albatross/evaluation/cross_validation.h
+++ b/albatross/evaluation/cross_validation.h
@@ -253,16 +253,16 @@ public:
 
   template <typename FeatureType>
   CVPrediction<ModelType, FeatureType>
-  get_prediction(const RegressionDataset<FeatureType> &dataset,
-                 const FoldIndexer &indexer) const {
+  predict(const RegressionDataset<FeatureType> &dataset,
+          const FoldIndexer &indexer) const {
     return CVPrediction<ModelType, FeatureType>(model_, dataset, indexer);
   }
 
   template <typename FeatureType, typename IndexFunc>
-  auto get_prediction(const RegressionDataset<FeatureType> &dataset,
-                      const IndexFunc &index_function) const {
+  auto predict(const RegressionDataset<FeatureType> &dataset,
+               const IndexFunc &index_function) const {
     const auto indexer = index_function(dataset);
-    return get_prediction(dataset, indexer);
+    return predict(dataset, indexer);
   }
 
   // Scores
@@ -280,7 +280,7 @@ public:
                          const RegressionDataset<FeatureType> &dataset,
                          const FoldIndexer &indexer) const {
     const auto folds = folds_from_fold_indexer(dataset, indexer);
-    const auto prediction = get_prediction(dataset, indexer);
+    const auto prediction = predict(dataset, indexer);
     const auto predictions =
         prediction.template get<std::vector<RequiredPredictType>>();
     return cross_validated_scores(metric, folds, predictions);

--- a/albatross/evaluation/cross_validation_utils.h
+++ b/albatross/evaluation/cross_validation_utils.h
@@ -23,8 +23,8 @@ get_predictions(const ModelType &model,
   using FitType = typename fit_type<ModelType, FeatureType>::type;
   std::vector<Prediction<ModelType, FeatureType, FitType>> predictions;
   for (const auto &fold : folds) {
-    predictions.emplace_back(model.get_fit_model(fold.train_dataset)
-                                 .get_prediction(fold.test_dataset.features));
+    predictions.emplace_back(
+        model.fit(fold.train_dataset).predict(fold.test_dataset.features));
   }
 
   return predictions;

--- a/albatross/models/least_squares.h
+++ b/albatross/models/least_squares.h
@@ -40,8 +40,10 @@ class LeastSquares : public ModelBase<LeastSquares<ImplType>> {
 public:
   using FitType = Fit<LeastSquares<ImplType>>;
 
-  FitType fit(const std::vector<Eigen::VectorXd> &features,
-              const MarginalDistribution &targets) const {
+  std::string get_name() const { return "least_squares"; }
+
+  FitType _fit_impl(const std::vector<Eigen::VectorXd> &features,
+                    const MarginalDistribution &targets) const {
     // The way this is currently implemented we assume all targets have the same
     // variance (or zero variance).
     assert(!targets.has_covariance());
@@ -60,14 +62,14 @@ public:
   template <typename FeatureType,
             typename std::enable_if<has_valid_fit<ImplType, FeatureType>::value,
                                     int>::type = 0>
-  FitType fit(const std::vector<FeatureType> &features,
-              const MarginalDistribution &targets) const {
-    return impl().fit(features, targets);
+  FitType _fit_impl(const std::vector<FeatureType> &features,
+                    const MarginalDistribution &targets) const {
+    return impl()._fit_impl(features, targets);
   }
 
-  Eigen::VectorXd predict(const std::vector<Eigen::VectorXd> &features,
-                          const FitType &least_squares_fit,
-                          PredictTypeIdentity<Eigen::VectorXd>) const {
+  Eigen::VectorXd _predict_impl(const std::vector<Eigen::VectorXd> &features,
+                                const FitType &least_squares_fit,
+                                PredictTypeIdentity<Eigen::VectorXd>) const {
     std::size_t n = features.size();
     Eigen::VectorXd mean(n);
     for (std::size_t i = 0; i < n; i++) {
@@ -82,11 +84,11 @@ public:
       typename std::enable_if<
           has_valid_predict<ImplType, FeatureType, FitType, PredictType>::value,
           int>::type = 0>
-  PredictType predict(const std::vector<FeatureType> &features,
-                      const FitType &least_squares_fit,
-                      PredictTypeIdentity<PredictType>) const {
-    return impl().predict(features, least_squares_fit,
-                          PredictTypeIdentity<PredictType>());
+  PredictType _predict_impl(const std::vector<FeatureType> &features,
+                            const FitType &least_squares_fit,
+                            PredictTypeIdentity<PredictType>) const {
+    return impl()._predict_impl(features, least_squares_fit,
+                                PredictTypeIdentity<PredictType>());
   }
 
   /*
@@ -119,6 +121,8 @@ class LinearRegression : public LeastSquares<LinearRegression> {
 public:
   using Base = LeastSquares<LinearRegression>;
 
+  std::string get_name() const { return "linear_regression"; }
+
   Eigen::VectorXd convert_feature(const double &f) const {
     Eigen::VectorXd converted(2);
     converted << 1., f;
@@ -134,16 +138,16 @@ public:
     return output;
   }
 
-  Base::FitType fit(const std::vector<double> &features,
-                    const MarginalDistribution &targets) const {
-    return Base::fit(convert_features(features), targets);
+  Base::FitType _fit_impl(const std::vector<double> &features,
+                          const MarginalDistribution &targets) const {
+    return Base::_fit_impl(convert_features(features), targets);
   }
 
-  Eigen::VectorXd predict(const std::vector<double> &features,
-                          const Base::FitType &least_squares_fit,
-                          PredictTypeIdentity<Eigen::VectorXd>) const {
-    return Base::predict(convert_features(features), least_squares_fit,
-                         PredictTypeIdentity<Eigen::VectorXd>());
+  Eigen::VectorXd _predict_impl(const std::vector<double> &features,
+                                const Base::FitType &least_squares_fit,
+                                PredictTypeIdentity<Eigen::VectorXd>) const {
+    return Base::_predict_impl(convert_features(features), least_squares_fit,
+                               PredictTypeIdentity<Eigen::VectorXd>());
   }
 };
 } // namespace albatross

--- a/examples/call_trace_example.cc
+++ b/examples/call_trace_example.cc
@@ -21,7 +21,7 @@ class LinearScalar : public ScalingFunction {
 public:
   std::string get_name() const override { return "linear_scalar"; }
 
-  double call_impl_(const double &x) const { return 1. + 3. * x; }
+  double _call_impl((const double &x) const { return 1. + 3. * x; }
 };
 
 auto complicated_covariance_function() {

--- a/examples/sinc_example_utils.h
+++ b/examples/sinc_example_utils.h
@@ -13,19 +13,8 @@
 #ifndef ALBATROSS_SINC_EXAMPLE_UTILS_H
 #define ALBATROSS_SINC_EXAMPLE_UTILS_H
 
-#include "csv.h"
-#include <Eigen/Core>
-#include <fstream>
-#include <iostream>
-#include <random>
-#include <sstream>
-
-#include "core/model.h"
-#include "covariance_functions/covariance_functions.h"
-#include "models/gp.h"
-
-#define EXAMPLE_SLOPE_VALUE sqrt(2.)
-#define EXAMPLE_CONSTANT_VALUE 3.14159
+#include "GP"
+#include "example_utils.h"
 
 namespace albatross {
 
@@ -39,134 +28,11 @@ public:
 
   std::string get_name() const { return "slope_term"; }
 
-  double call_impl_(const double &x, const double &y) const {
-    double sigma_slope = this->params_.at("sigma_slope");
+  double _call_impl((const double &x, const double &y) const {
+    double sigma_slope = this->params_.at("sigma_slope").value;
     return sigma_slope * sigma_slope * x * y;
   }
 };
 } // namespace albatross
-
-/*
- * Randomly samples n points between low and high.
- */
-std::vector<double> random_points_on_line(const int n, const double low,
-                                          const double high) {
-  std::default_random_engine generator;
-  std::uniform_real_distribution<double> distribution(low, high);
-
-  std::vector<double> xs;
-  for (int i = 0; i < n; i++) {
-    xs.push_back(distribution(generator));
-  }
-  return xs;
-};
-
-/*
- * Creates a grid of n points between low and high.
- */
-std::vector<double> uniform_points_on_line(const int n, const double low,
-                                           const double high) {
-  const auto line = Eigen::VectorXd::LinSpaced(n, low, high);
-  std::vector<double> xs(line.data(), line.data() + line.rows() * line.cols());
-  return xs;
-};
-
-/*
- * The noise free function we're attempting to estimate.
- */
-double truth(double x) {
-  return x * EXAMPLE_SLOPE_VALUE + EXAMPLE_CONSTANT_VALUE + 10. * sin(x) / x;
-}
-
-/*
- * Create random noisy observations to use as train data.
- */
-albatross::RegressionDataset<double>
-create_train_data(const int n, const double low, const double high,
-                  const double measurement_noise) {
-  auto xs = random_points_on_line(n, low, high);
-
-  std::default_random_engine generator;
-  std::normal_distribution<double> noise_distribution(0., measurement_noise);
-
-  Eigen::VectorXd ys(n);
-
-  for (int i = 0; i < n; i++) {
-    double noise = noise_distribution(generator);
-    ys[i] = (truth(xs[i]) + noise);
-  }
-
-  return albatross::RegressionDataset<double>(xs, ys);
-}
-
-albatross::RegressionDataset<double> read_csv_input(std::string file_path) {
-  std::vector<double> xs;
-  std::vector<double> ys;
-
-  io::CSVReader<2> file_in(file_path);
-
-  file_in.read_header(io::ignore_extra_column, "x", "y");
-  double x, y;
-  bool more_to_parse = true;
-  while (more_to_parse) {
-    more_to_parse = file_in.read_row(x, y);
-    if (more_to_parse) {
-      xs.push_back(x);
-      ys.push_back(y);
-    }
-  }
-  Eigen::Map<Eigen::VectorXd> eigen_ys(&ys[0], static_cast<int>(ys.size()));
-  return albatross::RegressionDataset<double>(xs, eigen_ys);
-}
-
-inline bool file_exists(const std::string &name) {
-  std::ifstream f(name.c_str());
-  return f.good();
-}
-
-void maybe_create_training_data(std::string input_path, const int n,
-                                const double low, const double high,
-                                const double meas_noise) {
-  /*
-   * Either read the input data from file, or if it doesn't exist
-   * generate new input data and write it to file.
-   */
-  if (file_exists(input_path)) {
-    std::cout << "reading data from : " << input_path << std::endl;
-  } else {
-    std::cout << "creating training data and writing it to : " << input_path
-              << std::endl;
-    auto data = create_train_data(n, low, high, meas_noise);
-    std::ofstream train;
-    train.open(input_path);
-    train << "x,y" << std::endl;
-    for (int i = 0; i < static_cast<int>(data.features.size()); i++) {
-      train << data.features[i] << ", " << data.targets.mean[i] << std::endl;
-    }
-  }
-}
-
-void write_predictions_to_csv(const std::string output_path,
-                              const albatross::RegressionModel<double> &model,
-                              const double low, const double high) {
-  std::ofstream output;
-  output.open(output_path);
-
-  const int k = 161;
-  auto grid_xs = uniform_points_on_line(k, low - 2., high + 2.);
-
-  auto predictions = model.predict(grid_xs);
-
-  std::cout << "writing predictions to : " << output_path << std::endl;
-  output << "x,y,variance,truth" << std::endl;
-  for (int i = 0; i < k; i++) {
-    output << grid_xs[i];
-    output << "," << predictions.mean[i];
-    output << "," << predictions.covariance(i, i);
-    output << "," << truth(grid_xs[i]);
-    output << std::endl;
-  }
-  output.close();
-}
 
 #endif

--- a/tests/mock_model.h
+++ b/tests/mock_model.h
@@ -62,24 +62,14 @@ public:
     this->bar = {bar_, std::make_shared<PositivePrior>()};
   };
 
-  //  std::string get_name() const override { return "mock_model"; };
+  std::string get_name() const { return "mock_model"; }
 
-  //  template <typename Archive> void save(Archive &archive) const {
-  //    archive(
-  //        cereal::base_class<SerializableRegressionModel<MockFeature,
-  //        MockFit>>(
-  //            this));
-  //  }
-  //
-  //  template <typename Archive> void load(Archive &archive) {
-  //    archive(
-  //        cereal::base_class<SerializableRegressionModel<MockFeature,
-  //        MockFit>>(
-  //            this));
-  //  }
+  bool operator==(const MockModel &other) const {
+    return other.get_params() == this->get_params();
+  }
 
-  Fit<MockModel> fit(const std::vector<MockFeature> &features,
-                     const MarginalDistribution &targets) const {
+  Fit<MockModel> _fit_impl(const std::vector<MockFeature> &features,
+                           const MarginalDistribution &targets) const {
     int n = static_cast<int>(features.size());
     Eigen::VectorXd predictions(n);
     Fit<MockModel> model_fit;
@@ -91,29 +81,31 @@ public:
   }
 
   // looks up the prediction in the map
-  Eigen::VectorXd predict(const std::vector<MockFeature> &features,
-                          const Fit<MockModel> &fit,
-                          PredictTypeIdentity<Eigen::VectorXd> &&) const {
+  Eigen::VectorXd _predict_impl(const std::vector<MockFeature> &features,
+                                const Fit<MockModel> &fit_,
+                                PredictTypeIdentity<Eigen::VectorXd> &&) const {
     int n = static_cast<int>(features.size());
     Eigen::VectorXd predictions(n);
 
     for (int i = 0; i < n; i++) {
       int index = features[static_cast<std::size_t>(i)].value;
-      predictions[i] = fit.train_data.find(index)->second;
+      predictions[i] = fit_.train_data.find(index)->second;
     }
 
     return predictions;
   }
 
   // convert before predicting
-  Eigen::VectorXd predict(const std::vector<ContainsMockFeature> &features,
-                          const Fit<MockModel> &fit,
-                          PredictTypeIdentity<Eigen::VectorXd> &&) const {
+  Eigen::VectorXd
+  _predict_impl(const std::vector<ContainsMockFeature> &features,
+                const Fit<MockModel> &fit_,
+                PredictTypeIdentity<Eigen::VectorXd> &&) const {
     std::vector<MockFeature> mock_features;
     for (const auto &f : features) {
       mock_features.push_back(f.mock);
     }
-    return predict(mock_features, fit, PredictTypeIdentity<Eigen::VectorXd>());
+    return _predict_impl(mock_features, fit_,
+                         PredictTypeIdentity<Eigen::VectorXd>());
   }
 };
 

--- a/tests/test_call_trace.cc
+++ b/tests/test_call_trace.cc
@@ -9,13 +9,10 @@
  * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
+#include "Core"
+#include "CovarianceFunctions"
 
-// clang-format off
-#include "covariance_functions/covariance_functions.h"
-#include "covariance_functions/call_trace.h"
-// clang-format on
 #include <gtest/gtest.h>
-#include <iostream>
 
 namespace albatross {
 
@@ -24,23 +21,23 @@ struct Y {};
 
 class DefinedForX : public CovarianceFunction<DefinedForX> {
 public:
-  double call_impl_(const X &, const X &) const { return 1.; }
+  double _call_impl(const X &, const X &) const { return 1.; }
   std::string name_ = "defined_for_x";
 };
 
 class DefinedForY : public CovarianceFunction<DefinedForY> {
 public:
-  double call_impl_(const Y &, const Y &) const { return 3.; }
+  double _call_impl(const Y &, const Y &) const { return 3.; }
   std::string name_ = "defined_for_y";
 };
 
 class DefinedForXY : public CovarianceFunction<DefinedForXY> {
 public:
-  double call_impl_(const X &, const X &) const { return 5.; }
+  double _call_impl(const X &, const X &) const { return 5.; }
 
-  double call_impl_(const X &, const Y &) const { return 7.; }
+  double _call_impl(const X &, const Y &) const { return 7.; }
 
-  double call_impl_(const Y &, const Y &) const { return 9.; }
+  double _call_impl(const Y &, const Y &) const { return 9.; }
   std::string name_ = "defined_for_xy";
 };
 

--- a/tests/test_core_model.cc
+++ b/tests/test_core_model.cc
@@ -24,9 +24,8 @@ TEST(test_core_model, test_fit_predict) {
   auto dataset = mock_training_data();
 
   MockModel m;
-  const auto fit_model = m.get_fit_model(dataset.features, dataset.targets);
-  Eigen::VectorXd predictions =
-      fit_model.get_prediction(dataset.features).mean();
+  const auto fit_model = m.fit(dataset.features, dataset.targets);
+  Eigen::VectorXd predictions = fit_model.predict(dataset.features).mean();
 
   EXPECT_LT((predictions - dataset.targets.mean).norm(), 1e-10);
 }
@@ -35,15 +34,14 @@ TEST(test_core_model, test_fit_predict_different_types) {
   auto dataset = mock_training_data();
   MockModel m;
 
-  const auto fit_model = m.get_fit_model(dataset.features, dataset.targets);
+  const auto fit_model = m.fit(dataset.features, dataset.targets);
 
   std::vector<ContainsMockFeature> derived_features;
   for (const auto &f : dataset.features) {
     derived_features.push_back({f});
   }
 
-  Eigen::VectorXd predictions =
-      fit_model.get_prediction(derived_features).mean();
+  Eigen::VectorXd predictions = fit_model.predict(derived_features).mean();
 
   EXPECT_LT((predictions - dataset.targets.mean).norm(), 1e-10);
 }

--- a/tests/test_covariance_function.cc
+++ b/tests/test_covariance_function.cc
@@ -10,11 +10,8 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include "core/traits.h"
-#include "covariance_functions/covariance_function.h"
-#include "covariance_functions/noise.h"
-#include "models/gp.h"
-#include "models/ransac_gp.h"
+#include "CovarianceFunctions"
+
 #include <gtest/gtest.h>
 
 namespace albatross {
@@ -43,23 +40,23 @@ struct Z {};
 
 class HasXX : public CovarianceFunction<HasXX> {
 public:
-  double call_impl_(const X &, const X &) const { return 1.; };
+  double _call_impl(const X &, const X &) const { return 1.; };
 };
 
 class HasXY : public CovarianceFunction<HasXY> {
 public:
-  double call_impl_(const X &, const Y &) const { return 1.; };
+  double _call_impl(const X &, const Y &) const { return 1.; };
 };
 
 class HasNone : public CovarianceFunction<HasNone> {};
 
 class HasMultiple : public CovarianceFunction<HasMultiple> {
 public:
-  double call_impl_(const X &, const Y &) const { return 1.; };
+  double _call_impl(const X &, const Y &) const { return 1.; };
 
-  double call_impl_(const X &, const X &) const { return 1.; };
+  double _call_impl(const X &, const X &) const { return 1.; };
 
-  double call_impl_(const Y &, const Y &) const { return 1.; };
+  double _call_impl(const Y &, const Y &) const { return 1.; };
 
   std::string name_ = "has_multiple";
 };

--- a/tests/test_covariance_functions.cc
+++ b/tests/test_covariance_functions.cc
@@ -106,7 +106,7 @@ public:
 
   ALBATROSS_DECLARE_PARAMS(foo, bar)
 
-  double call_impl_(const double &, const double &) const {
+  double _call_impl(const double &, const double &) const {
     return foo.value + bar.value;
   }
 

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -25,7 +25,7 @@ TYPED_TEST_P(RegressionModelTester, test_predict_variants) {
 
   LeaveOneOut leave_one_out;
   const auto prediction =
-      model.cross_validate().get_prediction(dataset, leave_one_out);
+      model.cross_validate().predict(dataset, leave_one_out);
 
   expect_predict_variants_consistent(prediction);
 }

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -48,25 +48,26 @@ public:
   template <typename FitFeatureType>
   using GPFitType = Fit<Base, FitFeatureType>;
 
-  auto fit(const std::vector<AdaptedFeature> &features,
-           const MarginalDistribution &targets) const {
+  auto _fit_impl(const std::vector<AdaptedFeature> &features,
+                 const MarginalDistribution &targets) const {
     std::vector<double> converted;
     for (const auto &f : features) {
       converted.push_back(f.value);
     }
-    return Base::fit(converted, targets);
+    return Base::_fit_impl(converted, targets);
   }
 
   template <typename FitFeatureType>
-  JointDistribution predict(const std::vector<AdaptedFeature> &features,
-                            const GPFitType<FitFeatureType> &gp_fit,
-                            PredictTypeIdentity<JointDistribution> &&) const {
+  JointDistribution
+  _predict_impl(const std::vector<AdaptedFeature> &features,
+                const GPFitType<FitFeatureType> &gp_fit,
+                PredictTypeIdentity<JointDistribution> &&) const {
     std::vector<double> converted;
     for (const auto &f : features) {
       converted.push_back(f.value);
     }
-    return Base::predict(converted, gp_fit,
-                         PredictTypeIdentity<JointDistribution>());
+    return Base::_predict_impl(converted, gp_fit,
+                               PredictTypeIdentity<JointDistribution>());
   }
 };
 

--- a/tests/test_prediction.cc
+++ b/tests/test_prediction.cc
@@ -20,14 +20,14 @@ struct X {};
 
 class MeanOnlyModel : public ModelBase<MeanOnlyModel> {
 public:
-  Fit<MeanOnlyModel> fit(const std::vector<X> &,
-                         const MarginalDistribution &) const {
+  Fit<MeanOnlyModel> _fit_impl(const std::vector<X> &,
+                               const MarginalDistribution &) const {
     return {};
   }
 
-  Eigen::VectorXd predict(const std::vector<X> &features,
-                          const Fit<MeanOnlyModel> &,
-                          PredictTypeIdentity<Eigen::VectorXd>) const {
+  Eigen::VectorXd _predict_impl(const std::vector<X> &features,
+                                const Fit<MeanOnlyModel> &,
+                                PredictTypeIdentity<Eigen::VectorXd>) const {
     return Eigen::VectorXd::Zero(static_cast<Eigen::Index>(features.size()));
   }
 };
@@ -39,22 +39,22 @@ TEST(test_prediction, test_mean_only) {
       Eigen::VectorXd::Zero(static_cast<Eigen::Index>(xs.size()));
   MarginalDistribution targets(zeros);
 
-  const auto fit_model = m.get_fit_model(xs, targets);
-  const auto prediction = fit_model.get_prediction(xs);
+  const auto fit_model = m.fit(xs, targets);
+  const auto prediction = fit_model.predict(xs);
   auto mean = prediction.mean();
   EXPECT_TRUE(bool(std::is_same<Eigen::VectorXd, decltype(mean)>::value));
 }
 
 class MarginalOnlyModel : public ModelBase<MarginalOnlyModel> {
 public:
-  Fit<MarginalOnlyModel> fit(const std::vector<X> &,
-                             const MarginalDistribution &) const {
+  Fit<MarginalOnlyModel> _fit_impl(const std::vector<X> &,
+                                   const MarginalDistribution &) const {
     return {};
   }
 
   MarginalDistribution
-  predict(const std::vector<X> &features, const Fit<MarginalOnlyModel> &,
-          PredictTypeIdentity<MarginalDistribution>) const {
+  _predict_impl(const std::vector<X> &features, const Fit<MarginalOnlyModel> &,
+                PredictTypeIdentity<MarginalDistribution>) const {
     auto mean =
         Eigen::VectorXd::Zero(static_cast<Eigen::Index>(features.size()));
     return MarginalDistribution(mean);
@@ -68,8 +68,8 @@ TEST(test_prediction, test_marginal_only) {
       Eigen::VectorXd::Zero(static_cast<Eigen::Index>(xs.size()));
   MarginalDistribution targets(zeros);
 
-  const auto fit_model = m.get_fit_model(xs, targets);
-  const auto prediction = fit_model.get_prediction(xs);
+  const auto fit_model = m.fit(xs, targets);
+  const auto prediction = fit_model.predict(xs);
   auto mean = prediction.mean();
   EXPECT_TRUE(bool(std::is_same<Eigen::VectorXd, decltype(mean)>::value));
 
@@ -80,14 +80,14 @@ TEST(test_prediction, test_marginal_only) {
 
 class JointOnlyModel : public ModelBase<JointOnlyModel> {
 public:
-  Fit<JointOnlyModel> fit(const std::vector<X> &,
-                          const MarginalDistribution &) const {
+  Fit<JointOnlyModel> _fit_impl(const std::vector<X> &,
+                                const MarginalDistribution &) const {
     return {};
   }
 
-  JointDistribution predict(const std::vector<X> &features,
-                            const Fit<JointOnlyModel> &,
-                            PredictTypeIdentity<JointDistribution>) const {
+  JointDistribution
+  _predict_impl(const std::vector<X> &features, const Fit<JointOnlyModel> &,
+                PredictTypeIdentity<JointDistribution>) const {
     auto mean =
         Eigen::VectorXd::Zero(static_cast<Eigen::Index>(features.size()));
     return JointDistribution(mean);
@@ -101,8 +101,8 @@ TEST(test_prediction, test_joint_only) {
       Eigen::VectorXd::Zero(static_cast<Eigen::Index>(xs.size()));
   MarginalDistribution targets(zeros);
 
-  const auto fit_model = m.get_fit_model(xs, targets);
-  const auto prediction = fit_model.get_prediction(xs);
+  const auto fit_model = m.fit(xs, targets);
+  const auto prediction = fit_model.predict(xs);
 
   auto mean = prediction.mean();
   EXPECT_TRUE(bool(std::is_same<Eigen::VectorXd, decltype(mean)>::value));

--- a/tests/test_ransac.cc
+++ b/tests/test_ransac.cc
@@ -66,16 +66,15 @@ TEST(test_outlier, test_ransac_model) {
   std::size_t max_iterations = 20;
   const auto ransac_model = model.ransac(nll, inlier_threshold, sample_size,
                                          min_inliers, max_iterations);
-  const auto fit_model = ransac_model.get_fit_model(dataset);
+  const auto fit_model = ransac_model.fit(dataset);
 
-  const auto pred = fit_model.get_prediction(dataset.features);
+  const auto pred = fit_model.predict(dataset.features);
   expect_predict_variants_consistent(pred);
 
   const auto indexer = leave_one_out_indexer(dataset.features);
   const auto inliers = ransac(dataset, indexer, model, nll, inlier_threshold,
                               sample_size, min_inliers, max_iterations);
-  const auto direct_pred =
-      model.get_fit_model(inliers).get_prediction(dataset.features);
+  const auto direct_pred = model.fit(inliers).predict(dataset.features);
   expect_predict_variants_consistent(direct_pred);
 
   EXPECT_EQ(pred.mean(), direct_pred.mean());

--- a/tests/test_traits_core.cc
+++ b/tests/test_traits_core.cc
@@ -27,83 +27,84 @@ struct Z {};
 
 class HasValidFitImpl : public ModelBase<HasValidFitImpl> {
 public:
-  Fit<HasValidFitImpl, X> fit(const std::vector<X> &,
-                              const MarginalDistribution &) const {
+  Fit<HasValidFitImpl, X> _fit_impl(const std::vector<X> &,
+                                    const MarginalDistribution &) const {
     return {};
   };
 };
 
 class HasWrongReturnTypeFitImpl : public ModelBase<HasWrongReturnTypeFitImpl> {
 public:
-  Fit<X, X> fit(const std::vector<X> &, const MarginalDistribution &) const {
+  Fit<X, X> _fit_impl(const std::vector<X> &,
+                      const MarginalDistribution &) const {
     return {};
   };
 };
 
 class HasNonConstFitImpl : public ModelBase<HasNonConstFitImpl> {
 public:
-  Fit<HasNonConstFitImpl, X> fit(const std::vector<X> &,
-                                 const MarginalDistribution &) {
+  Fit<HasNonConstFitImpl, X> _fit_impl(const std::vector<X> &,
+                                       const MarginalDistribution &) {
     return {};
   };
 };
 
 class HasNonConstArgsFitImpl : public ModelBase<HasNonConstFitImpl> {
 public:
-  Fit<HasNonConstArgsFitImpl, X> fit(std::vector<X> &,
-                                     const MarginalDistribution &) const {
+  Fit<HasNonConstArgsFitImpl, X> _fit_impl(std::vector<X> &,
+                                           const MarginalDistribution &) const {
     return {};
   };
 
-  Fit<HasNonConstArgsFitImpl, X> fit(const std::vector<X> &,
-                                     MarginalDistribution &) const {
+  Fit<HasNonConstArgsFitImpl, X> _fit_impl(const std::vector<X> &,
+                                           MarginalDistribution &) const {
     return {};
   };
 
-  Fit<HasNonConstArgsFitImpl, X> fit(std::vector<X> &,
-                                     MarginalDistribution &) const {
+  Fit<HasNonConstArgsFitImpl, X> _fit_impl(std::vector<X> &,
+                                           MarginalDistribution &) const {
     return {};
   };
 };
 
 class HasProtectedValidFitImpl : public ModelBase<HasNonConstFitImpl> {
 protected:
-  Fit<HasProtectedValidFitImpl, X> fit(const std::vector<X> &,
-                                       const MarginalDistribution &) const {
+  Fit<HasProtectedValidFitImpl, X>
+  _fit_impl(const std::vector<X> &, const MarginalDistribution &) const {
     return {};
   };
 };
 
 class HasPrivateValidFitImpl : public ModelBase<HasPrivateValidFitImpl> {
 private:
-  Fit<HasPrivateValidFitImpl, X> fit(const std::vector<X> &,
-                                     const MarginalDistribution &) const {
+  Fit<HasPrivateValidFitImpl, X> _fit_impl(const std::vector<X> &,
+                                           const MarginalDistribution &) const {
     return {};
   };
 };
 
 class HasValidAndInvalidFitImpl : public ModelBase<HasValidAndInvalidFitImpl> {
 public:
-  Fit<HasValidAndInvalidFitImpl, X> fit(const std::vector<X> &,
-                                        const MarginalDistribution &) const {
+  Fit<HasValidAndInvalidFitImpl, X>
+  _fit_impl(const std::vector<X> &, const MarginalDistribution &) const {
     return {};
   };
 
-  Fit<HasValidAndInvalidFitImpl, X> fit(const std::vector<X> &,
-                                        const MarginalDistribution &) {
+  Fit<HasValidAndInvalidFitImpl, X> _fit_impl(const std::vector<X> &,
+                                              const MarginalDistribution &) {
     return {};
   };
 };
 
 class HasValidXYFitImpl : public ModelBase<HasValidXYFitImpl> {
 public:
-  Fit<HasValidXYFitImpl, X> fit(const std::vector<X> &,
-                                const MarginalDistribution &) const {
+  Fit<HasValidXYFitImpl, X> _fit_impl(const std::vector<X> &,
+                                      const MarginalDistribution &) const {
     return {};
   };
 
-  Fit<HasValidXYFitImpl, Y> fit(const std::vector<Y> &,
-                                const MarginalDistribution &) const {
+  Fit<HasValidXYFitImpl, Y> _fit_impl(const std::vector<Y> &,
+                                      const MarginalDistribution &) const {
     return {};
   };
 };
@@ -181,8 +182,8 @@ struct Fit<Adaptable<T>, FeatureType> {};
 template <typename ImplType>
 struct Adaptable : public ModelBase<Adaptable<ImplType>> {
 
-  Fit<Adaptable<ImplType>, X> fit(const std::vector<X> &,
-                                  const MarginalDistribution &) const {
+  Fit<Adaptable<ImplType>, X> _fit_impl(const std::vector<X> &,
+                                        const MarginalDistribution &) const {
     return Fit<Adaptable<ImplType>, X>();
   }
 
@@ -193,9 +194,9 @@ struct Adaptable : public ModelBase<Adaptable<ImplType>> {
   template <typename FeatureType,
             typename std::enable_if<has_valid_fit<ImplType, FeatureType>::value,
                                     int>::type = 0>
-  auto fit(const std::vector<FeatureType> &features,
-           const MarginalDistribution &targets) const {
-    return impl().fit(features, targets);
+  auto _fit_impl(const std::vector<FeatureType> &features,
+                 const MarginalDistribution &targets) const {
+    return impl()._fit_impl(features, targets);
   }
 
   /*
@@ -209,13 +210,14 @@ struct Extended : public Adaptable<Extended> {
 
   using Base = Adaptable<Extended>;
 
-  auto fit(const std::vector<Y> &, const MarginalDistribution &targets) const {
+  auto _fit_impl(const std::vector<Y> &,
+                 const MarginalDistribution &targets) const {
     std::vector<X> xs = {{}};
-    return Base::fit(xs, targets);
+    return Base::_fit_impl(xs, targets);
   }
 
-  Z predict(const std::vector<Y> &, const Fit<Adaptable<Extended>, X> &,
-            PredictTypeIdentity<Z>) const {
+  Z _predict_impl(const std::vector<Y> &, const Fit<Adaptable<Extended>, X> &,
+                  PredictTypeIdentity<Z>) const {
     return {};
   }
 };
@@ -251,9 +253,9 @@ TEST(test_traits_core, test_adaptable_has_valid_fit) {
  */
 class HasMeanPredictImpl {
 public:
-  Eigen::VectorXd predict(const std::vector<X> &,
-                          const Fit<HasMeanPredictImpl> &,
-                          PredictTypeIdentity<Eigen::VectorXd>) const {
+  Eigen::VectorXd _predict_impl(const std::vector<X> &,
+                                const Fit<HasMeanPredictImpl> &,
+                                PredictTypeIdentity<Eigen::VectorXd>) const {
     return Eigen::VectorXd::Zero(0);
   }
 };
@@ -261,8 +263,8 @@ public:
 class HasMarginalPredictImpl {
 public:
   MarginalDistribution
-  predict(const std::vector<X> &, const Fit<HasMarginalPredictImpl> &,
-          PredictTypeIdentity<MarginalDistribution>) const {
+  _predict_impl(const std::vector<X> &, const Fit<HasMarginalPredictImpl> &,
+                PredictTypeIdentity<MarginalDistribution>) const {
     const auto mean = Eigen::VectorXd::Zero(0);
     return MarginalDistribution(mean);
   }
@@ -270,9 +272,9 @@ public:
 
 class HasJointPredictImpl {
 public:
-  JointDistribution predict(const std::vector<X> &,
-                            const Fit<HasJointPredictImpl> &,
-                            PredictTypeIdentity<JointDistribution>) const {
+  JointDistribution
+  _predict_impl(const std::vector<X> &, const Fit<HasJointPredictImpl> &,
+                PredictTypeIdentity<JointDistribution>) const {
     const auto mean = Eigen::VectorXd::Zero(0);
     return JointDistribution(mean);
   }
@@ -280,22 +282,22 @@ public:
 
 class HasAllPredictImpls {
 public:
-  Eigen::VectorXd predict(const std::vector<X> &,
-                          const Fit<HasAllPredictImpls> &,
-                          PredictTypeIdentity<Eigen::VectorXd>) const {
+  Eigen::VectorXd _predict_impl(const std::vector<X> &,
+                                const Fit<HasAllPredictImpls> &,
+                                PredictTypeIdentity<Eigen::VectorXd>) const {
     return Eigen::VectorXd::Zero(0);
   }
 
   MarginalDistribution
-  predict(const std::vector<X> &, const Fit<HasAllPredictImpls> &,
-          PredictTypeIdentity<MarginalDistribution>) const {
+  _predict_impl(const std::vector<X> &, const Fit<HasAllPredictImpls> &,
+                PredictTypeIdentity<MarginalDistribution>) const {
     const auto mean = Eigen::VectorXd::Zero(0);
     return MarginalDistribution(mean);
   }
 
-  JointDistribution predict(const std::vector<X> &,
-                            const Fit<HasAllPredictImpls> &,
-                            PredictTypeIdentity<JointDistribution>) const {
+  JointDistribution
+  _predict_impl(const std::vector<X> &, const Fit<HasAllPredictImpls> &,
+                PredictTypeIdentity<JointDistribution>) const {
     const auto mean = Eigen::VectorXd::Zero(0);
     return JointDistribution(mean);
   }

--- a/tests/test_traits_covariance_functions.cc
+++ b/tests/test_traits_covariance_functions.cc
@@ -54,21 +54,21 @@ TEST(test_traits_covariance, test_has_call_operator) {
 
 class HasPublicCallImpl {
 public:
-  double call_impl_(const X &, const Y &) const { return 1.; };
+  double _call_impl(const X &, const Y &) const { return 1.; };
 };
 
 class HasProtectedCallImpl {
 protected:
-  double call_impl_(const X &, const Y &) const { return 1.; };
+  double _call_impl(const X &, const Y &) const { return 1.; };
 };
 
 class HasPrivateCallImpl {
-  double call_impl_(const X &, const Y &) const { return 1.; };
+  double _call_impl(const X &, const Y &) const { return 1.; };
 };
 
 class HasNoCallImpl {};
 
-TEST(test_traits_covariance, test_has_any_call_impl_) {
+TEST(test_traits_covariance, test_has_any_call_impl) {
   EXPECT_TRUE(bool(has_any_call_impl<HasPublicCallImpl>::value));
   EXPECT_TRUE(bool(has_any_call_impl<HasProtectedCallImpl>::value));
   EXPECT_TRUE(bool(has_any_call_impl<HasPrivateCallImpl>::value));
@@ -76,19 +76,20 @@ TEST(test_traits_covariance, test_has_any_call_impl_) {
 }
 
 class HasMultiplePublicCallImpl {
+
 public:
-  double call_impl_(const X &, const Y &) const { return 1.; };
+  double _call_impl(const X &, const Y &) const { return 1.; };
 
-  double call_impl_(const X &, const X &) const { return 1.; };
+  double _call_impl(const X &, const X &) const { return 1.; };
 
-  double call_impl_(const Y &, const Y &) const { return 1.; };
+  double _call_impl(const Y &, const Y &) const { return 1.; };
 
   // These are all invalid:
-  double call_impl_(const Z &, const X &) { return 1.; };
+  double _call_impl(const Z &, const X &) { return 1.; };
 
-  double call_impl_(Z &, const Y &) const { return 1.; };
+  double _call_impl(Z &, const Y &) const { return 1.; };
 
-  int call_impl_(const Z &, const Z &) const { return 1.; };
+  int _call_impl(const Z &, const Z &) const { return 1.; };
 };
 
 TEST(test_traits_covariance, test_has_valid_call_impl) {
@@ -108,7 +109,7 @@ TEST(test_traits_covariance, test_has_valid_call_impl) {
 
 /*
  * Here we test to make sure we can identify situations where
- * call_impl_ has been defined but not necessarily properly.
+ * _call_impl( has been defined but not necessarily properly.
  */
 TEST(test_traits_covariance, test_has_possible_call_impl) {
   EXPECT_TRUE(bool(has_possible_call_impl<HasPublicCallImpl, X, Y>::value));


### PR DESCRIPTION
Renames:
```
   get_fit_model -> fit
   get_prediction -> predict
   fit -> _fit_impl
   predict -> _predict_impl
```
So the new syntax will look like:
```
model.fit(dataset).predict(features).mean();
```
This makes creating a new model a little less intuitive since you need to write methods for `_fit_impl` and `_predict_impl`.  BUT this mimics the syntax used for writing a new `CovarianceFunction`, matches Eigen and makes it more obvious that you shouldn't do, `model._fit_impl(dataset)`.