### PR TITLE
Return Maps from Cross Validation

### DIFF
--- a/albatross/evaluation/cross_validation.h
+++ b/albatross/evaluation/cross_validation.h
@@ -35,7 +35,7 @@ public:
       typename DummyType = ModelType,
       typename std::enable_if<has_valid_cv_mean<DummyType, FeatureType>::value,
                               int>::type = 0>
-  std::vector<Eigen::VectorXd> means() const {
+  std::map<std::string, Eigen::VectorXd> means() const {
     return model_.cross_validated_predictions(
         dataset_, indexer_, PredictTypeIdentity<Eigen::VectorXd>());
   }
@@ -48,7 +48,7 @@ public:
                     typename fit_type<DummyType, FeatureType>::type>>::value &&
                     !has_valid_cv_mean<DummyType, FeatureType>::value,
                 int>::type = 0>
-  std::vector<Eigen::VectorXd> means() const {
+  std::map<std::string, Eigen::VectorXd> means() const {
     const auto folds = folds_from_fold_indexer(dataset_, indexer_);
     const auto predictions = albatross::get_predictions(model_, folds);
     return get_means(predictions);
@@ -62,7 +62,7 @@ public:
                     typename fit_type<DummyType, FeatureType>::type>>::value &&
                     !has_valid_cv_mean<DummyType, FeatureType>::value,
                 int>::type = 0>
-  std::vector<Eigen::VectorXd> means() const = delete;
+  std::map<std::string, Eigen::VectorXd> means() const = delete;
 
   template <typename DummyType = ModelType,
             typename std::enable_if<
@@ -94,7 +94,7 @@ public:
       typename DummyType = ModelType,
       typename std::enable_if<
           has_valid_cv_marginal<DummyType, FeatureType>::value, int>::type = 0>
-  std::vector<MarginalDistribution> marginals() const {
+  std::map<std::string, MarginalDistribution> marginals() const {
     return model_.cross_validated_predictions(
         dataset_, indexer_, PredictTypeIdentity<MarginalDistribution>());
   }
@@ -107,7 +107,7 @@ public:
                     typename fit_type<DummyType, FeatureType>::type>>::value &&
                     !has_valid_cv_marginal<DummyType, FeatureType>::value,
                 int>::type = 0>
-  std::vector<MarginalDistribution> marginals() const {
+  std::map<std::string, MarginalDistribution> marginals() const {
     const auto folds = folds_from_fold_indexer(dataset_, indexer_);
     const auto predictions = albatross::get_predictions(model_, folds);
     return get_marginals(predictions);
@@ -153,7 +153,7 @@ public:
       typename DummyType = ModelType,
       typename std::enable_if<has_valid_cv_joint<DummyType, FeatureType>::value,
                               int>::type = 0>
-  std::vector<JointDistribution> joints() const {
+  std::map<std::string, JointDistribution> joints() const {
     return model_.cross_validated_predictions(
         dataset_, indexer_, PredictTypeIdentity<JointDistribution>());
   }
@@ -166,7 +166,7 @@ public:
                     typename fit_type<DummyType, FeatureType>::type>>::value &&
                     !has_valid_cv_joint<DummyType, FeatureType>::value,
                 int>::type = 0>
-  std::vector<JointDistribution> joints() const {
+  std::map<std::string, JointDistribution> joints() const {
     const auto folds = folds_from_fold_indexer(dataset_, indexer_);
     const auto predictions = albatross::get_predictions(model_, folds);
     return get_joints(predictions);
@@ -180,7 +180,7 @@ public:
                     typename fit_type<DummyType, FeatureType>::type>>::value &&
                     !has_valid_cv_joint<DummyType, FeatureType>::value,
                 int>::type = 0>
-  std::vector<JointDistribution> joints() const = delete;
+  std::map<std::string, JointDistribution> joints() const = delete;
 
   template <typename DummyType = ModelType>
   JointDistribution joint() const =
@@ -197,19 +197,19 @@ private:
 
   auto get(get_type<Eigen::VectorXd>) const { return this->mean(); }
 
-  auto get(get_type<std::vector<Eigen::VectorXd>>) const {
+  auto get(get_type<std::map<std::string, Eigen::VectorXd>>) const {
     return this->means();
   }
 
   auto get(get_type<MarginalDistribution>) const { return this->marginal(); }
 
-  auto get(get_type<std::vector<MarginalDistribution>>) const {
+  auto get(get_type<std::map<std::string, MarginalDistribution>>) const {
     return this->marginals();
   }
 
   auto get(get_type<JointDistribution>) const { return this->joint(); }
 
-  auto get(get_type<std::vector<JointDistribution>>) const {
+  auto get(get_type<std::map<std::string, JointDistribution>>) const {
     return this->joints();
   }
 
@@ -281,7 +281,7 @@ public:
     const auto folds = folds_from_fold_indexer(dataset, indexer);
     const auto prediction = predict(dataset, indexer);
     const auto predictions =
-        prediction.template get<std::vector<RequiredPredictType>>();
+        prediction.template get<std::map<std::string, RequiredPredictType>>();
     return cross_validated_scores(metric, folds, predictions);
   }
 

--- a/albatross/evaluation/traits.h
+++ b/albatross/evaluation/traits.h
@@ -27,7 +27,7 @@ class has_valid_cross_validated_predictions {
                     std::declval<const FoldIndexer &>(),
                     std::declval<PredictTypeIdentity<PredictType>>()))>
   static typename std::enable_if<
-      std::is_same<std::vector<PredictType>, ReturnType>::value,
+      std::is_same<std::map<std::string, PredictType>, ReturnType>::value,
       std::true_type>::type
   test(C *);
   template <typename> static std::false_type test(...);

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -80,7 +80,7 @@ TYPED_TEST_P(RegressionModelTester, test_loo_get_predictions) {
       model.cross_validate().get_predictions(dataset, leave_one_out);
 
   for (const auto &pred : predictions) {
-    expect_predict_variants_consistent(pred);
+    expect_predict_variants_consistent(pred.second);
   }
 }
 

--- a/tests/test_traits_evaluation.cc
+++ b/tests/test_traits_evaluation.cc
@@ -25,64 +25,56 @@ struct Y {};
 class HasMeanPredictImpl {
 public:
   template <typename FeatureType>
-  std::vector<Eigen::VectorXd>
+  std::map<std::string, Eigen::VectorXd>
   cross_validated_predictions(const RegressionDataset<FeatureType> &,
                               const FoldIndexer &,
                               PredictTypeIdentity<Eigen::VectorXd>) const {
-    return {Eigen::VectorXd(0)};
+    return std::map<std::string, Eigen::VectorXd>();
   }
 };
 
 class HasMarginalPredictImpl {
 public:
   template <typename FeatureType>
-  std::vector<MarginalDistribution>
+  std::map<std::string, MarginalDistribution>
   cross_validated_predictions(const RegressionDataset<FeatureType> &,
                               const FoldIndexer &,
                               PredictTypeIdentity<MarginalDistribution>) const {
-
-    const auto mean = Eigen::VectorXd::Zero(0);
-    return {MarginalDistribution(mean)};
+    return std::map<std::string, MarginalDistribution>();
   }
 };
 
 class HasJointPredictImpl {
 public:
   template <typename FeatureType>
-  std::vector<JointDistribution>
+  std::map<std::string, JointDistribution>
   cross_validated_predictions(const RegressionDataset<FeatureType> &,
                               const FoldIndexer &,
                               PredictTypeIdentity<JointDistribution>) const {
-
-    const auto mean = Eigen::VectorXd::Zero(0);
-    return {JointDistribution(mean)};
+    return std::map<std::string, JointDistribution>();
   }
 };
 
 class HasAllPredictImpls {
 public:
-  std::vector<Eigen::VectorXd>
+  std::map<std::string, Eigen::VectorXd>
   cross_validated_predictions(const RegressionDataset<X> &, const FoldIndexer &,
                               PredictTypeIdentity<Eigen::VectorXd>) const {
-    return {Eigen::VectorXd(0)};
+    return std::map<std::string, Eigen::VectorXd>();
   }
 
   template <typename FeatureType>
-  std::vector<MarginalDistribution>
+  std::map<std::string, MarginalDistribution>
   cross_validated_predictions(const RegressionDataset<FeatureType> &,
                               const FoldIndexer &,
                               PredictTypeIdentity<MarginalDistribution>) const {
-
-    const auto mean = Eigen::VectorXd::Zero(0);
-    return {MarginalDistribution(mean)};
+    return std::map<std::string, MarginalDistribution>();
   }
 
-  std::vector<JointDistribution>
+  std::map<std::string, JointDistribution>
   cross_validated_predictions(const RegressionDataset<X> &, const FoldIndexer &,
                               PredictTypeIdentity<JointDistribution>) const {
-
-    const auto mean = Eigen::VectorXd::Zero(0);
-    return {JointDistribution(mean)};
+    return std::map<std::string, JointDistribution>();
   }
 };
 


### PR DESCRIPTION
Cross validation now returns a map from the fold name to a predictions, instead of a vector of predictions.  This makes it so we don't need to rely on preserved order.