### PR TITLE
Ransac refactor

### DIFF
--- a/include/albatross/Common
+++ b/include/albatross/Common
@@ -35,6 +35,7 @@
 #include <numeric>
 #include <random>
 
+#include <albatross/core/declarations.h>
 #include <albatross/utils/map_utils.h>
 #include <albatross/cereal/eigen.h>
 

--- a/include/albatross/Core
+++ b/include/albatross/Core
@@ -17,7 +17,6 @@
 
 #include <type_traits>
 
-#include <albatross/core/declarations.h>
 #include <albatross/core/indexing.h>
 #include <albatross/core/traits.h>
 #include <albatross/core/priors.h>

--- a/include/albatross/Evaluation
+++ b/include/albatross/Evaluation
@@ -16,6 +16,7 @@
 #include "Core"
 
 #include <albatross/evaluation/likelihood.h>
+#include <albatross/covariance_functions/traits.h>
 #include <albatross/evaluation/traits.h>
 #include <albatross/evaluation/folds.h>
 #include <albatross/evaluation/prediction_metrics.h>

--- a/include/albatross/core/declarations.h
+++ b/include/albatross/core/declarations.h
@@ -93,7 +93,7 @@ template <typename ModelType> class CrossValidation;
 /*
  * RANSAC
  */
-template <typename ModelType, typename MetricType> class Ransac;
+template <typename ModelType, typename StrategyType> class Ransac;
 } // namespace albatross
 
 #endif

--- a/include/albatross/core/indexing.h
+++ b/include/albatross/core/indexing.h
@@ -172,6 +172,16 @@ indices_complement(const std::vector<std::size_t> &indices,
   return vector_set_difference(all_indices, indices);
 }
 
+inline FoldIndices indices_from_names(const FoldIndexer &indexer,
+                                      const std::vector<FoldName> &names) {
+  FoldIndices output;
+  for (const auto &name : names) {
+    output.insert(output.end(), indexer.at(name).begin(),
+                  indexer.at(name).end());
+  }
+  return output;
+}
+
 } // namespace albatross
 
 #endif

--- a/include/albatross/evaluation/folds.h
+++ b/include/albatross/evaluation/folds.h
@@ -34,7 +34,6 @@ template <typename FeatureType> struct RegressionFold {
 /*
  * Leave One Out
  */
-
 template <typename FeatureType>
 static inline FoldIndexer
 leave_one_out_indexer(const std::vector<FeatureType> &features) {
@@ -63,6 +62,8 @@ struct LeaveOneOut {
   FoldIndexer operator()(const std::vector<FeatureType> &features) const {
     return leave_one_out_indexer(features);
   }
+
+  template <class Archive> void serialize(Archive &){};
 };
 
 /*
@@ -101,6 +102,10 @@ template <typename FeatureType> struct LeaveOneGroupOut {
 
   FoldIndexer operator()(const RegressionDataset<FeatureType> &dataset) const {
     return leave_one_group_out_indexer(dataset.features, grouper);
+  }
+
+  template <class Archive> void serialize(Archive &) {
+    archive(cereal::make_nvp("grouper", grouper));
   }
 
   GroupFunction<FeatureType> grouper;

--- a/include/albatross/evaluation/traits.h
+++ b/include/albatross/evaluation/traits.h
@@ -51,7 +51,8 @@ using has_valid_cv_joint =
 /*
  * PredictionMetrics
  */
-template <typename T, typename PredictType> class is_prediction_metric {
+template <typename T, typename PredictType>
+class is_specific_prediction_metric {
   template <typename C,
             typename ReturnType = decltype(std::declval<const C>().operator()(
                 std::declval<const PredictType &>(),
@@ -63,6 +64,13 @@ template <typename T, typename PredictType> class is_prediction_metric {
 
 public:
   static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+template <typename T> struct is_prediction_metric {
+  static constexpr bool value =
+      (is_specific_prediction_metric<T, Eigen::VectorXd>::value ||
+       is_specific_prediction_metric<T, MarginalDistribution>::value ||
+       is_specific_prediction_metric<T, JointDistribution>::value);
 };
 
 /*

--- a/include/albatross/models/ransac.h
+++ b/include/albatross/models/ransac.h
@@ -15,34 +15,34 @@
 
 namespace albatross {
 
-using Indexer = std::vector<std::size_t>;
-using GroupIndexer = std::vector<std::vector<std::size_t>>;
-
-// This struct is just a type helper to make it obvious that
-// the `FitType` used in the Fitter needs to be the same as
-// the one used in `InlierMetric`
 template <typename FitType> struct RansacFunctions {
-  // A function which takes a bunch of indices and fits a model
+  // A function which takes a bunch of keys and fits a model
   // to the corresponding subset of data.
-  using Fitter = std::function<FitType(const Indexer &)>;
+  using FitterFunc = std::function<FitType(const std::vector<FoldName> &)>;
+  //  using FitterFunc = FitType (*) (const std::vector<FoldName> &);
+
   // A function which takes a fit and a set of indices
   // and returns a metric which represents how well the model
   // predicted the subset corresponding to the indices.
-  using InlierMetric = std::function<double(const Indexer &, const FitType &)>;
-  // A function which returns a metric indicating how good a
-  // model is when fit to a set of inliers (given by Indexer)
-  using ModelMetric = std::function<double(const Indexer &)>;
+  using InlierMetric = std::function<double(const FoldName &, const FitType &)>;
+
+  // A function which returns an error metric value which indicates
+  // how good a set of inliers is, lower is better.
+  using ConsensusMetric = std::function<double(const std::vector<FoldName> &)>;
+
+  RansacFunctions(FitterFunc fitter_, InlierMetric inlier_metric_,
+                  ConsensusMetric consensus_metric_)
+      : fitter(fitter_), inlier_metric(inlier_metric_),
+        consensus_metric(consensus_metric_){};
+
+  FitterFunc fitter;
+  InlierMetric inlier_metric;
+  ConsensusMetric consensus_metric;
 };
 
-inline Indexer concatenate_subset_of_groups(const Indexer &subset_indices,
-                                            const GroupIndexer &indexer) {
-
-  Indexer output;
-  for (const auto &i : subset_indices) {
-    assert(i < static_cast<std::size_t>(indexer.size()));
-    output.insert(output.end(), indexer[i].begin(), indexer[i].end());
-  }
-  return output;
+inline bool contains_group(const std::vector<FoldName> &vect,
+                           const FoldName &group) {
+  return std::find(vect.begin(), vect.end(), group) != vect.end();
 }
 
 /*
@@ -51,9 +51,9 @@ inline Indexer concatenate_subset_of_groups(const Indexer &subset_indices,
  *   1) Randomly sample a small number of data points and fit a
  *      reference model to that data.
  *   2) Assemble all the data points that agree with the
- *      reference model into a set of inliers.
- *   3) Evaluate the quality of the inliers.
- *   4) Repeat N times keeping track of the best set of inliers.
+ *      reference model into a set of inliers (a consensus).
+ *   3) Evaluate the quality of the consensus.
+ *   4) Repeat N times keeping track of the best consensus.
  *
  * One of the large drawbacks of this approach is the computational
  * load since it requires fitting and predicting repeatedly.
@@ -64,111 +64,184 @@ inline Indexer concatenate_subset_of_groups(const Indexer &subset_indices,
  * metrics.
  */
 template <typename FitType>
-Indexer
-ransac(const typename RansacFunctions<FitType>::Fitter &fitter,
-       const typename RansacFunctions<FitType>::InlierMetric &inlier_metric,
-       const typename RansacFunctions<FitType>::ModelMetric &model_metric,
-       const GroupIndexer &indexer, double inlier_threshold,
-       std::size_t random_sample_size, std::size_t min_inliers,
+std::vector<FoldName>
+ransac(const RansacFunctions<FitType> &ransac_functions,
+       const std::vector<FoldName> &groups, double inlier_threshold,
+       std::size_t random_sample_size, std::size_t min_consensus_size,
        std::size_t max_iterations) {
 
   std::default_random_engine gen;
 
-  Indexer reference;
-  double best_metric = HUGE_VAL;
-  Indexer best_inds;
+  double best_consensus_metric = HUGE_VAL;
+  std::vector<FoldName> best_consensus;
 
   for (std::size_t i = 0; i < max_iterations; i++) {
     // Sample a random subset of the data and fit a model.
-    reference = randint_without_replacement(random_sample_size, 0,
-                                            indexer.size() - 1, gen);
-    auto ref_inds = concatenate_subset_of_groups(reference, indexer);
-    const auto fit = fitter(ref_inds);
+    auto candidate_groups =
+        random_without_replacement(groups, random_sample_size, gen);
+    const auto fit = ransac_functions.fitter(candidate_groups);
 
+    std::vector<FoldName> candidate_consensus;
     // Find which of the other groups agree with the reference model
-    // which gives us a set of inliers.
-    auto test_groups = indices_complement(reference, indexer.size());
-    Indexer inliers;
-    for (const auto &test_ind : test_groups) {
-      double metric_value = inlier_metric(indexer[test_ind], fit);
-      if (metric_value < inlier_threshold) {
-        inliers.push_back(test_ind);
+    // which gives us a consensus (set of inliers).
+    for (const auto &possible_inlier : groups) {
+      if (contains_group(candidate_groups, possible_inlier)) {
+        // Any group that's part of the candidate set is automatically an
+        // inlier.
+        candidate_consensus.emplace_back(possible_inlier);
+      } else {
+        double metric_value =
+            ransac_functions.inlier_metric(possible_inlier, fit);
+        if (metric_value < inlier_threshold) {
+          candidate_consensus.emplace_back(possible_inlier);
+        }
       }
     }
+
     // If there is enough agreement, consider this random set of inliers
     // as a candidate model.
-    if (inliers.size() + random_sample_size >= min_inliers) {
-      const auto inlier_inds = concatenate_subset_of_groups(inliers, indexer);
-      ref_inds.insert(ref_inds.end(), inlier_inds.begin(), inlier_inds.end());
-      std::sort(ref_inds.begin(), ref_inds.end());
-      double model_metric_value = model_metric(ref_inds);
-      if (model_metric_value < best_metric) {
-        best_inds = ref_inds;
-        best_metric = model_metric_value;
+    if (candidate_consensus.size() + random_sample_size >= min_consensus_size) {
+      double consensus_metric_value =
+          ransac_functions.consensus_metric(candidate_consensus);
+      if (consensus_metric_value < best_consensus_metric) {
+        best_consensus = candidate_consensus;
+        best_consensus_metric = consensus_metric_value;
       }
     }
   }
-  return best_inds;
+  return best_consensus;
 }
 
-/*
- * Creates the lambda functions required to run ransac on a
- * generic RegressionModel.
- *
- * Note: This will iteratively call fit/predict for the same features which may
- * end up being prohibitively computationally expensive.  See the ransac
- * Gaussian
- * process implementation for an example of ways to speed things up for specific
- * models.
- */
-template <typename ModelType, typename FeatureType, typename MetricPredictType>
-RegressionDataset<FeatureType>
-ransac(const RegressionDataset<FeatureType> &dataset,
-       const FoldIndexer &fold_indexer, const ModelBase<ModelType> &model,
-       const PredictionMetric<MetricPredictType> &metric,
-       double inlier_threshold, std::size_t random_sample_size,
-       std::size_t min_inliers, int max_iterations) {
+template <typename FitType>
+std::vector<FoldName>
+ransac(const RansacFunctions<FitType> &ransac_functions,
+       const FoldIndexer &indexer, double inlier_threshold,
+       std::size_t random_sample_size, std::size_t min_consensus_size,
+       std::size_t max_iterations) {
+  return ransac(ransac_functions, map_keys(indexer), inlier_threshold,
+                random_sample_size, min_consensus_size, max_iterations);
+}
 
-  using FitType = typename fit_model_type<ModelType, FeatureType>::type;
+template <typename ModelType, typename FeatureType, typename InlierMetric,
+          typename ConsensusMetric,
+          typename FitModelType =
+              typename fit_model_type<ModelType, FeatureType>::type>
+inline RansacFunctions<FitModelType> get_generic_ransac_functions(
+    const ModelType &model, const RegressionDataset<FeatureType> &dataset,
+    const FoldIndexer &indexer, const InlierMetric &inlier_metric,
+    const ConsensusMetric &consensus_metric) {
 
-  typename RansacFunctions<FitType>::Fitter fitter =
-      [&](const std::vector<std::size_t> &inds) {
+  static_assert(is_prediction_metric<InlierMetric>::value,
+                "InlierMetric must be an PredictionMetric.");
+
+  static_assert(is_model_metric<ConsensusMetric, FeatureType, ModelType>::value,
+                "ConsensusMetric must be a ModelMetric valid for the feature "
+                "and model provided");
+
+  std::function<FitModelType(const std::vector<FoldName> &)> fitter =
+      [&, indexer](const std::vector<FoldName> &groups) {
+        auto inds = indices_from_names(indexer, groups);
         return model.fit(subset(dataset, inds));
       };
 
-  typename RansacFunctions<FitType>::InlierMetric inlier_metric = [&](
-      const std::vector<std::size_t> &inds, const FitType &fit) {
+  auto inlier_metric_from_group = [&, indexer](const FoldName &group,
+                                               const FitModelType &fit) {
+    FoldIndices inds = indexer.at(group);
     const auto pred = fit.predict(subset(dataset.features, inds));
     const auto target = subset(dataset.targets, inds);
-    const MetricPredictType prediction = pred.template get<MetricPredictType>();
-    return metric(prediction, target);
+    return inlier_metric(pred, target);
   };
 
-  typename RansacFunctions<FitType>::ModelMetric model_metric =
-      [&](const std::vector<std::size_t> &inds) {
+  auto consensus_metric_from_group =
+      [&, indexer](const std::vector<FoldName> &groups) {
+        auto inds = indices_from_names(indexer, groups);
         RegressionDataset<FeatureType> inlier_dataset = subset(dataset, inds);
-
-        const auto inlier_loo = leave_one_out_indexer(inlier_dataset.features);
-        double mean_score = model.cross_validate()
-                                .scores(metric, inlier_dataset, inlier_loo)
-                                .mean();
-        return mean_score;
+        return consensus_metric(inlier_dataset, model);
       };
 
-  const auto best_inds = ransac<FitType>(
-      fitter, inlier_metric, model_metric, map_values(fold_indexer),
-      inlier_threshold, random_sample_size, min_inliers, max_iterations);
-  return subset(dataset, best_inds);
+  return RansacFunctions<FitModelType>(fitter, inlier_metric_from_group,
+                                       consensus_metric_from_group);
+};
+
+/*
+ * Ransac Strategy implementation
+ *
+ * A RansacStrategy defines how Ransac should be performed
+ * before seeing the actual model and dataset.  It is
+ * responsible for defining how the dataset should be split
+ * into groups and for producing the functions which produce
+ * a fit/inlier_metric/consensus_metric when given group names.
+ */
+template <typename InlierMetric, typename ConsensusMetric,
+          typename IndexingFunction>
+struct GenericRansacStrategy {
+
+  static_assert(is_prediction_metric<InlierMetric>::value,
+                "InlierMetric is not a valid prediction metric");
+
+  GenericRansacStrategy() = default;
+
+  GenericRansacStrategy(const InlierMetric &inlier_metric,
+                        const ConsensusMetric &consensus_metric,
+                        const IndexingFunction &indexing_function)
+      : inlier_metric_(inlier_metric), consensus_metric_(consensus_metric),
+        indexing_function_(indexing_function){};
+
+  template <typename ModelType, typename FeatureType,
+            typename FitModelType =
+                typename fit_model_type<ModelType, FeatureType>::type>
+  RansacFunctions<FitModelType>
+  operator()(const ModelType &model,
+             const RegressionDataset<FeatureType> &dataset) const {
+    const auto indexer = get_indexer(dataset);
+    return get_generic_ransac_functions(model, dataset, indexer, inlier_metric_,
+                                        consensus_metric_);
+  }
+
+  template <typename FeatureType>
+  FoldIndexer get_indexer(const RegressionDataset<FeatureType> &dataset) const {
+    return indexing_function_(dataset);
+  }
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::make_nvp("inlier_metric", inlier_metric_));
+    archive(cereal::make_nvp("consensus_metric", consensus_metric_));
+    archive(cereal::make_nvp("indexing_function", indexing_function_));
+  }
+
+private:
+  InlierMetric inlier_metric_;
+  ConsensusMetric consensus_metric_;
+  IndexingFunction indexing_function_;
+};
+
+using DefaultRansacStrategy =
+    GenericRansacStrategy<NegativeLogLikelihood<JointDistribution>,
+                          LeaveOneOutLikelihood<JointDistribution>,
+                          LeaveOneOut>;
+
+template <typename InlierMetric, typename ConsensusMetric,
+          typename IndexingFunction>
+auto get_generic_ransac_strategy(const InlierMetric &inlier_metric,
+                                 const ConsensusMetric &consensus_metric,
+                                 const IndexingFunction &indexing_function) {
+  return GenericRansacStrategy<InlierMetric, ConsensusMetric, IndexingFunction>(
+      inlier_metric, consensus_metric, indexing_function);
 }
 
-template <typename ModelType, typename MetricType, typename FeatureType>
-struct Fit<Ransac<ModelType, MetricType>, FeatureType> {
+/*
+ * Ransac Model Implementation.
+ */
+template <typename ModelType, typename StrategyType, typename FeatureType>
+struct Fit<Ransac<ModelType, StrategyType>, FeatureType> {
 
   using FitModelType = typename fit_model_type<ModelType, FeatureType>::type;
 
   Fit(){};
 
-  Fit(const FitModelType &fit_model_) : fit_model(fit_model_){};
+  Fit(const FitModelType &fit_model_, const std::vector<FoldName> &inliers_,
+      const std::vector<FoldName> &outliers_)
+      : fit_model(fit_model_), inliers(inliers_), outliers(outliers_){};
 
   bool operator==(const Fit &other) const {
     return fit_model == other.fit_model;
@@ -176,34 +249,31 @@ struct Fit<Ransac<ModelType, MetricType>, FeatureType> {
 
   template <typename Archive> void serialize(Archive &archive) {
     archive(cereal::make_nvp("fit_model", fit_model));
+    archive(cereal::make_nvp("inliers", inliers));
+    archive(cereal::make_nvp("outliers", outliers));
   }
 
   FitModelType fit_model;
+  std::vector<FoldName> inliers;
+  std::vector<FoldName> outliers;
 };
 
 /*
  * This wraps any other model and performs ransac each time fit is called.
  */
-template <typename ModelType, typename MetricType>
-class Ransac : public ModelBase<Ransac<ModelType, MetricType>> {
+template <typename ModelType, typename StrategyType>
+class Ransac : public ModelBase<Ransac<ModelType, StrategyType>> {
 public:
   Ransac(){};
 
-  Ransac(const ModelType &sub_model, const MetricType &metric,
-         double inlier_threshold, std::size_t min_inliers,
-         std::size_t random_sample_size, std::size_t max_iterations)
-      : sub_model_(sub_model), metric_(metric),
-        inlier_threshold_(inlier_threshold), min_inliers_(min_inliers),
+  Ransac(const ModelType &sub_model, const StrategyType &strategy,
+         double inlier_threshold, std::size_t random_sample_size,
+         std::size_t min_consensus_size, std::size_t max_iterations)
+      : sub_model_(sub_model), strategy_(strategy),
+        inlier_threshold_(inlier_threshold),
         random_sample_size_(random_sample_size),
+        min_consensus_size_(min_consensus_size),
         max_iterations_(max_iterations){};
-
-  static_assert(
-      std::is_base_of<PredictionMetric<Eigen::VectorXd>, MetricType>::value ||
-          std::is_base_of<PredictionMetric<MarginalDistribution>,
-                          MetricType>::value ||
-          std::is_base_of<PredictionMetric<JointDistribution>,
-                          MetricType>::value,
-      "MetricType must be an PredictionMetric.");
 
   std::string get_name() const {
     return "ransac[" + sub_model_.get_name() + "]";
@@ -218,18 +288,36 @@ public:
   }
 
   template <typename FeatureType>
-  Fit<Ransac<ModelType, MetricType>, FeatureType>
+  Fit<Ransac<ModelType, StrategyType>, FeatureType>
   _fit_impl(const std::vector<FeatureType> &features,
             const MarginalDistribution &targets) const {
-    // Remove outliers
+
+    static_assert(has_call_operator<StrategyType, ModelType,
+                                    RegressionDataset<FeatureType>>::value,
+                  "Invalid Ransac Strategy");
+
     RegressionDataset<FeatureType> dataset(features, targets);
-    const auto fold_indexer = leave_one_out_indexer(dataset.features);
-    RegressionDataset<FeatureType> inliers =
-        ransac(dataset, fold_indexer, sub_model_, metric_, inlier_threshold_,
-               random_sample_size_, min_inliers_, max_iterations_);
+
+    auto indexer = strategy_.get_indexer(dataset);
+    auto ransac_functions = strategy_(sub_model_, dataset);
+
+    std::vector<FoldName> inliers =
+        ransac(ransac_functions, map_keys(indexer), inlier_threshold_,
+               random_sample_size_, min_consensus_size_, max_iterations_);
+
+    const auto good_inds = indices_from_names(indexer, inliers);
+    const auto consensus_set = subset(dataset, good_inds);
+
+    std::vector<FoldName> outliers;
+    for (const auto &pair : indexer) {
+      if (!contains_group(inliers, pair.first)) {
+        outliers.emplace_back(pair.first);
+      }
+    }
+
     // Then generate a fit.
-    return Fit<Ransac<ModelType, MetricType>, FeatureType>(
-        sub_model_.fit(inliers));
+    return Fit<Ransac<ModelType, StrategyType>, FeatureType>(
+        sub_model_.fit(consensus_set), inliers, outliers);
   }
 
   template <typename PredictFeatureType, typename FitType, typename PredictType>
@@ -245,29 +333,30 @@ public:
 
   template <typename Archive> void serialize(Archive &archive) {
     archive(cereal::make_nvp("sub_model", sub_model_));
-    archive(cereal::make_nvp("metric", metric_));
+    archive(cereal::make_nvp("strategy", strategy_));
     archive(cereal::make_nvp("inlier_threshold", inlier_threshold_));
-    archive(cereal::make_nvp("min_inliers", min_inliers_));
     archive(cereal::make_nvp("random_sample_size", random_sample_size_));
+    archive(cereal::make_nvp("min_consensus_size", min_consensus_size_));
     archive(cereal::make_nvp("max_iterations", max_iterations_));
   }
 
   ModelType sub_model_;
-  MetricType metric_;
+  StrategyType strategy_;
   double inlier_threshold_;
-  std::size_t min_inliers_;
   std::size_t random_sample_size_;
+  std::size_t min_consensus_size_;
   std::size_t max_iterations_;
 };
 
 template <typename ModelType>
-template <typename MetricType>
-Ransac<ModelType, MetricType> ModelBase<ModelType>::ransac(
-    const MetricType &metric, double inlier_threshold, std::size_t min_inliers,
-    std::size_t random_sample_size, std::size_t max_iterations) const {
-  return Ransac<ModelType, MetricType>(derived(), metric, inlier_threshold,
-                                       min_inliers, random_sample_size,
-                                       max_iterations);
+template <typename StrategyType>
+Ransac<ModelType, StrategyType> ModelBase<ModelType>::ransac(
+    const StrategyType &strategy, double inlier_threshold,
+    std::size_t random_sample_size, std::size_t min_consensus_size,
+    std::size_t max_iterations) const {
+  return Ransac<ModelType, StrategyType>(derived(), strategy, inlier_threshold,
+                                         random_sample_size, min_consensus_size,
+                                         max_iterations);
 }
 
 } // namespace albatross

--- a/include/albatross/utils/random_utils.h
+++ b/include/albatross/utils/random_utils.h
@@ -56,6 +56,18 @@ randint_without_replacement(std::size_t n, std::size_t low, std::size_t high,
   }
   return std::vector<std::size_t>(samples.begin(), samples.end());
 }
+
+template <typename X>
+inline std::vector<X>
+random_without_replacement(const std::vector<X> &xs, std::size_t n,
+                           std::default_random_engine &gen) {
+  std::vector<X> random_sample;
+  for (const auto &i : randint_without_replacement(n, 0, xs.size() - 1, gen)) {
+    random_sample.emplace_back(xs[i]);
+  }
+  return random_sample;
+}
+
 } // namespace albatross
 
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(albatross_unit_tests EXCLUDE_FROM_ALL
   test_model_adapter.cc
   test_model_metrics.cc  
   test_models.cc
+  test_model_metrics.cc
   test_parameter_handling_mixin.cc
   test_prediction.cc
   test_radial.cc

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -46,10 +46,12 @@ public:
     std::size_t sample_size = 3;
     std::size_t min_inliers = 3;
     std::size_t max_iterations = 20;
-    NegativeLogLikelihood<JointDistribution> nll;
+
+    DefaultRansacStrategy ransac_strategy;
     const auto gp = gp_from_covariance(covariance);
-    return gp.ransac(nll, inlier_threshold, sample_size, min_inliers,
-                     max_iterations);
+
+    return gp.ransac(ransac_strategy, inlier_threshold, sample_size,
+                     min_inliers, max_iterations);
   }
 
   auto get_dataset() const { return make_toy_linear_data(); }

--- a/tests/test_random_utils.cc
+++ b/tests/test_random_utils.cc
@@ -39,6 +39,9 @@ TEST(test_random_utils, randint_without_replacement) {
 TEST(test_random_utils, randint_without_replacement_full_set) {
   std::default_random_engine gen;
   const auto inds = randint_without_replacement(10, 0, 9, gen);
+  EXPECT_EQ(inds.size(), 10);
+  std::set<std::size_t> unique_inds(inds.begin(), inds.end());
+  EXPECT_EQ(unique_inds.size(), inds.size());
 }
 
 } // namespace albatross


### PR DESCRIPTION
Before this change `Ransac` was restricted to a single approach for evaluating a consensus set.  This change opens it up to different methods via a `RansacStrategy`.  Currently the only strategy is the `GenericRansacStrategy` which wraps a `ModelBase`, subsequent changes will (re)introduce a more efficient approach specific to Gaussian processes.

- Ransac model fits now include information about what was considered an inlier/outlier.
- `RansacFunctions` are now the focal point of the `ransac` function.
- Instead of `Ransac` working directly with indices it works with group (or fold) names.  This makes inspection of inliers/outliers a little more user friendly.