### PR TITLE
CRTP: Cleanup

### DIFF
--- a/albatross/core/dataset.h
+++ b/albatross/core/dataset.h
@@ -27,6 +27,8 @@ template <typename FeatureType> struct RegressionDataset {
   MarginalDistribution targets;
   std::map<std::string, std::string> metadata;
 
+  using Feature = FeatureType;
+
   RegressionDataset(){};
 
   RegressionDataset(const std::vector<FeatureType> &features_,

--- a/albatross/core/dataset.h
+++ b/albatross/core/dataset.h
@@ -47,6 +47,8 @@ template <typename FeatureType> struct RegressionDataset {
             metadata == other.metadata);
   }
 
+  std::size_t size() const { return features.size(); }
+
   template <class Archive>
   typename std::enable_if<valid_in_out_serializer<FeatureType, Archive>::value,
                           void>::type
@@ -65,6 +67,17 @@ template <typename FeatureType> struct RegressionDataset {
                   "FeatureType must be serializable.");
   }
 };
+
+/*
+ * Convenience method which subsets the features and targets of a dataset.
+ */
+template <typename SizeType, typename FeatureType>
+inline RegressionDataset<FeatureType>
+subset(const RegressionDataset<FeatureType> &dataset,
+       const std::vector<SizeType> &indices) {
+  return RegressionDataset<FeatureType>(subset(dataset.features, indices),
+                                        subset(dataset.targets, indices));
+}
 
 } // namespace albatross
 

--- a/albatross/core/declarations.h
+++ b/albatross/core/declarations.h
@@ -83,11 +83,10 @@ using FoldIndexer = std::map<FoldName, FoldIndices>;
 template <typename FeatureType> struct RegressionFold;
 
 template <typename FeatureType>
-using GrouperFunction = std::function<FoldName(const FeatureType &)>;
+using GroupFunction = std::string (*)(const FeatureType &);
 
 template <typename FeatureType>
-using IndexerFunction =
-    std::function<FoldIndexer(const RegressionDataset<FeatureType> &)>;
+using IndexerFunction = FoldIndexer (*) (const RegressionDataset<FeatureType> &);
 
 template <typename ModelType> class CrossValidation;
 

--- a/albatross/core/declarations.h
+++ b/albatross/core/declarations.h
@@ -86,7 +86,7 @@ template <typename FeatureType>
 using GroupFunction = std::string (*)(const FeatureType &);
 
 template <typename FeatureType>
-using IndexerFunction = FoldIndexer (*) (const RegressionDataset<FeatureType> &);
+using IndexerFunction = FoldIndexer (*)(const RegressionDataset<FeatureType> &);
 
 template <typename ModelType> class CrossValidation;
 

--- a/albatross/core/distribution.h
+++ b/albatross/core/distribution.h
@@ -44,7 +44,7 @@ template <typename CovarianceType> struct Distribution {
   template <typename OtherCovarianceType>
   typename std::enable_if<
       !std::is_same<CovarianceType, OtherCovarianceType>::value, bool>::type
-  operator==(const Distribution<OtherCovarianceType> &other) const {
+  operator==(const Distribution<OtherCovarianceType> &) const {
     return false;
   }
 

--- a/albatross/core/parameter_handling_mixin.h
+++ b/albatross/core/parameter_handling_mixin.h
@@ -269,7 +269,7 @@ public:
   };
 
   template <class Archive> void load(Archive &archive) {
-    archive(cereal::make_nvp("parameter_store", params_));
+    archive(cereal::make_nvp("parameters", params_));
   };
 
   /*

--- a/albatross/core/parameter_macros.h
+++ b/albatross/core/parameter_macros.h
@@ -73,7 +73,7 @@
  *       $1 = value;
  *     } else if (key == "$2") {
  *       $2 = value;
- *     }
+ *     } else if {
  *     ...
  *     } else {
  *       assert(false);

--- a/albatross/covariance_functions/radial.h
+++ b/albatross/covariance_functions/radial.h
@@ -21,6 +21,10 @@ namespace albatross {
 inline double squared_exponential_covariance(double distance,
                                              double length_scale,
                                              double sigma = 1.) {
+  if (length_scale <= 0.) {
+    return 0.;
+  }
+  assert(distance >= 0.);
   return sigma * sigma * exp(-pow(distance / length_scale, 2));
 }
 
@@ -73,6 +77,10 @@ public:
 
 inline double exponential_covariance(double distance, double length_scale,
                                      double sigma = 1.) {
+  if (length_scale <= 0.) {
+    return 0.;
+  }
+  assert(distance >= 0.);
   return sigma * sigma * exp(-fabs(distance / length_scale));
 }
 

--- a/albatross/csv_utils.h
+++ b/albatross/csv_utils.h
@@ -159,7 +159,6 @@ to_map(const RegressionDataset<FeatureType> &dataset,
                     target_variance, predictions.mean[ei], predict_variance);
 
   row = map_join(row, dataset.metadata);
-  row = map_join(row, predictions.metadata);
 
   return row;
 }

--- a/albatross/eigen/serializable_ldlt.h
+++ b/albatross/eigen/serializable_ldlt.h
@@ -93,7 +93,7 @@ public:
   }
 
   std::vector<Eigen::MatrixXd>
-  inverse_blocks(const std::vector<albatross::FoldIndices> &blocks) const {
+  inverse_blocks(const std::vector<std::vector<std::size_t>> &blocks) const {
 
     /*
      * The LDLT decomposition is stored such that,
@@ -121,10 +121,12 @@ public:
         this->vectorD().array().sqrt().inverse().matrix().asDiagonal();
     inverse_cholesky = sqrt_diag * inverse_cholesky;
 
+    assert(!inverse_cholesky.hasNaN());
+
     std::vector<Eigen::MatrixXd> output;
     for (const auto &block_indices : blocks) {
       Eigen::MatrixXd sub_matrix =
-          albatross::subset_cols(block_indices, inverse_cholesky);
+          albatross::subset_cols(inverse_cholesky, block_indices);
       Eigen::MatrixXd one_block =
           sub_matrix.transpose().lazyProduct(sub_matrix);
       output.push_back(one_block);

--- a/albatross/eigen/serializable_ldlt.h
+++ b/albatross/eigen/serializable_ldlt.h
@@ -142,9 +142,9 @@ public:
     Eigen::Index n = this->rows();
 
     std::size_t size_n = static_cast<std::size_t>(n);
-    std::vector<albatross::FoldIndices> block_indices(size_n);
+    std::vector<std::vector<std::size_t>> block_indices(size_n);
     for (Eigen::Index i = 0; i < n; i++) {
-      block_indices[i] = {static_cast<albatross::FoldIndices::value_type>(i)};
+      block_indices[i] = {static_cast<std::size_t>(i)};
     }
 
     Eigen::VectorXd inv_diag(n);

--- a/albatross/evaluation/cross_validation.h
+++ b/albatross/evaluation/cross_validation.h
@@ -250,7 +250,6 @@ public:
   }
 
   // get_prediction
-
   template <typename FeatureType>
   CVPrediction<ModelType, FeatureType>
   predict(const RegressionDataset<FeatureType> &dataset,

--- a/albatross/evaluation/cross_validation_utils.h
+++ b/albatross/evaluation/cross_validation_utils.h
@@ -70,9 +70,8 @@ inline Eigen::VectorXd concatenate_mean_predictions(
   Eigen::Index number_filled = 0;
   // Put all the predicted means back in order.
   for (std::size_t i = 0; i < folds.size(); ++i) {
-    Eigen::Index fold_size =
-        static_cast<Eigen::Index>(folds[i].test_dataset.size());
-    assert(means[i].size() == fold_size);
+    assert(means[i].size() ==
+           static_cast<Eigen::Index>(folds[i].test_dataset.size()));
     set_subset(means[i], folds[i].test_indices, &pred);
     number_filled += static_cast<Eigen::Index>(folds[i].test_indices.size());
   }
@@ -127,9 +126,8 @@ cross_validated_scores(const EvaluationMetricType &metric,
   Eigen::Index n = static_cast<Eigen::Index>(predictions.size());
   Eigen::VectorXd output(n);
   for (Eigen::Index i = 0; i < n; ++i) {
-    auto fold_size = static_cast<std::size_t>(folds[i].test_dataset.size());
-    auto pred_size = static_cast<std::size_t>(predictions[i].size());
-    assert(fold_size == pred_size);
+    assert(static_cast<std::size_t>(folds[i].test_dataset.size()) ==
+           static_cast<std::size_t>(predictions[i].size()));
     output[i] = metric(predictions[i], folds[i].test_dataset.targets);
   }
   return output;

--- a/albatross/evaluation/folds.h
+++ b/albatross/evaluation/folds.h
@@ -65,9 +65,9 @@ struct LeaveOneOut {
  */
 
 template <typename FeatureType>
-static inline FoldIndexer leave_one_group_out_indexer(
-    const std::vector<FeatureType> &features,
-    GroupFunction<FeatureType> get_group_name) {
+static inline FoldIndexer
+leave_one_group_out_indexer(const std::vector<FeatureType> &features,
+                            GroupFunction<FeatureType> get_group_name) {
   FoldIndexer groups;
   for (std::size_t i = 0; i < features.size(); i++) {
     const std::string k = get_group_name(features[i]);
@@ -86,8 +86,7 @@ static inline FoldIndexer leave_one_group_out_indexer(
   return groups;
 }
 
-template <typename FeatureType>
-struct LeaveOneGroupOut {
+template <typename FeatureType> struct LeaveOneGroupOut {
 
   LeaveOneGroupOut(GroupFunction<FeatureType> grouper_) : grouper(grouper_){};
 
@@ -170,7 +169,9 @@ dataset_size_from_folds(const std::vector<RegressionFold<FeatureType>> &folds) {
   // Make sure the minimum was zero
   std::size_t zero =
       *std::min_element(unique_indices.begin(), unique_indices.end());
-  assert(zero == 0);
+  if (zero != 0) {
+    assert(false);
+  }
 
   // And the maximum agrees with the size;
   std::size_t n =

--- a/albatross/evaluation/folds.h
+++ b/albatross/evaluation/folds.h
@@ -67,7 +67,7 @@ struct LeaveOneOut {
 template <typename FeatureType>
 static inline FoldIndexer leave_one_group_out_indexer(
     const std::vector<FeatureType> &features,
-    const GrouperFunction<FeatureType> &get_group_name) {
+    GroupFunction<FeatureType> get_group_name) {
   FoldIndexer groups;
   for (std::size_t i = 0; i < features.size(); i++) {
     const std::string k = get_group_name(features[i]);
@@ -86,16 +86,16 @@ static inline FoldIndexer leave_one_group_out_indexer(
   return groups;
 }
 
-template <typename GroupFunc> struct LeaveOneGroupOut {
+template <typename FeatureType>
+struct LeaveOneGroupOut {
 
-  LeaveOneGroupOut(const GroupFunc &grouper_) : grouper(grouper_){};
+  LeaveOneGroupOut(GroupFunction<FeatureType> grouper_) : grouper(grouper_){};
 
-  template <typename FeatureType>
   FoldIndexer operator()(const RegressionDataset<FeatureType> &dataset) const {
     return leave_one_group_out_indexer(dataset.features, grouper);
   }
 
-  GroupFunc grouper;
+  GroupFunction<FeatureType> grouper;
 };
 
 /*

--- a/albatross/models/gp.h
+++ b/albatross/models/gp.h
@@ -52,6 +52,7 @@ struct Fit<GaussianProcessBase<CovFunc, ImplType>, FeatureType> {
     if (targets.has_covariance()) {
       cov += targets.covariance;
     }
+    assert(!cov.hasNaN());
     train_ldlt = Eigen::SerializableLDLT(cov.ldlt());
     // Precompute the information vector
     information = train_ldlt.solve(targets.mean);
@@ -337,6 +338,8 @@ public:
     }
     return output;
   }
+
+  CovFunc get_covariance() const { return covariance_function_; }
 
 protected:
   /*

--- a/albatross/models/ransac.h
+++ b/albatross/models/ransac.h
@@ -169,6 +169,10 @@ struct Fit<Ransac<ModelType, MetricType>, FeatureType> {
 
   Fit(const FitModelType &fit_model_) : fit_model(fit_model_){};
 
+  bool operator==(const Fit &other) const {
+    return fit_model == other.fit_model;
+  }
+
   template <typename Archive> void serialize(Archive &archive) {
     archive(cereal::make_nvp("fit_model", fit_model));
   }
@@ -234,6 +238,7 @@ public:
     return ransac_fit_.fit_model.predict(features).template get<PredictType>();
   }
 
+  // Hide any inherited save/load methods.
   void save() const;
   void load();
 

--- a/albatross/tune.h
+++ b/albatross/tune.h
@@ -118,8 +118,8 @@ struct ModelTuner {
     return model.get_params();
   }
 
-  void
-  initialize_optimizer(const nlopt::algorithm &algorithm = nlopt::LN_PRAXIS) {
+  void initialize_optimizer(
+      const nlopt::algorithm &algorithm = nlopt::LN_NELDERMEAD) {
     // The various algorithms in nlopt are coded by the first two characters.
     // In this case LN stands for local, gradient free.
     auto tunable_params = model.get_tunable_parameters();

--- a/albatross/tuning_metrics.h
+++ b/albatross/tuning_metrics.h
@@ -44,17 +44,18 @@ struct GaussianProcessLikelihoodTuningMetric {
   }
 };
 
+template <typename PredictType = JointDistribution>
 struct LeaveOneOutLikelihood {
 
   template <typename FeatureType, typename ModelType>
   double operator()(const RegressionDataset<FeatureType> &dataset,
                     const ModelBase<ModelType> &model) const {
-    NegativeLogLikelihood<JointDistribution> nll;
+    NegativeLogLikelihood<PredictType> nll;
     LeaveOneOut loo;
     const auto scores = model.cross_validate().scores(nll, dataset, loo);
     double data_nll = scores.sum();
     double prior_nll = model.prior_log_likelihood();
-    return data_nll + prior_nll;
+    return data_nll - prior_nll;
   }
 };
 

--- a/albatross/tuning_metrics.h
+++ b/albatross/tuning_metrics.h
@@ -65,7 +65,10 @@ struct LeaveOneOutRMSE {
                     const ModelBase<ModelType> &model) const {
     RootMeanSquareError rmse;
     LeaveOneOut loo;
-    return model.cross_validate().scores(rmse, dataset, loo).mean();
+
+    double rmse_score =
+        model.cross_validate().scores(rmse, dataset, loo).mean();
+    return rmse_score;
   }
 };
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(inspection_example m gflags pthread)
 add_custom_target(
     run_inspection_example ALL
     DEPENDS ${example_HEADERS}
-    COMMAND inspection_example -input ${PROJECT_SOURCE_DIR}/examples/inspection_input.csv -output ./inspection_predictions.csv
+    COMMAND inspection_example -input ${PROJECT_SOURCE_DIR}/examples/inspection_input.csv
     COMMENT "Running inspection_example"
 )
 

--- a/examples/example_utils.h
+++ b/examples/example_utils.h
@@ -109,7 +109,7 @@ inline bool file_exists(const std::string &name) {
   return f.good();
 }
 
-void maybe_create_training_data(std::string input_path, const int n,
+void maybe_create_training_data(const std::string &input_path, const int n,
                                 const double low, const double high,
                                 const double meas_noise) {
   /*
@@ -131,16 +131,18 @@ void maybe_create_training_data(std::string input_path, const int n,
   }
 }
 
-void write_predictions_to_csv(const std::string output_path,
-                              const albatross::RegressionModel<double> *model,
-                              const double low, const double high) {
+template <typename ModelType, typename FitType>
+void write_predictions_to_csv(
+    const std::string output_path,
+    const albatross::FitModel<ModelType, FitType> &fit_model, const double low,
+    const double high) {
   std::ofstream output;
   output.open(output_path);
 
   const std::size_t k = 161;
   auto grid_xs = uniform_points_on_line(k, low - 2., high + 2.);
 
-  auto predictions = model->predict(grid_xs);
+  auto prediction = fit_model.predict(grid_xs).marginal();
 
   Eigen::VectorXd targets(static_cast<Eigen::Index>(k));
   for (std::size_t i = 0; i < k; i++) {
@@ -149,7 +151,7 @@ void write_predictions_to_csv(const std::string output_path,
 
   const albatross::RegressionDataset<double> dataset(grid_xs, targets);
 
-  albatross::write_to_csv(output, dataset, predictions);
+  albatross::write_to_csv(output, dataset, prediction);
 
   output.close();
 }

--- a/examples/example_utils.h
+++ b/examples/example_utils.h
@@ -84,7 +84,7 @@ create_train_data(const int n, const double low, const double high,
   return albatross::RegressionDataset<double>(xs, ys);
 }
 
-albatross::RegressionDataset<double> read_csv_input(std::string file_path) {
+albatross::RegressionDataset<double> read_csv_input(const std::string &file_path) {
   std::vector<double> xs;
   std::vector<double> ys;
 
@@ -133,7 +133,7 @@ void maybe_create_training_data(const std::string &input_path, const int n,
 
 template <typename ModelType, typename FitType>
 void write_predictions_to_csv(
-    const std::string output_path,
+    const std::string &output_path,
     const albatross::FitModel<ModelType, FitType> &fit_model, const double low,
     const double high) {
   std::ofstream output;

--- a/examples/inspection.cc
+++ b/examples/inspection.cc
@@ -27,6 +27,9 @@ int main(int argc, char *argv[]) {
   const double high = 13.;
   const double meas_noise = 1.;
 
+  if (FLAGS_input == "") {
+    FLAGS_input = "input.csv";
+  }
   maybe_create_training_data(FLAGS_input, n, low, high, meas_noise);
 
   auto data = read_csv_input(FLAGS_input);
@@ -42,17 +45,17 @@ int main(int argc, char *argv[]) {
   SquaredExp squared_exponential(3.5, 5.7);
   auto cov = constant + noise + squared_exponential;
 
-  auto model = gp_from_covariance<double>(cov);
+  auto model = gp_from_covariance(cov);
 
   std::cout << "Using Model:" << std::endl;
   std::cout << model.pretty_string() << std::endl;
 
-  model.fit(data);
+  const auto fit_model = model.fit(data);
 
   const auto constant_state =
       constant.get_state_space_representation(data.features);
 
-  auto posterior_state = model.inspect(constant_state);
+  auto posterior_state = fit_model.predict(constant_state).joint();
   std::cout << "The posterior estimate of the constant term is: ";
   std::cout << posterior_state.mean << " +/- " << posterior_state.covariance
             << std::endl;

--- a/examples/sinc_example.cc
+++ b/examples/sinc_example.cc
@@ -27,24 +27,20 @@ DEFINE_bool(tune, false, "a flag indication parameters should be tuned first.");
 
 using albatross::ParameterStore;
 using albatross::RegressionDataset;
-using albatross::RegressionModelCreator;
-using albatross::TuningMetric;
-using albatross::TuneModelConfig;
-using albatross::tune_regression_model;
+using albatross::get_tuner;
 
-albatross::ParameterStore
-tune_model(RegressionModelCreator<double> &model_creator,
-           RegressionDataset<double> &data) {
+template <typename ModelType>
+albatross::ParameterStore tune_model(ModelType &model,
+                                     RegressionDataset<double> &data) {
   /*
    * Now we tune the model by finding the hyper parameters that
    * maximize the likelihood (or minimize the negative log likelihood).
    */
   std::cout << "Tuning the model." << std::endl;
 
-  TuningMetric<double> metric = albatross::loo_nll;
+  albatross::LeaveOneOutLikelihood<> loo_nll;
 
-  TuneModelConfig<double> config(model_creator, data, metric);
-  return tune_regression_model<double>(config);
+  return get_tuner(model, loo_nll, data).tune();
 }
 
 int main(int argc, char *argv[]) {
@@ -56,6 +52,9 @@ int main(int argc, char *argv[]) {
   const double high = 13.;
   const double meas_noise = 1.;
 
+  if (FLAGS_input == "") {
+    FLAGS_input = "input.csv";
+  }
   maybe_create_training_data(FLAGS_input, n, low, high, meas_noise);
 
   using namespace albatross;
@@ -74,30 +73,18 @@ int main(int argc, char *argv[]) {
 
   std::cout << cov.pretty_string() << std::endl;
 
-  RegressionModelCreator<double> model_creator = [&]() {
-    /*
-     * A side effect of having statically composable covariance
-     * functions is that we don't explicitly know the type of the
-     * resulting Gaussian process, so to instantiate the model
-     * we need to ride off of template inferrence using a helper
-     * function.
-     */
-    auto model = gp_pointer_from_covariance<double>(cov);
-    return model;
-  };
-
-  auto model = model_creator();
+  auto model = gp_from_covariance(cov);
 
   if (FLAGS_tune) {
-    model->set_params(tune_model(model_creator, data));
+    model.set_params(tune_model(model, data));
   }
 
-  std::cout << pretty_param_details(model->get_params()) << std::endl;
-  model->fit(data);
+  std::cout << pretty_param_details(model.get_params()) << std::endl;
+  const auto fit_model = model.fit(data);
 
   /*
    * Make predictions at a bunch of locations which we can then
    * visualize if desired.
    */
-  write_predictions_to_csv(FLAGS_output, model.get(), low, high);
+  write_predictions_to_csv(FLAGS_output, fit_model, low, high);
 }

--- a/examples/sinc_example_utils.h
+++ b/examples/sinc_example_utils.h
@@ -28,7 +28,7 @@ public:
 
   std::string get_name() const { return "slope_term"; }
 
-  double _call_impl((const double &x, const double &y) const {
+  double _call_impl(const double &x, const double &y) const {
     double sigma_slope = this->params_.at("sigma_slope").value;
     return sigma_slope * sigma_slope * x * y;
   }

--- a/examples/temperature_example/temperature_example_utils.h
+++ b/examples/temperature_example/temperature_example_utils.h
@@ -77,7 +77,7 @@ public:
 
   std::string get_name() const { return "elevation_scaled"; }
 
-  double operator()(const Station &x) const {
+  double _call_impl((const Station &x) const {
     // This is the negative orientation rectifier function which
     // allows lower elevations to have a higher variance.
     double center = this->get_param_value("elevation_scaling_center");
@@ -120,9 +120,10 @@ inline bool file_exists(const std::string &name) {
   return f.good();
 }
 
+template <typename ModelType, typename FitType>
 void write_predictions(const std::string output_path,
                        const std::vector<Station> features,
-                       const albatross::RegressionModel<Station> &model) {
+                       const FitModel<ModelType, FitType> &fit_model) {
 
   std::ofstream ostream;
   ostream.open(output_path);
@@ -132,7 +133,7 @@ void write_predictions(const std::string output_path,
 
   albatross::RegressionDataset<Station> dataset(features, targets);
 
-  const auto predictions = model.predict<MarginalDistribution>(features);
+  const auto predictions = fit_model.predict(features).marginal();
   albatross::write_to_csv(ostream, dataset, predictions);
 }
 

--- a/examples/temperature_example/temperature_example_utils.h
+++ b/examples/temperature_example/temperature_example_utils.h
@@ -87,7 +87,7 @@ public:
 };
 
 albatross::RegressionDataset<Station>
-read_temperature_csv_input(std::string file_path, int thin = 5) {
+read_temperature_csv_input(const std::string &file_path, int thin = 5) {
   std::vector<Station> features;
   std::vector<double> targets;
 
@@ -121,8 +121,8 @@ inline bool file_exists(const std::string &name) {
 }
 
 template <typename ModelType, typename FitType>
-void write_predictions(const std::string output_path,
-                       const std::vector<Station> features,
+void write_predictions(const std::string &output_path,
+                       const std::vector<Station> &features,
                        const FitModel<ModelType, FitType> &fit_model) {
 
   std::ofstream ostream;

--- a/examples/temperature_example/temperature_example_utils.h
+++ b/examples/temperature_example/temperature_example_utils.h
@@ -77,7 +77,7 @@ public:
 
   std::string get_name() const { return "elevation_scaled"; }
 
-  double _call_impl((const Station &x) const {
+  double _call_impl(const Station &x) const {
     // This is the negative orientation rectifier function which
     // allows lower elevations to have a higher variance.
     double center = this->get_param_value("elevation_scaling_center");

--- a/tests/test_core_dataset.cc
+++ b/tests/test_core_dataset.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "Dataset"
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+TEST(test_dataset, test_construct_and_subset) {
+  std::vector<int> features = {3, 7, 1};
+  Eigen::VectorXd targets = Eigen::VectorXd::Random(3);
+
+  RegressionDataset<int> dataset(features, targets);
+
+  EXPECT_EQ(dataset.size(), features.size());
+  EXPECT_EQ(dataset.size(), static_cast<std::size_t>(targets.size()));
+
+  std::vector<std::size_t> indices = {0, 2};
+  const auto subset_dataset = subset(dataset, indices);
+  EXPECT_EQ(subset_dataset.size(), indices.size());
+}
+
+} // namespace albatross

--- a/tests/test_core_distribution.h
+++ b/tests/test_core_distribution.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <gtest/gtest.h>
+
+#include "Distribution"
+
+namespace albatross {
+
+void expect_subset_equal(const Eigen::VectorXd &original,
+                         const Eigen::VectorXd &actual,
+                         const std::vector<int> indices) {
+  for (std::size_t i = 0; i < indices.size(); i++) {
+    EXPECT_EQ(actual[i], original[indices[i]]);
+  }
+};
+
+void expect_subset_equal(const Eigen::MatrixXd &original,
+                         const Eigen::MatrixXd &actual,
+                         const std::vector<int> indices) {
+  for (std::size_t i = 0; i < indices.size(); i++) {
+    for (std::size_t j = 0; j < indices.size(); j++) {
+      EXPECT_EQ(actual(i, j), original(indices[i], indices[j]));
+    }
+  }
+}
+
+template <typename Scalar, int Size>
+void expect_subset_equal(const Eigen::DiagonalMatrix<Scalar, Size> &original,
+                         const Eigen::DiagonalMatrix<Scalar, Size> &actual,
+                         const std::vector<int> indices) {
+  expect_subset_equal(original.diagonal(), actual.diagonal(), indices);
+}
+
+template <typename X> struct DistributionTestCase {
+  using RepresentationType = X;
+  virtual RepresentationType create() const {
+    RepresentationType obj;
+    return obj;
+  }
+};
+
+template <typename Distribution>
+struct DistributionTest : public ::testing::Test {
+  typedef typename Distribution::RepresentationType Representation;
+};
+
+TYPED_TEST_CASE_P(DistributionTest);
+}

--- a/tests/test_core_model.cc
+++ b/tests/test_core_model.cc
@@ -16,6 +16,13 @@
 
 namespace albatross {
 
+TEST(test_core_model, test_get_name) {
+  auto dataset = mock_training_data();
+
+  MockModel m;
+  EXPECT_EQ(m.get_name(), "mock_model");
+}
+
 /*
  * Simply makes sure that a BaseModel that should be able to
  * make perfect predictions compiles and runs as expected.

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -51,8 +51,7 @@ TYPED_TEST_P(RegressionModelTester, test_logo_predict_variants) {
   auto model = this->test_case.get_model();
 
   LeaveOneGroupOut<typename decltype(dataset)::Feature> logo(group_by_interval);
-  const auto prediction =
-      model.cross_validate().predict(dataset, logo);
+  const auto prediction = model.cross_validate().predict(dataset, logo);
 
   EXPECT_TRUE(is_monotonic_increasing(prediction.mean()));
 
@@ -108,8 +107,8 @@ TYPED_TEST_P(RegressionModelTester, test_score_variants) {
 }
 
 REGISTER_TYPED_TEST_CASE_P(RegressionModelTester, test_loo_predict_variants,
-                           test_logo_predict_variants,
-                           test_loo_get_predictions, test_score_variants);
+                           test_logo_predict_variants, test_loo_get_predictions,
+                           test_score_variants);
 
 INSTANTIATE_TYPED_TEST_CASE_P(test_cross_validation, RegressionModelTester,
                               ExampleModels);

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -19,7 +19,47 @@
 
 namespace albatross {
 
-TYPED_TEST_P(RegressionModelTester, test_predict_variants) {
+// Group values by interval, but return keys that once sorted won't be
+// in order
+std::string group_by_interval(const double &x) {
+  if (x <= 3) {
+    return "2";
+  } else if (x <= 6) {
+    return "3";
+  } else {
+    return "1";
+  }
+}
+
+// Group values by interval, but return keys that once sorted won't be
+// in order
+std::string group_by_interval(const AdaptedFeature &x) {
+  return group_by_interval(x.value);
+}
+
+bool is_monotonic_increasing(const Eigen::VectorXd &x) {
+  for (Eigen::Index i = 0; i < x.size() - 1; i++) {
+    if (x[i + 1] - x[i] <= 0.) {
+      return false;
+    }
+  }
+  return true;
+}
+
+TYPED_TEST_P(RegressionModelTester, test_logo_predict_variants) {
+  auto dataset = this->test_case.get_dataset();
+  auto model = this->test_case.get_model();
+
+  LeaveOneGroupOut<typename decltype(dataset)::Feature> logo(group_by_interval);
+  const auto prediction =
+      model.cross_validate().predict(dataset, logo);
+
+  EXPECT_TRUE(is_monotonic_increasing(prediction.mean()));
+
+  expect_predict_variants_consistent(prediction);
+}
+
+TYPED_TEST_P(RegressionModelTester, test_loo_predict_variants) {
   auto dataset = this->test_case.get_dataset();
   auto model = this->test_case.get_model();
 
@@ -30,7 +70,7 @@ TYPED_TEST_P(RegressionModelTester, test_predict_variants) {
   expect_predict_variants_consistent(prediction);
 }
 
-TYPED_TEST_P(RegressionModelTester, test_get_predictions) {
+TYPED_TEST_P(RegressionModelTester, test_loo_get_predictions) {
   auto dataset = this->test_case.get_dataset();
   auto model = this->test_case.get_model();
 
@@ -67,8 +107,9 @@ TYPED_TEST_P(RegressionModelTester, test_score_variants) {
   EXPECT_LE(cv_scores.mean(), 0.1);
 }
 
-REGISTER_TYPED_TEST_CASE_P(RegressionModelTester, test_predict_variants,
-                           test_get_predictions, test_score_variants);
+REGISTER_TYPED_TEST_CASE_P(RegressionModelTester, test_loo_predict_variants,
+                           test_logo_predict_variants,
+                           test_loo_get_predictions, test_score_variants);
 
 INSTANTIATE_TYPED_TEST_CASE_P(test_cross_validation, RegressionModelTester,
                               ExampleModels);
@@ -82,18 +123,18 @@ INSTANTIATE_TYPED_TEST_CASE_P(test_cross_validation, RegressionModelTester,
  */
 TEST(test_crossvalidation, test_heteroscedastic) {
   const auto dataset = make_heteroscedastic_toy_linear_data();
-  const auto indexer = leave_one_out_indexer(dataset.features);
 
   auto model = MakeGaussianProcess().get_model();
 
+  LeaveOneOut loo;
   const RootMeanSquareError rmse;
-  const auto scores = model.cross_validate().scores(rmse, dataset, indexer);
+  const auto scores = model.cross_validate().scores(rmse, dataset, loo);
 
   RegressionDataset<double> dataset_without_variance(dataset.features,
                                                      dataset.targets.mean);
 
   const auto scores_without_variance =
-      model.cross_validate().scores(rmse, dataset_without_variance, indexer);
+      model.cross_validate().scores(rmse, dataset_without_variance, loo);
 
   EXPECT_LE(scores.mean(), scores_without_variance.mean());
 }

--- a/tests/test_csv_utils.cc
+++ b/tests/test_csv_utils.cc
@@ -109,23 +109,22 @@ TEST(test_csv_utils, test_writes_without_predictions) {
  * the CSV were missing columns or had unparsable data.
  */
 void read_test_csv_with_metadata(std::istream &stream) {
-  io::CSVReader<10> reader("garbage", stream);
+  io::CSVReader<9> reader("garbage", stream);
   reader.read_header(io::ignore_no_column, "bar", "foo", "prediction",
                      "prediction_variance", "sub_feature.one",
-                     "sub_feature.two", "target", "target_variance", "time",
-                     "model");
+                     "sub_feature.two", "target", "target_variance", "time");
 
   bool more_to_parse = true;
   while (more_to_parse) {
     double prediction;
     std::string prediction_variance_str;
     double target;
-    std::string time, model;
+    std::string time;
     std::string target_variance_str;
     TestFeature f;
     more_to_parse = reader.read_row(
         f.bar, f.foo, prediction, prediction_variance_str, f.feature.one,
-        f.feature.two, target, target_variance_str, time, model);
+        f.feature.two, target, target_variance_str, time);
   }
 }
 
@@ -140,7 +139,6 @@ TEST(test_csv_utils, test_writes_metadata) {
   targets << 1., 2., 3.;
 
   MarginalDistribution prediction(targets);
-  prediction.metadata["model"] = "null";
 
   RegressionDataset<TestFeature> first(features, targets);
   first.metadata["time"] = "1";

--- a/tests/test_evaluate.cc
+++ b/tests/test_evaluate.cc
@@ -36,62 +36,30 @@ TEST(test_evaluate, test_negative_log_likelihood) {
   Eigen::MatrixXd cov(3, 3);
   cov << 1., 0.9, 0.8, 0.9, 1., 0.9, 0.8, 0.9, 1.;
 
-  const auto nll = albatross::negative_log_likelihood(x, cov);
+  const auto nll = negative_log_likelihood(x, cov);
   EXPECT_NEAR(nll, 6.0946974293510134, 1e-6);
 
-  const auto ldlt_nll = albatross::negative_log_likelihood(x, cov.ldlt());
+  const auto ldlt_nll = negative_log_likelihood(x, cov.ldlt());
   EXPECT_NEAR(nll, ldlt_nll, 1e-6);
 
   const DiagonalMatrixXd diagonal_matrix = cov.diagonal().asDiagonal();
   const Eigen::MatrixXd dense_diagonal = diagonal_matrix.toDenseMatrix();
-  const auto diag_nll = albatross::negative_log_likelihood(x, diagonal_matrix);
-  const auto dense_diag_nll =
-      albatross::negative_log_likelihood(x, dense_diagonal);
+  const auto diag_nll = negative_log_likelihood(x, diagonal_matrix);
+  const auto dense_diag_nll = negative_log_likelihood(x, dense_diagonal);
   EXPECT_NEAR(diag_nll, dense_diag_nll, 1e-6);
 
-  JointDistribution pred(x, dense_diagonal);
+  JointDistribution pred(x, cov);
   MarginalDistribution truth(Eigen::VectorXd::Zero(x.size()));
 
-  const auto dist_nll =
-      evaluation_metrics::negative_log_likelihood(pred, truth);
-  EXPECT_NEAR(dist_nll, dense_diag_nll, 1e-6);
+  const NegativeLogLikelihood<JointDistribution> joint_nll;
+  const auto joint_nll_value = joint_nll(pred, truth);
+  EXPECT_NEAR(joint_nll_value, nll, 1e-6);
+
+  const NegativeLogLikelihood<MarginalDistribution> marginal_nll;
+  MarginalDistribution marginal_pred(pred.mean,
+                                     pred.covariance.diagonal().asDiagonal());
+  const auto marginal_nll_value = marginal_nll(marginal_pred, truth);
+  EXPECT_NEAR(marginal_nll_value, dense_diag_nll, 1e-6);
 }
 
-TEST_F(LinearRegressionTest, test_leave_one_out) {
-  model_ptr_->fit(dataset_);
-  Eigen::VectorXd preds =
-      model_ptr_->predict<Eigen::VectorXd>(dataset_.features);
-  double in_sample_rmse = root_mean_square_error(preds, dataset_.targets);
-  const auto folds = leave_one_out(dataset_);
-
-  EvaluationMetric<Eigen::VectorXd> rmse = root_mean_square_error;
-  Eigen::VectorXd rmses = cross_validated_scores(rmse, folds, model_ptr_.get());
-  double out_of_sample_rmse = rmses.mean();
-
-  // Make sure the RMSE computed doing leave one out cross validation is larger
-  // than the in sample version.  This should always be true as the in sample
-  // version has already seen the values we're trying to predict.
-  EXPECT_LT(in_sample_rmse, out_of_sample_rmse);
-}
-
-TEST_F(LinearRegressionTest, test_cross_validated_predict) {
-  const auto folds = leave_one_group_out<double>(dataset_, group_by_interval);
-
-  const auto preds = cross_validated_predict(folds, model_ptr_.get());
-
-  // Make sure the group cross validation resulted in folds that
-  // are out of order
-  EXPECT_TRUE(folds[0].name == "1");
-  // And that cross_validate_predict put them back in order.
-  EXPECT_TRUE(is_monotonic_increasing(preds.mean));
-}
-
-TEST_F(LinearRegressionTest, test_leave_one_group_out) {
-  const auto folds = leave_one_group_out<double>(dataset_, group_by_interval);
-  EvaluationMetric<Eigen::VectorXd> rmse = root_mean_square_error;
-  Eigen::VectorXd rmses = cross_validated_scores(rmse, folds, model_ptr_.get());
-
-  // Make sure we get a single RMSE for each of the three groups.
-  EXPECT_EQ(rmses.size(), 3);
-}
 } // namespace albatross

--- a/tests/test_indexing.cc
+++ b/tests/test_indexing.cc
@@ -46,7 +46,6 @@ TEST(test_indexing, test_vector_subset) {
   idx = {};
   expected = {};
   EXPECT_EQ(subset(x, idx), expected);
-
 }
 
 TEST(test_indexing, test_vector_set_subset) {
@@ -211,7 +210,6 @@ TEST(test_indexing, test_eigen_vector_subset) {
   idx = {};
   expected.resize(0);
   EXPECT_EQ(subset(x, idx), expected);
-
 }
 
 TEST(test_indexing, test_matrix_subset_col) {
@@ -254,7 +252,6 @@ TEST(test_indexing, test_matrix_subset_col) {
   idx = {};
   expected.resize(4, 0);
   EXPECT_EQ(subset_cols(x, idx), expected);
-
 }
 
 TEST(test_indexing, test_matrix_subset_row) {
@@ -297,7 +294,6 @@ TEST(test_indexing, test_matrix_subset_row) {
   idx = {};
   expected.resize(0, 4);
   EXPECT_EQ(subset_rows(x, idx), expected);
-
 }
 
 TEST(test_indexing, test_matrix_symmetric_subset) {
@@ -333,7 +329,6 @@ TEST(test_indexing, test_matrix_symmetric_subset) {
   idx = {};
   expected = subset_cols(subset_rows(x, idx), idx);
   EXPECT_EQ(symmetric_subset(x, idx), expected);
-
 }
 
 } // namespace albatross

--- a/tests/test_model_adapter.cc
+++ b/tests/test_model_adapter.cc
@@ -38,8 +38,9 @@ public:
     return converted;
   }
 
-  auto _fit_impl(const std::vector<AdaptedFeature> &features,
-                 const MarginalDistribution &targets) const {
+  typename fit_type<Base, double>::type
+  _fit_impl(const std::vector<AdaptedFeature> &features,
+            const MarginalDistribution &targets) const {
     return Base::_fit_impl(convert(features), targets);
   }
 

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -36,6 +36,24 @@ public:
   auto get_dataset() const { return make_toy_linear_data(); }
 };
 
+class MakeRansacGaussianProcess {
+public:
+  auto get_model() const {
+    auto covariance = make_simple_covariance_function();
+
+    double inlier_threshold = 1.;
+    std::size_t sample_size = 3;
+    std::size_t min_inliers = 3;
+    std::size_t max_iterations = 20;
+    NegativeLogLikelihood<JointDistribution> nll;
+    const auto gp = gp_from_covariance(covariance);
+    return gp.ransac(nll, inlier_threshold, sample_size, min_inliers,
+                     max_iterations);
+  }
+
+  auto get_dataset() const { return make_toy_linear_data(); }
+};
+
 template <typename CovarianceFunc>
 class AdaptedGaussianProcess
     : public GaussianProcessBase<CovarianceFunc,
@@ -99,7 +117,7 @@ public:
 };
 
 typedef ::testing::Types<MakeLinearRegression, MakeGaussianProcess,
-                         MakeAdaptedGaussianProcess>
+                         MakeAdaptedGaussianProcess, MakeRansacGaussianProcess>
     ExampleModels;
 
 TYPED_TEST_CASE_P(RegressionModelTester);

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -28,6 +28,8 @@ inline auto make_simple_covariance_function() {
 
 class MakeGaussianProcess {
 public:
+  MakeGaussianProcess(){};
+
   auto get_model() const {
     auto covariance = make_simple_covariance_function();
     return gp_from_covariance(covariance);
@@ -67,8 +69,9 @@ public:
   template <typename FitFeatureType>
   using GPFitType = Fit<Base, FitFeatureType>;
 
-  auto _fit_impl(const std::vector<AdaptedFeature> &features,
-                 const MarginalDistribution &targets) const {
+  typename fit_type<Base, double>::type
+  _fit_impl(const std::vector<AdaptedFeature> &features,
+            const MarginalDistribution &targets) const {
     std::vector<double> converted;
     for (const auto &f : features) {
       converted.push_back(f.value);

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -22,7 +22,7 @@ TEST(test_tune, test_single_dataset) {
   auto dataset = test_case.get_dataset();
   auto model = test_case.get_model();
 
-  LeaveOneOutLikelihood loo_nll;
+  LeaveOneOutLikelihood<> loo_nll;
   std::ostringstream output_stream;
   auto tuner =
       get_tuner(model, loo_nll, dataset, mean_aggregator, output_stream);
@@ -53,7 +53,7 @@ TEST(test_tune, test_with_prior_bounds) {
     model.set_param(pair.first, param);
   }
 
-  LeaveOneOutLikelihood loo_nll;
+  LeaveOneOutLikelihood<> loo_nll;
   std::ostringstream output_stream;
   auto tuner =
       get_tuner(model, loo_nll, dataset, mean_aggregator, output_stream);
@@ -69,6 +69,7 @@ TEST(test_tune, test_with_prior) {
   auto dataset = test_case.get_dataset();
   auto model_no_priors = test_case.get_model();
 
+  // Add priors to the parameters
   auto model_with_priors = test_case.get_model();
   for (const auto &pair : model_with_priors.get_params()) {
     model_with_priors.set_prior(
@@ -78,25 +79,31 @@ TEST(test_tune, test_with_prior) {
   auto param_names = map_keys(model_with_priors.get_params());
   model_with_priors.set_prior(param_names[0], std::make_shared<FixedPrior>());
 
-  LeaveOneOutLikelihood loo_nll;
+  // Tune using likelihood which will include the parameter priors
+  LeaveOneOutLikelihood<> loo_nll;
   std::ostringstream output_stream;
   auto tuner = get_tuner(model_with_priors, loo_nll, dataset, mean_aggregator,
                          output_stream);
-  tuner.optimizer.set_maxeval(20);
+  tuner.optimizer.set_maxeval(50);
   auto params = tuner.tune();
-
-  auto tuner_no_priors = get_tuner(model_no_priors, loo_nll, dataset,
-                                   mean_aggregator, output_stream);
-  tuner_no_priors.optimizer.set_maxeval(20);
-  auto params_no_prior = tuner.tune();
-
   model_with_priors.set_params(params);
   double ll_with_prior = model_with_priors.prior_log_likelihood();
 
+  // Then tune without
+  auto tuner_no_priors = get_tuner(model_no_priors, loo_nll, dataset,
+                                   mean_aggregator, output_stream);
+  tuner_no_priors.optimizer.set_maxeval(50);
+  auto params_no_prior = tuner_no_priors.tune();
+
+  // Set the model with priors to have the parameters from tuning
+  // without.  These parameters should be inconsistent with the
+  // prior which should lead to a smaller likelihood.
   for (const auto &pair : params_no_prior) {
     model_with_priors.set_param(pair.first, pair.second.value);
   }
-  EXPECT_GT(ll_with_prior, model_with_priors.prior_log_likelihood());
+  double ll_without_prior = model_with_priors.prior_log_likelihood();
+
+  EXPECT_GT(ll_with_prior, ll_without_prior);
 }
 
 TEST(test_tune, test_multiple_datasets) {
@@ -108,7 +115,7 @@ TEST(test_tune, test_multiple_datasets) {
   std::vector<RegressionDataset<double>> datasets = {one_dataset,
                                                      another_dataset};
 
-  LeaveOneOutLikelihood loo_nll;
+  LeaveOneOutLikelihood<> loo_nll;
   std::ostringstream output_stream;
   auto tuner = get_tuner(model_no_priors, loo_nll, datasets, mean_aggregator,
                          output_stream);

--- a/tests/test_tuning_metrics.cc
+++ b/tests/test_tuning_metrics.cc
@@ -26,8 +26,9 @@ public:
 /*
  * Add any new tuning metrics here:
  */
-typedef ::testing::Types<LeaveOneOutLikelihood, LeaveOneOutRMSE,
-                         GaussianProcessLikelihoodTuningMetric>
+typedef ::testing::Types<LeaveOneOutLikelihood<JointDistribution>,
+                         LeaveOneOutLikelihood<MarginalDistribution>,
+                         LeaveOneOutRMSE, GaussianProcessLikelihoodTuningMetric>
     MetricsToTest;
 
 TYPED_TEST_CASE(TuningMetricTester, MetricsToTest);

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -13,147 +13,15 @@
 #ifndef ALBATROSS_TESTS_TEST_UTILS_H
 #define ALBATROSS_TESTS_TEST_UTILS_H
 
-#include "core/serialize.h"
-#include "covariance_functions/covariance_functions.h"
-#include "evaluate.h"
-#include "models/least_squares.h"
-#include "models/ransac_gp.h"
-#include <Eigen/Dense>
-#include <cereal/types/map.hpp>
-#include <cmath>
-#include <gtest/gtest.h>
-#include <iostream>
-#include <memory>
+#include "Core"
+
+#include "GP"
+
 #include <random>
 
+#include "mock_model.h"
+
 namespace albatross {
-
-// A simple predictor which is effectively just an integer.
-struct MockFeature {
-  int value;
-
-  MockFeature() : value(){};
-  MockFeature(int v) : value(v){};
-
-  bool operator==(const MockFeature &other) const {
-    return value == other.value;
-  };
-
-  template <class Archive> void serialize(Archive &archive) {
-    archive(cereal::make_nvp("value", value));
-  }
-};
-
-struct MockFit {
-  std::map<int, double> train_data;
-
-public:
-  template <class Archive> void serialize(Archive &ar) {
-    ar(cereal::make_nvp("train_data", train_data));
-  };
-
-  bool operator==(const MockFit &other) const {
-    return train_data == other.train_data;
-  };
-};
-
-class IdentityScaling : public ScalingFunction {
-public:
-  IdentityScaling() : ScalingFunction(){};
-
-  std::string get_name() const { return "identity_scaling"; }
-
-  double call_impl_(const double &) const { return 1.; }
-};
-
-/*
- * A simple model which builds a map from MockPredict (aka, int)
- * to a double value.
- */
-class MockModel : public SerializableRegressionModel<MockFeature, MockFit> {
-public:
-  MockModel(double parameter = 3.14159) {
-    this->params_["parameter"] = {parameter,
-                                  std::make_shared<GaussianPrior>(3., 2.)};
-  };
-
-  std::string get_name() const override { return "mock_model"; };
-
-  template <typename Archive> void save(Archive &archive) const {
-    archive(
-        cereal::base_class<SerializableRegressionModel<MockFeature, MockFit>>(
-            this));
-  }
-
-  template <typename Archive> void load(Archive &archive) {
-    archive(
-        cereal::base_class<SerializableRegressionModel<MockFeature, MockFit>>(
-            this));
-  }
-
-protected:
-  // builds the map from int to value
-  MockFit
-  serializable_fit_(const std::vector<MockFeature> &features,
-                    const MarginalDistribution &targets) const override {
-    int n = static_cast<int>(features.size());
-    Eigen::VectorXd predictions(n);
-
-    MockFit model_fit;
-    for (int i = 0; i < n; i++) {
-      model_fit.train_data[features[static_cast<std::size_t>(i)].value] =
-          targets.mean[i];
-    }
-    return model_fit;
-  }
-
-  // looks up the prediction in the map
-  JointDistribution
-  predict_(const std::vector<MockFeature> &features) const override {
-    int n = static_cast<int>(features.size());
-    Eigen::VectorXd predictions(n);
-
-    for (int i = 0; i < n; i++) {
-      int index = features[static_cast<std::size_t>(i)].value;
-      predictions[i] = this->model_fit_.train_data.find(index)->second;
-    }
-
-    return JointDistribution(predictions);
-  }
-};
-
-class MockParameterHandler : public ParameterHandlingMixin {
-public:
-  MockParameterHandler(const ParameterStore &params)
-      : ParameterHandlingMixin(params){};
-};
-
-class TestParameterHandler : public ParameterHandlingMixin {
-public:
-  TestParameterHandler() : ParameterHandlingMixin() {
-    params_ = {{"A", 1.}, {"B", 2.}};
-  };
-};
-
-static inline RegressionDataset<MockFeature>
-mock_training_data(const int n = 10) {
-  std::vector<MockFeature> features;
-  Eigen::VectorXd targets(n);
-  for (int i = 0; i < n; i++) {
-    features.push_back(MockFeature(i));
-    targets[i] = static_cast<double>(i + n);
-  }
-  return RegressionDataset<MockFeature>(features, targets);
-}
-
-static inline void
-expect_parameter_vector_equal(const std::vector<ParameterValue> &x,
-                              const std::vector<ParameterValue> &y) {
-  for (std::size_t i = 0; i < x.size(); i++) {
-    EXPECT_DOUBLE_EQ(x[i], y[i]);
-  }
-  EXPECT_EQ(x.size(), y.size());
-}
 
 static inline auto make_toy_linear_data(const double a = 5.,
                                         const double b = 1.,
@@ -173,6 +41,28 @@ static inline auto make_toy_linear_data(const double a = 5.,
   }
 
   return RegressionDataset<double>(features, targets);
+}
+
+class MockParameterHandler : public ParameterHandlingMixin {
+public:
+  MockParameterHandler(const ParameterStore &params)
+      : ParameterHandlingMixin(params){};
+};
+
+class TestParameterHandler : public ParameterHandlingMixin {
+public:
+  TestParameterHandler() : ParameterHandlingMixin() {
+    params_ = {{"A", 1.}, {"B", 2.}};
+  };
+};
+
+static inline void
+expect_parameter_vector_equal(const std::vector<ParameterValue> &x,
+                              const std::vector<ParameterValue> &y) {
+  for (std::size_t i = 0; i < x.size(); i++) {
+    EXPECT_DOUBLE_EQ(x[i], y[i]);
+  }
+  EXPECT_EQ(x.size(), y.size());
 }
 
 static inline auto
@@ -202,16 +92,12 @@ make_heteroscedastic_toy_linear_data(const double a = 5., const double b = 1.,
   return RegressionDataset<double>(dataset.features, target_dist);
 }
 
-static inline auto toy_covariance_function() {
+inline auto toy_covariance_function() {
   using Noise = IndependentNoise<double>;
   SquaredExponential<EuclideanDistance> squared_exponential(100., 100.);
   IndependentNoise<double> noise = Noise(0.1);
   auto covariance = squared_exponential + noise;
   return covariance;
-}
-
-static inline std::unique_ptr<RegressionModel<double>> toy_gaussian_process() {
-  return gp_pointer_from_covariance<double>(toy_covariance_function());
 }
 
 /*
@@ -238,37 +124,6 @@ static inline auto make_adapted_toy_linear_data(const double a = 5.,
   return adapted_dataset;
 }
 
-template <typename SubModelType>
-class AdaptedExample
-    : public AdaptedRegressionModel<AdaptedFeature, SubModelType> {
-public:
-  AdaptedExample(const SubModelType &model)
-      : AdaptedRegressionModel<AdaptedFeature, SubModelType>(model){};
-  virtual ~AdaptedExample(){};
-
-  double convert_feature(const AdaptedFeature &parent_feature) const override {
-    return double(parent_feature.value);
-  }
-};
-
-static inline std::unique_ptr<RegressionModel<AdaptedFeature>>
-adapted_toy_gaussian_process() {
-  auto covariance = toy_covariance_function();
-  auto gp = gp_from_covariance<double>(covariance);
-  return std::make_unique<AdaptedExample<decltype(gp)>>(gp);
-}
-
-class LinearRegressionTest : public ::testing::Test {
-public:
-  LinearRegressionTest() : model_ptr_(), dataset_() {
-    model_ptr_ = std::make_unique<LinearRegression>();
-    dataset_ = make_toy_linear_data();
-  };
-
-  std::unique_ptr<LinearRegression> model_ptr_;
-  RegressionDataset<double> dataset_;
-};
-
 inline auto random_spherical_points(std::size_t n = 10, double radius = 1.,
                                     int seed = 5) {
   std::random_device rd{};
@@ -290,27 +145,6 @@ inline auto random_spherical_points(std::size_t n = 10, double radius = 1.,
     points.push_back(x);
   }
   return points;
-}
-
-// Group values by interval, but return keys that once sorted won't be
-// in order
-inline std::string group_by_interval(const double &x) {
-  if (x <= 3) {
-    return "2";
-  } else if (x <= 6) {
-    return "3";
-  } else {
-    return "1";
-  }
-}
-
-inline bool is_monotonic_increasing(const Eigen::VectorXd &x) {
-  for (Eigen::Index i = 0; i < x.size() - 1; i++) {
-    if (x[i + 1] - x[i] <= 0.) {
-      return false;
-    }
-  }
-  return true;
 }
 
 } // namespace albatross


### PR DESCRIPTION
This PR contains a variety of smaller changes which include:

- Cleanup of `Distribution` and `RegressionDataset` which includes some separation of method declaration and definition as well as some additional methods for computing `size()` etc ...
- A bug fix for radial covariance functions that was exposed when running the examples.
- Cleanup of the tests as well as adding some additional tests for leave one group out cross validation.
- Changes to get the examples working.
- Switch to using NEALDERMEAD by default.  This seemed to work better for the examples.

Each of these are in separate commits which hopefully makes reviewing easier.