### PR TITLE
Faster Gaussian Process Strategy for Ransac

### DIFF
--- a/include/albatross/Evaluation
+++ b/include/albatross/Evaluation
@@ -16,6 +16,7 @@
 #include "Core"
 
 #include <albatross/evaluation/likelihood.h>
+#include <albatross/evaluation/differential_entropy.h>
 #include <albatross/covariance_functions/traits.h>
 #include <albatross/evaluation/traits.h>
 #include <albatross/evaluation/folds.h>

--- a/include/albatross/Ransac
+++ b/include/albatross/Ransac
@@ -18,5 +18,6 @@
 
 #include <albatross/utils/random_utils.h>
 #include <albatross/models/ransac.h>
+#include <albatross/models/ransac_gp.h>
 
 #endif

--- a/include/albatross/core/prediction.h
+++ b/include/albatross/core/prediction.h
@@ -168,5 +168,12 @@ private:
   const FitType fit_;
   const std::vector<FeatureType> features_;
 };
+
+template <typename ModelType, typename FeatureType, typename FitType>
+auto get_prediction(const ModelType &model, const FitType &fit,
+                    const std::vector<FeatureType> &features) {
+  return Prediction<ModelType, FeatureType, FitType>(model, fit, features);
+}
+
 } // namespace albatross
 #endif

--- a/include/albatross/evaluation/differential_entropy.h
+++ b/include/albatross/evaluation/differential_entropy.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef INCLUDE_ALBATROSS_EVALUATION_DIFFERENTIAL_ENTROPY_H_
+#define INCLUDE_ALBATROSS_EVALUATION_DIFFERENTIAL_ENTROPY_H_
+
+namespace albatross {
+
+// Calculate a numerically stable log determinant of a symmetric matrix using
+// the Cholesky (LDLT) decomposition.
+inline double
+log_determinant_of_symmetric(const Eigen::LDLT<Eigen::MatrixXd> &ldlt) {
+  double log_determinant = 0;
+  const auto diagonal = ldlt.vectorD();
+  for (Eigen::Index i = 0; i < diagonal.size(); ++i) {
+    log_determinant += log(diagonal(i));
+  }
+  return log_determinant;
+}
+
+/*
+ * Loosely describes the entropy of a model given the
+ * covariance matrix.  This can be thought of as describing
+ * the dispersion of the data.
+ *
+ * https://en.wikipedia.org/wiki/Differential_entropy
+ */
+inline double
+differential_entropy(const Eigen::LDLT<Eigen::MatrixXd> &cov_ldlt) {
+  double k = static_cast<double>(cov_ldlt.rows());
+  double log_det = log_determinant_of_symmetric(cov_ldlt);
+  return 0.5 * (k * (1 + log(2 * M_PI) + log_det));
+}
+
+inline double differential_entropy(const Eigen::MatrixXd &cov) {
+  Eigen::LDLT<Eigen::MatrixXd> ldlt(cov);
+  return differential_entropy(ldlt);
+}
+}
+
+#endif /* INCLUDE_ALBATROSS_EVALUATION_DIFFERENTIAL_ENTROPY_H_ */

--- a/include/albatross/models/ransac.h
+++ b/include/albatross/models/ransac.h
@@ -19,7 +19,6 @@ template <typename FitType> struct RansacFunctions {
   // A function which takes a bunch of keys and fits a model
   // to the corresponding subset of data.
   using FitterFunc = std::function<FitType(const std::vector<FoldName> &)>;
-  //  using FitterFunc = FitType (*) (const std::vector<FoldName> &);
 
   // A function which takes a fit and a set of indices
   // and returns a metric which represents how well the model

--- a/include/albatross/models/ransac_gp.h
+++ b/include/albatross/models/ransac_gp.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_MODELS_RANSAC_GP_H_
+#define ALBATROSS_MODELS_RANSAC_GP_H_
+
+namespace albatross {
+
+template <typename ModelType, typename FeatureType> struct FitAndIndices {
+  using FitType = typename fit_type<ModelType, FeatureType>::type;
+
+  FitType fit;
+  FoldIndices indices;
+};
+
+template <typename ModelType, typename FeatureType>
+inline
+    typename RansacFunctions<FitAndIndices<ModelType, FeatureType>>::FitterFunc
+    get_gp_ransac_fitter(const RegressionDataset<FeatureType> &dataset,
+                         const FoldIndexer &indexer,
+                         const Eigen::MatrixXd &cov) {
+  return [&, indexer, cov](const std::vector<FoldName> &groups) {
+    auto inds = indices_from_names(indexer, groups);
+
+    const auto train_dataset = subset(dataset, inds);
+    const auto train_cov = symmetric_subset(cov, inds);
+
+    using GPFitType = typename FitAndIndices<ModelType, FeatureType>::FitType;
+
+    const GPFitType fit(train_dataset.features, train_cov,
+                        train_dataset.targets);
+
+    FitAndIndices<ModelType, FeatureType> fit_and_indices = {fit, inds};
+    return fit_and_indices;
+  };
+}
+
+template <typename ModelType, typename FeatureType, typename InlierMetricType>
+inline typename RansacFunctions<
+    FitAndIndices<ModelType, FeatureType>>::InlierMetric
+get_gp_ransac_inlier_metric(const RegressionDataset<FeatureType> &dataset,
+                            const FoldIndexer &indexer,
+                            const Eigen::MatrixXd &cov, const ModelType &model,
+                            const InlierMetricType &metric) {
+
+  return [&, indexer, cov,
+          model](const FoldName &group,
+                 const FitAndIndices<ModelType, FeatureType> &fit_and_indices) {
+    auto inds = indexer.at(group);
+
+    const auto test_dataset = subset(dataset, inds);
+    const auto test_cov = symmetric_subset(cov, inds);
+
+    const auto cross_cov = subset(cov, fit_and_indices.indices, inds);
+
+    const auto pred =
+        get_prediction(model, fit_and_indices.fit, test_dataset.features);
+    double metric_value = metric(pred, test_dataset.targets);
+    return metric_value;
+  };
+}
+
+template <typename ModelType, typename FeatureType>
+inline typename RansacFunctions<
+    FitAndIndices<ModelType, FeatureType>>::ConsensusMetric
+get_gp_ransac_model_entropy_metric(const FoldIndexer &indexer,
+                                   const Eigen::MatrixXd &cov) {
+  return [&, indexer, cov](const std::vector<FoldName> &groups) {
+    auto inds = indices_from_names(indexer, groups);
+    auto consensus_cov = symmetric_subset(cov, inds);
+    return differential_entropy(consensus_cov);
+  };
+}
+
+template <typename ModelType, typename FeatureType, typename InlierMetric>
+inline RansacFunctions<FitAndIndices<ModelType, FeatureType>>
+get_gp_ransac_functions(const ModelType &model,
+                        const RegressionDataset<FeatureType> &dataset,
+                        const FoldIndexer &indexer,
+                        const InlierMetric &inlier_metric) {
+
+  static_assert(is_prediction_metric<InlierMetric>::value,
+                "InlierMetric must be an PredictionMetric.");
+
+  const auto full_cov = model.get_covariance()(dataset.features);
+
+  const auto fitter =
+      get_gp_ransac_fitter<ModelType, FeatureType>(dataset, indexer, full_cov);
+
+  const auto inlier_metric_from_group =
+      get_gp_ransac_inlier_metric<ModelType, FeatureType, InlierMetric>(
+          dataset, indexer, full_cov, model, inlier_metric);
+
+  const auto consensus_metric_from_gorup =
+      get_gp_ransac_model_entropy_metric<ModelType, FeatureType>(indexer,
+                                                                 full_cov);
+
+  return RansacFunctions<FitAndIndices<ModelType, FeatureType>>(
+      fitter, inlier_metric_from_group, consensus_metric_from_gorup);
+};
+
+template <typename InlierMetric, typename IndexingFunction>
+struct GaussianProcessRansacStrategy {
+
+  GaussianProcessRansacStrategy() = default;
+
+  GaussianProcessRansacStrategy(const InlierMetric &inlier_metric,
+                                const IndexingFunction &indexing_function)
+      : inlier_metric_(inlier_metric), indexing_function_(indexing_function){};
+
+  template <typename ModelType, typename FeatureType>
+  RansacFunctions<FitAndIndices<ModelType, FeatureType>>
+  operator()(const ModelType &model,
+             const RegressionDataset<FeatureType> &dataset) const {
+    const auto indexer = get_indexer(dataset);
+    return get_gp_ransac_functions(model, dataset, indexer, inlier_metric_);
+  }
+
+  template <typename FeatureType>
+  FoldIndexer get_indexer(const RegressionDataset<FeatureType> &dataset) const {
+    return indexing_function_(dataset);
+  }
+
+  template <typename Archive> void serialize(Archive &archive) {
+    archive(cereal::make_nvp("inlier_metric", inlier_metric_));
+    archive(cereal::make_nvp("indexing_function", indexing_function_));
+  }
+
+private:
+  InlierMetric inlier_metric_;
+  IndexingFunction indexing_function_;
+};
+
+using DefaultGPRansacStrategy =
+    GaussianProcessRansacStrategy<NegativeLogLikelihood<JointDistribution>,
+                                  LeaveOneOut>;
+}
+
+#endif /* INCLUDE_ALBATROSS_MODELS_RANSAC_GP_H_ */

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -47,9 +47,9 @@ public:
     std::size_t min_inliers = 3;
     std::size_t max_iterations = 20;
 
-    DefaultRansacStrategy ransac_strategy;
     const auto gp = gp_from_covariance(covariance);
 
+    DefaultGPRansacStrategy ransac_strategy;
     return gp.ransac(ransac_strategy, inlier_threshold, sample_size,
                      min_inliers, max_iterations);
   }


### PR DESCRIPTION
(re)Adds a faster version of Ransac for use with Gaussian Processes.

The speedup comes largely from the fact that the covariance matrix is computed only once, after which the ransac operations just index out the required blocks of that matrix, but additionally through the use of the differential entropy metric which need only compute the cholesky decomposition (without ever using it in a solve) to get a measure of how much information is held in a model.

This was all previously in albatross, but got lost in the recent refactor.