### PR TITLE
Creating a Model Based on Predictions From a Model

### DIFF
--- a/tests/test_model_metrics.cc
+++ b/tests/test_model_metrics.cc
@@ -41,4 +41,20 @@ TYPED_TEST(ModelMetricTester, test_sanity) {
   EXPECT_FALSE(std::isnan(metric));
 }
 
+TEST(test_gp_from_prediction, test_model_from_prediction) {
+  MakeGaussianProcess test_case;
+  auto dataset = test_case.get_dataset();
+  auto model = test_case.get_model();
+  std::vector<double> test_features = {0.1, 1.1, 2.2};
+  auto joint_prediction = model.fit(dataset).predict(test_features).joint();
+  auto joint_prediction_from_prediction =
+      model.fit_from_prediction(test_features, joint_prediction)
+          .predict(test_features)
+          .joint();
+  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
+      joint_prediction.mean, 1e-16));
+  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
+      joint_prediction.covariance, 1e-8));
+}
+
 } // namespace albatross

--- a/tests/test_model_metrics.cc
+++ b/tests/test_model_metrics.cc
@@ -41,20 +41,4 @@ TYPED_TEST(ModelMetricTester, test_sanity) {
   EXPECT_FALSE(std::isnan(metric));
 }
 
-TEST(test_gp_from_prediction, test_model_from_prediction) {
-  MakeGaussianProcess test_case;
-  auto dataset = test_case.get_dataset();
-  auto model = test_case.get_model();
-  std::vector<double> test_features = {0.1, 1.1, 2.2};
-  auto joint_prediction = model.fit(dataset).predict(test_features).joint();
-  auto joint_prediction_from_prediction =
-      model.fit_from_prediction(test_features, joint_prediction)
-          .predict(test_features)
-          .joint();
-  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
-      joint_prediction.mean, 1e-16));
-  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
-      joint_prediction.covariance, 1e-8));
-}
-
 } // namespace albatross

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -79,4 +79,20 @@ TEST(test_models, test_expect_predict_variants_consistent_fails) {
   expect_predict_variants_inconsistent(pred);
 }
 
+TEST(test_models, test_model_from_prediction) {
+  MakeGaussianProcess test_case;
+  auto dataset = test_case.get_dataset();
+  auto model = test_case.get_model();
+  std::vector<double> test_features = {0.1, 1.1, 2.2};
+  auto joint_prediction = model.fit(dataset).predict(test_features).joint();
+  auto joint_prediction_from_prediction =
+      model.fit_from_prediction(test_features, joint_prediction)
+          .predict(test_features)
+          .joint();
+  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
+      joint_prediction.mean, 1e-12));
+  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
+      joint_prediction.covariance, 1e-8));
+}
+
 } // namespace albatross


### PR DESCRIPTION
Our current architecture is based around a large model that takes in a lot of data (in the AM). To reduce CPU load, we then query this at select locations (in the AQ) and in turn create a small model from this subset of information that we then query repeatedly from the CG.

This PR implements a method that will ensure that the queries from the smaller model will return the same predictions and prediction variances for the data points queried from the larger model (though there is no guarantee that other points will have comparable values, we assume that they will as long as they are sufficiently close to the originally queried values). The current implementation will give a different  distribution to the original in general (though the mean may be the same).