### PR TITLE
Sparse Gaussian Processes

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -59,11 +59,29 @@ add_custom_target(run_call_trace_example
   COMMENT "Running call_trace_example"
   )
 
+
+add_executable(sparse_example
+  sparse_example.cc
+  )
+target_link_libraries(sparse_example
+  albatross
+  gflags
+  pthread
+  nlopt
+  )
+add_custom_target(run_sparse_example
+  DEPENDS sparse_example
+  COMMAND sparse_example -input ${PROJECT_SOURCE_DIR}/examples/sinc_input.csv -output ./sinc_predictions.csv
+  COMMENT "Running inspection_example"
+  )
+
+
 set(albatross_example_BINARIES
   sinc_example
   temperature_example
   call_trace_example
   inspection_example
+  sparse_example
   )
 foreach(TARGET IN LISTS albatross_example_BINARIES)
   target_compile_options(${TARGET} PRIVATE ${albatross_COMPILE_OPTIONS})

--- a/examples/plot_example_predictions.py
+++ b/examples/plot_example_predictions.py
@@ -52,8 +52,8 @@ if __name__ == "__main__":
              predictions_data['target'].astype('float'), color='black',
              label='truth')
     # Show the training points
-    plt.scatter(train_data['x'],
-                train_data['y'], color='k',
+    plt.scatter(train_data['feature'],
+                train_data['target'], color='k',
                 label='training points')
 
     y_min = np.min(predictions_data['target'].astype('float'))

--- a/examples/sparse_example.cc
+++ b/examples/sparse_example.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/Tune>
+
+#include <albatross/GP>
+#include <albatross/models/sparse_gp.h>
+
+#include <csv.h>
+#include <fstream>
+#include <gflags/gflags.h>
+#include <iostream>
+
+#define EXAMPLE_SLOPE_VALUE 0.
+#define EXAMPLE_CONSTANT_VALUE 0.
+
+#include "sinc_example_utils.h"
+
+DEFINE_string(input, "", "path to csv containing input data.");
+DEFINE_string(output, "", "path where predictions will be written in csv.");
+DEFINE_int32(n, 10, "number of training points to use.");
+DEFINE_int32(k, 5, "number of training points to use.");
+DEFINE_bool(tune, false, "a flag indication parameters should be tuned first.");
+
+using albatross::get_tuner;
+using albatross::ParameterStore;
+using albatross::RegressionDataset;
+
+template <typename ModelType>
+albatross::ParameterStore tune_model(ModelType &model,
+                                     RegressionDataset<double> &data) {
+  /*
+   * Now we tune the model by finding the hyper parameters that
+   * maximize the likelihood (or minimize the negative log likelihood).
+   */
+  std::cout << "Tuning the model." << std::endl;
+
+  albatross::LeaveOneOutLikelihood<> loo_nll;
+
+  return get_tuner(model, loo_nll, data).tune();
+}
+
+int main(int argc, char *argv[]) {
+
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  int n = FLAGS_n;
+  const double low = -3.;
+  const double high = 13.;
+  const double meas_noise = 0.1;
+
+  if (FLAGS_input == "") {
+    FLAGS_input = "input.csv";
+  }
+  maybe_create_training_data(FLAGS_input, n, low, high, meas_noise);
+
+  using namespace albatross;
+
+  std::cout << "Reading the input data." << std::endl;
+  RegressionDataset<double> data = read_csv_input(FLAGS_input);
+
+  std::cout << "Defining the model." << std::endl;
+  using Noise = IndependentNoise<double>;
+  using SquaredExp = SquaredExponential<EuclideanDistance>;
+
+  Noise noise(meas_noise);
+  SquaredExp squared_exponential(3.5, 5.7);
+  auto cov = noise + squared_exponential;
+
+  std::cout << cov.pretty_string() << std::endl;
+
+  LeaveOneOut loo;
+  UniformlySpacedInducingPoints strategy(FLAGS_k);
+  auto model = sparse_gp_from_covariance(cov, strategy, loo, "example");
+  //  auto model = gp_from_covariance(cov, "example");
+
+  if (FLAGS_tune) {
+    model.set_params(tune_model(model, data));
+  }
+
+  std::cout << pretty_param_details(model.get_params()) << std::endl;
+  const auto fit_model = model.fit(data);
+
+  /*
+   * Make predictions at a bunch of locations which we can then
+   * visualize if desired.
+   */
+  write_predictions_to_csv(FLAGS_output, fit_model, low, high);
+}

--- a/include/albatross/covariance_functions/covariance_function.h
+++ b/include/albatross/covariance_functions/covariance_function.h
@@ -209,6 +209,25 @@ public:
   }
 
   /*
+   * Diagonal of the covariance matrix.
+   */
+  template <typename X,
+            typename std::enable_if<
+                has_valid_call_impl<Derived, X &, X &>::value, int>::type = 0>
+  Eigen::VectorXd diagonal(const std::vector<X> &xs) const {
+    int n = static_cast<int>(xs.size());
+    Eigen::VectorXd diag(n);
+
+    int i;
+    std::size_t si;
+    for (i = 0; i < n; i++) {
+      si = static_cast<std::size_t>(i);
+      diag[i] = this->operator()(xs[si], xs[si]);
+    }
+    return diag;
+  }
+
+  /*
    * Stubs to catch the case where a covariance function was called
    * with arguments that aren't supported.
    *
@@ -268,6 +287,14 @@ public:
   double operator()(const X &x,
                     const Y &y) const =
       delete; // Invalid _call_impl(.  See comments for help.
+
+  /*
+   * Covariance between each element and every other in a vector.
+   */
+  template <typename X,
+            typename std::enable_if<
+                !has_valid_call_impl<Derived, X &, X &>::value, int>::type = 0>
+  DiagonalMatrixXd diagonal(const std::vector<X> &xs) const = delete;
 
   CallTrace<Derived> call_trace() const;
 

--- a/include/albatross/models/gp.h
+++ b/include/albatross/models/gp.h
@@ -45,8 +45,14 @@ struct Fit<GaussianProcessBase<CovFunc, ImplType>, FeatureType> {
 
   Fit(){};
 
+  Fit(const std::vector<FeatureType> &features_,
+      const Eigen::SerializableLDLT &ldlt_, const Eigen::VectorXd &information_)
+      : train_features(features_), train_ldlt(ldlt_),
+        information(information_) {}
+
   Fit(const std::vector<FeatureType> &features,
       const Eigen::MatrixXd &train_cov, const MarginalDistribution &targets) {
+
     train_features = features;
     Eigen::MatrixXd cov(train_cov);
     if (targets.has_covariance()) {

--- a/include/albatross/models/sparse_gp.h
+++ b/include/albatross/models/sparse_gp.h
@@ -148,7 +148,7 @@ public:
     // P is such that:
     //     Q_ff = K_fu K_uu^-1 K_uf
     //          = K_fu L^-T L^-1 K_uf
-    //          = P P^T
+    //          = P^T P
     Eigen::MatrixXd P = K_uu_llt.matrixL().solve(K_fu.transpose());
 
     // Efficiently compute the diagonal diag[Q_ff].

--- a/include/albatross/models/sparse_gp.h
+++ b/include/albatross/models/sparse_gp.h
@@ -185,14 +185,17 @@ public:
      *     C^-1 = (K_uu^-1 - S)^-1
      *                                                  (Expansion of S)
      *          = (K_uu^-1 - (K_uu + K_uf A^-1 K_fu)^-1)^-1
-     *                                          (Matrix Inversion Lemma)
-     *          = (K_uu^-1 K_uf (A + K_fu K_uu^-1 K_uf)^-1 K_fu K_uu-1)
+     *                                        (Woodbury Matrix Identity)
+     *          = (K_uu^-1 K_uf (A + K_fu K_uu^-1 K_uf)^-1 K_fu K_uu^-1)
      *                                   (LL^T = K_uu and P = L^-1 K_uf)
      *          = L^-T P (A + P^T P)^-1 P^T L^-1
      *                                        (Searle Set of Identities)
-     *          = L^-T C A^-1 P^T (I + P A^-1 P)^-1 L^-1
-     *                           (B = (I + P A^-1 P) and R = A^-1/2 P^T)
+     *          = L^-T P A^-1 P^T (I + P A^-1 P^T)^-1 L^-1
+     *                         (B = (I + P A^-1 P^T) and R = A^-1/2 P^T)
      *          = L^-T R^T R B^-1 L^-1
+     *
+     *  taking the inverse of that then gives us:
+     *      C   = L B (R^T R)^-1 L^T
      *
      *  reusing some of the precomputed values there leads to:
      *
@@ -212,8 +215,8 @@ public:
     Eigen::MatrixXd L_uu_inv =
         K_uu_llt.matrixL().solve(Eigen::MatrixXd::Identity(m, m));
     Eigen::MatrixXd RtRBiLi = RtR * B_ldlt.solve(L_uu_inv);
-    Eigen::MatrixXd C =
-        (K_uu_llt.matrixL().transpose().solve(RtRBiLi)).inverse();
+    Eigen::MatrixXd LT = K_uu_llt.matrixL().transpose();
+    Eigen::MatrixXd C = K_uu_llt.matrixL() * B * RtR.ldlt().solve(LT);
 
     return typename Base::template GPFitType<FeatureType>(u, C.ldlt(), v);
   }

--- a/include/albatross/models/sparse_gp.h
+++ b/include/albatross/models/sparse_gp.h
@@ -228,7 +228,8 @@ public:
   IndexingFunction independent_group_indexing_function;
 };
 
-template <typename CovFunc, typename InducingPointStrategy, typename IndexingFunction>
+template <typename CovFunc, typename InducingPointStrategy,
+          typename IndexingFunction>
 auto sparse_gp_from_covariance(CovFunc covariance_function,
                                InducingPointStrategy &strategy,
                                IndexingFunction &index_function,
@@ -237,6 +238,6 @@ auto sparse_gp_from_covariance(CovFunc covariance_function,
                                          IndexingFunction>(
       covariance_function, strategy, index_function, model_name);
 };
-}
+} // namespace albatross
 
 #endif /* INCLUDE_ALBATROSS_MODELS_SPARSE_GP_H_ */

--- a/include/albatross/models/sparse_gp.h
+++ b/include/albatross/models/sparse_gp.h
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef INCLUDE_ALBATROSS_MODELS_SPARSE_GP_H_
+#define INCLUDE_ALBATROSS_MODELS_SPARSE_GP_H_
+
+namespace albatross {
+
+template <typename CovFunc, typename InducingPointStrategy,
+          typename IndexingFunction>
+class SparseGaussianProcessRegression;
+
+std::vector<double> inline linspace(double a, double b, std::size_t n) {
+  double h = (b - a) / static_cast<double>(n - 1);
+  std::vector<double> xs(n);
+  typename std::vector<double>::iterator x;
+  double val;
+  for (x = xs.begin(), val = a; x != xs.end(); ++x, val += h)
+    *x = val;
+  return xs;
+}
+
+struct UniformlySpacedInducingPoints {
+
+  UniformlySpacedInducingPoints(std::size_t num_points_ = 10)
+      : num_points(num_points_) {}
+
+  std::vector<double> operator()(const std::vector<double> &features) const {
+    double min = *std::min_element(features.begin(), features.end());
+    double max = *std::max_element(features.begin(), features.end());
+
+    return linspace(min, max, num_points);
+  }
+
+  std::size_t num_points;
+};
+
+/*
+ *  This class implements an approximation technique for Gaussian processes
+ * which relies on an assumption that all observations are independent (or
+ * groups of observations are independent) conditional on a set of inducing
+ * points.  The method is based off:
+ *
+ *     [1] Sparse Gaussian Processes using Pseudo-inputs
+ *     Edward Snelson, Zoubin Ghahramani
+ *     http://www.gatsby.ucl.ac.uk/~snelson/SPGP_up.pdf
+ *
+ *  Though the code uses notation closer to that used in this (excellent)
+ * overview of these methods:
+ *
+ *     [2] A Unifying View of Sparse Approximate Gaussian Process Regression
+ *     Joaquin Quinonero-Candela, Carl Edward Rasmussen
+ *     http://www.jmlr.org/papers/volume6/quinonero-candela05a/quinonero-candela05a.pdf
+ *
+ *  Very broadly speaking this method starts with a prior over the observations,
+ *
+ *     [f] ~ N(0, K_ff)
+ *
+ *  where K_ff(i, j) = covariance_function(features[i], features[j]) and f
+ * represents the function value.
+ *
+ *  It then uses a set of inducing points, u, and makes some assumptions about
+ * the conditional distribution:
+ *
+ *     [f|u] ~ N(K_fu K_uu^-1 u, K_ff - Q_ff)
+ *
+ *  Where Q_ff = K_fu K_uu^-1 K_uf represents the variance in f that is
+ * explained by u.
+ *
+ *  For FITC (Fully Independent Training Contitional) the assumption is that
+ * K_ff - Qff is diagonal, for PITC (Partially Independent Training Conditional)
+ * that it is block diagonal.  These assumptions lead to an efficient way of
+ * inferring the posterior distribution for some new location f*,
+ *
+ *     [f*|f=y] ~ N(K_*u S K_uf^-1 A^-1 y, K_** − Q_** + K_*u S K_u*)
+ *
+ *  Where S = (K_uu + K_uf A^-1 K_fu)^-1 and A = diag(K_ff - Q_ff) and "diag"
+ * may mean diagonal or block diagonal.  Regardless we end up with O(m^2n)
+ * complexity instead of O(n^3) of direct Gaussian processes.  (Note that in [2]
+ * S is called sigma and A is lambda.)
+ *
+ *  Of course, the implementation details end up somewhat more complex in order
+ * to improve numerical stability.  A few great resources were heavily used to
+ * get those deails straight:
+ *
+ *     - https://bwengals.github.io/pymc3-fitcvfe-implementation-notes.html
+ *     - https://github.com/SheffieldML/GPy see fitc.py
+ */
+template <typename CovFunc, typename InducingPointStrategy,
+          typename IndexingFunction>
+class SparseGaussianProcessRegression
+    : public GaussianProcessBase<
+          CovFunc, SparseGaussianProcessRegression<
+                       CovFunc, InducingPointStrategy, IndexingFunction>> {
+
+public:
+  using Base = GaussianProcessBase<
+      CovFunc, SparseGaussianProcessRegression<CovFunc, InducingPointStrategy,
+                                               IndexingFunction>>;
+
+  SparseGaussianProcessRegression() : Base(){};
+  SparseGaussianProcessRegression(CovFunc &covariance_function)
+      : Base(covariance_function){};
+  SparseGaussianProcessRegression(
+      CovFunc &covariance_function,
+      InducingPointStrategy &inducing_point_strategy_,
+      IndexingFunction &independent_group_indexing_function_,
+      const std::string &model_name)
+      : Base(covariance_function, model_name),
+        inducing_point_strategy(inducing_point_strategy_),
+        independent_group_indexing_function(
+            independent_group_indexing_function_){};
+  SparseGaussianProcessRegression(CovFunc &covariance_function,
+                                  const std::string &model_name)
+      : Base(covariance_function, model_name){};
+
+  template <typename FeatureType>
+  auto _fit_impl(const std::vector<FeatureType> &features,
+                 const MarginalDistribution &targets) const {
+    static_assert(std::is_same<IndexingFunction, LeaveOneOut>::value,
+                  "Only FITC is currently implemented, but by allowing "
+                  "arbitrary groups this could turn into PITC");
+
+    // Determine the set of inducing points, u.
+    auto u = inducing_point_strategy(features);
+
+    Eigen::Index n = targets.mean.size();
+    Eigen::Index m = static_cast<Eigen::Index>(u.size());
+
+    // Create the covariance matrices we need.
+    Eigen::VectorXd K_ff_diag = this->covariance_function_.diagonal(features);
+    if (targets.has_covariance()) {
+      K_ff_diag += targets.covariance.diagonal();
+    }
+    Eigen::MatrixXd K_fu = this->covariance_function_(features, u);
+    Eigen::MatrixXd K_uu = this->covariance_function_(u);
+
+    auto K_uu_llt = K_uu.llt();
+    // P is such that:
+    //     Q_ff = K_fu K_uu^-1 K_uf
+    //          = K_fu L^-T L^-1 K_uf
+    //          = P P^T
+    Eigen::MatrixXd P = K_uu_llt.matrixL().solve(K_fu.transpose());
+
+    // Efficiently compute the diagonal diag[Q_ff].
+    Eigen::VectorXd Q_ff_diag = P.colwise().squaredNorm();
+
+    Eigen::VectorXd A = K_ff_diag - Q_ff_diag;
+
+    if (A.minCoeff() < 1e-6) {
+      // It's possible that the inducing points will perfectly describe
+      // some of the data, in which case we need to add a bit of extra
+      // noise to make sure lambda is invertible.
+      A += 1e-6 * Eigen::VectorXd::Ones(n);
+    }
+    /*
+     *
+     * The end goal here is to produce a vector, v, and matrix, C, such that
+     * for a prediction, f*, we can do,
+     *
+     *     [f*|f=y] ~ N(K_*u * v , K_** - K_*u * C^-1 * K_u*)
+     *
+     *  and it would match the desired prediction described above,
+     *
+     *     [f*|f=y] ~ N(K_*u S K_uf^-1 A^-1 y, K_** − Q_** + K_*u S K_u*)
+     *
+     *  we can find v easily,
+     *
+     *     v = S K_uf^-1 A^-1 y
+     *
+     *  and to get C we need to do some algebra,
+     *
+     *     K_** - K_*u * C * K_u* = K_** - Q_** + K_*u S K_u*
+     *                            = K_** - K_*u (K_uu^-1 - S) K_u*
+     *  which leads to:
+     *     C^-1 = (K_uu^-1 - S)^-1
+     *                                                  (Expansion of S)
+     *          = (K_uu^-1 - (K_uu + K_uf A^-1 K_fu)^-1)^-1
+     *                                          (Matrix Inversion Lemma)
+     *          = (K_uu^-1 K_uf (A + K_fu K_uu^-1 K_uf)^-1 K_fu K_uu-1)
+     *                                   (LL^T = K_uu and P = L^-1 K_uf)
+     *          = L^-T P (A + P^T P)^-1 P^T L^-1
+     *                                        (Searle Set of Identities)
+     *          = L^-T C A^-1 P^T (I + P A^-1 P)^-1 L^-1
+     *                           (B = (I + P A^-1 P) and R = A^-1/2 P^T)
+     *          = L^-T R^T R B^-1 L^-1
+     *
+     *  reusing some of the precomputed values there leads to:
+     *
+     *     v = L^-T B^-1 P * A^-1 y
+     */
+    Eigen::VectorXd A_sqrt = A.array().sqrt();
+    Eigen::MatrixXd RtR = A_sqrt.asDiagonal().inverse() * P.transpose();
+    RtR = RtR.transpose() * RtR;
+    Eigen::MatrixXd B = Eigen::MatrixXd::Identity(m, m) + RtR;
+
+    auto B_ldlt = B.ldlt();
+
+    Eigen::VectorXd v = P * (A.asDiagonal().inverse() * targets.mean);
+    v = B_ldlt.solve(v);
+    v = K_uu_llt.matrixL().transpose().solve(v);
+
+    Eigen::MatrixXd L_uu_inv =
+        K_uu_llt.matrixL().solve(Eigen::MatrixXd::Identity(m, m));
+    Eigen::MatrixXd RtRBiLi = RtR * B_ldlt.solve(L_uu_inv);
+    Eigen::MatrixXd C =
+        (K_uu_llt.matrixL().transpose().solve(RtRBiLi)).inverse();
+
+    return typename Base::template GPFitType<FeatureType>(u, C.ldlt(), v);
+  }
+
+  // This hides the inherited _predict_impl definitions from the base class
+  // Which makes the base class think nothing is defined and in turn leads
+  // it to using the default GP `_predict_impl`.
+  void _predict_impl() = delete;
+  void cross_validated_predictions() = delete;
+
+  InducingPointStrategy inducing_point_strategy;
+  IndexingFunction independent_group_indexing_function;
+};
+
+template <typename CovFunc, typename InducingPointStrategy, typename IndexingFunction>
+auto sparse_gp_from_covariance(CovFunc covariance_function,
+                               InducingPointStrategy &strategy,
+                               IndexingFunction &index_function,
+                               const std::string &model_name) {
+  return SparseGaussianProcessRegression<CovFunc, InducingPointStrategy,
+                                         IndexingFunction>(
+      covariance_function, strategy, index_function, model_name);
+};
+}
+
+#endif /* INCLUDE_ALBATROSS_MODELS_SPARSE_GP_H_ */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(albatross_unit_tests EXCLUDE_FROM_ALL
   test_scaling_function.cc
   test_serializable_ldlt.cc
   test_serialize.cc
+  test_sparse_gp.cc
   test_traits_cereal.cc
   test_traits_core.cc
   test_traits_covariance_functions.cc

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -29,26 +29,30 @@ TEST(test_sparse_gp, test_sanity) {
   auto sparse = sparse_gp_from_covariance(covariance, strategy, loo, "sparse");
 
   UniformlySpacedInducingPoints bad_strategy(2);
-  auto really_sparse = sparse_gp_from_covariance(covariance, bad_strategy, loo, "really_sparse");
+  auto really_sparse =
+      sparse_gp_from_covariance(covariance, bad_strategy, loo, "really_sparse");
 
   auto test_features = linspace(0.01, 9.9, 11);
 
   auto sparse_pred = sparse.fit(dataset).predict(test_features).joint();
-  auto really_sparse_pred = really_sparse.fit(dataset).predict(test_features).joint();
+  auto really_sparse_pred =
+      really_sparse.fit(dataset).predict(test_features).joint();
   auto direct_pred = direct.fit(dataset).predict(test_features).joint();
 
   double sparse_error = (sparse_pred.mean - direct_pred.mean).norm();
-  double really_sparse_error = (really_sparse_pred.mean - direct_pred.mean).norm();
+  double really_sparse_error =
+      (really_sparse_pred.mean - direct_pred.mean).norm();
   EXPECT_LT(sparse_error, 1e-2);
   EXPECT_LT(really_sparse_error, 0.5);
   EXPECT_GT(really_sparse_error, sparse_error);
 
-  double sparse_cov_diff = (sparse_pred.covariance - direct_pred.covariance).norm();
-  double really_sparse_cov_diff = (really_sparse_pred.covariance - direct_pred.covariance).norm();
+  double sparse_cov_diff =
+      (sparse_pred.covariance - direct_pred.covariance).norm();
+  double really_sparse_cov_diff =
+      (really_sparse_pred.covariance - direct_pred.covariance).norm();
 
   EXPECT_LT(sparse_cov_diff, 1e-2);
   EXPECT_LT(really_sparse_cov_diff, 0.5);
   EXPECT_GT(really_sparse_cov_diff, sparse_cov_diff);
 }
-
-}
+} // namespace albatross

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <gtest/gtest.h>
+
+#include "test_models.h"
+
+#include <albatross/models/sparse_gp.h>
+
+namespace albatross {
+
+TEST(test_sparse_gp, test_sanity) {
+  auto covariance = make_simple_covariance_function();
+  auto dataset = make_toy_linear_data();
+
+  auto direct = gp_from_covariance(covariance, "direct");
+
+  LeaveOneOut loo;
+  UniformlySpacedInducingPoints strategy(10);
+  auto sparse = sparse_gp_from_covariance(covariance, strategy, loo, "sparse");
+
+  UniformlySpacedInducingPoints bad_strategy(2);
+  auto really_sparse = sparse_gp_from_covariance(covariance, bad_strategy, loo, "really_sparse");
+
+  auto test_features = linspace(0.01, 9.9, 11);
+
+  auto sparse_pred = sparse.fit(dataset).predict(test_features).joint();
+  auto really_sparse_pred = really_sparse.fit(dataset).predict(test_features).joint();
+  auto direct_pred = direct.fit(dataset).predict(test_features).joint();
+
+  double sparse_error = (sparse_pred.mean - direct_pred.mean).norm();
+  double really_sparse_error = (really_sparse_pred.mean - direct_pred.mean).norm();
+  EXPECT_LT(sparse_error, 1e-2);
+  EXPECT_LT(really_sparse_error, 0.5);
+  EXPECT_GT(really_sparse_error, sparse_error);
+
+  double sparse_cov_diff = (sparse_pred.covariance - direct_pred.covariance).norm();
+  double really_sparse_cov_diff = (really_sparse_pred.covariance - direct_pred.covariance).norm();
+
+  EXPECT_LT(sparse_cov_diff, 1e-2);
+  EXPECT_LT(really_sparse_cov_diff, 0.5);
+  EXPECT_GT(really_sparse_cov_diff, sparse_cov_diff);
+}
+
+}

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -20,6 +20,25 @@
 
 namespace albatross {
 
+static inline auto make_toy_sine_data(const double a = 5., const double b = 10.,
+                                      const double sigma = 0.1,
+                                      const std::size_t n = 10) {
+  std::random_device rd{};
+  std::mt19937 gen{rd()};
+  gen.seed(3);
+  std::normal_distribution<> d{0., sigma};
+  std::vector<double> features;
+  Eigen::VectorXd targets(n);
+
+  for (std::size_t i = 0; i < n; i++) {
+    double x = static_cast<double>(i);
+    features.push_back(x);
+    targets[i] = a * sin(x * b) + d(gen);
+  }
+
+  return RegressionDataset<double>(features, targets);
+}
+
 static inline auto make_toy_linear_data(const double a = 5.,
                                         const double b = 1.,
                                         const double sigma = 0.1,


### PR DESCRIPTION
This change introduces an approach for approximating a Gaussian process using the Fully Independent Training Conditoinal (FITC) method.

An excellent survey of FITC in the context of other approximation methods can be found [here](http://www.jmlr.org/papers/volume6/quinonero-candela05a/quinonero-candela05a.pdf
).

This particular implementation works by first defining an `InducingPointStrategy`.  These strategies take a vector of features and will return a new vector of features which represent the inducing points, `u`.  For example, in `sparse_example.cc` we start with the same toy problem as `sinc_example.cc`.  The example has training data that is randomly sampled on the x-axis between 0 and 13.  The inducing point strategy in this example finds the bounds of the data and samples k linearly spaced points in the range.

FITC then works by effectively finding the posterior distribution of `u` conditional on the training data `y`, `[u|y]`.  For some new features, `x*` the corresponding predictions, `y*`, are then made by finding the posterior distribution `[y*|u]`.

The process is then:
- Start with some training data (features and targets)
- Find the distribution of the inducing points conditioned on the training data.
- Build a new representative Gaussian process over `u` which results in a `Fit<GaussianProcessBase<...>>` type equivalent to if one had been created using a full Gaussian process.
- Predictions are then made using the default Gaussian process `_predict_impl`.

Because `u` is typically much smaller than `y` this significantly accelerates inference.