### PR TITLE
Avoid unneccesary use of folds in favor of indexers.

### DIFF
--- a/include/albatross/evaluation/cross_validation.h
+++ b/include/albatross/evaluation/cross_validation.h
@@ -72,8 +72,7 @@ public:
                     has_valid_cv_mean<DummyType, FeatureType>::value,
                 int>::type = 0>
   Eigen::VectorXd mean() const {
-    const auto folds = folds_from_fold_indexer(dataset_, indexer_);
-    return concatenate_mean_predictions(folds, means());
+    return concatenate_mean_predictions(indexer_, means());
   }
 
   // No valid method of computing the means.
@@ -132,8 +131,7 @@ public:
                     has_valid_cv_marginal<DummyType, FeatureType>::value,
                 int>::type = 0>
   MarginalDistribution marginal() const {
-    const auto folds = folds_from_fold_indexer(dataset_, indexer_);
-    return concatenate_marginal_predictions(folds, marginals());
+    return concatenate_marginal_predictions(indexer_, marginals());
   }
 
   // No valid way of computing marginals.


### PR DESCRIPTION
Instead of
```
concatenate_marginals(folds, predictions);
```
you would now do:
```
concatenate_marginals(indexer, predictions);
```
This removes the need for the concat functions to be templated.  A few utility methods are included to help if you only have `folds` in which case you could now do:
```
concatenate_marginals(fold_indexer_from_folds(folds), predictions);
```