### PR TITLE
Forwarded Inheritence

### DIFF
--- a/include/albatross/core/model.h
+++ b/include/albatross/core/model.h
@@ -23,15 +23,8 @@ template <typename ModelType> class ModelBase : public ParameterHandlingMixin {
 
   template <typename T, typename FeatureType> friend class fit_model_type;
 
-private:
-  // Declaring these private makes it impossible to accidentally do things like:
-  //     class A : public ModelBase<B> {}
-  // or
-  //     using A = ModelBase<B>;
-  //
-  // which if unchecked can lead to some very strange behavior.
+protected:
   ModelBase() : insights_(){};
-  friend ModelType;
   Insights insights_;
 
   /*
@@ -60,9 +53,8 @@ private:
                 !has_possible_fit<ModelType, FeatureType>::value &&
                     !has_valid_fit<ModelType, FeatureType>::value,
                 int>::type = 0>
-  void
-  _fit(const std::vector<FeatureType> &features,
-       const MarginalDistribution &targets) const = delete; // No fit found.
+  void _fit(const std::vector<FeatureType> &features,
+            const MarginalDistribution &targets) const = delete;
 
   template <
       typename PredictFeatureType, typename FitType, typename PredictType,
@@ -85,6 +77,7 @@ private:
       const std::vector<PredictFeatureType> &features, const FitType &fit,
       PredictTypeIdentity<PredictType> &&) const = delete; // No valid predict.
 
+public:
   /*
    * CRTP Helpers
    */
@@ -93,7 +86,6 @@ private:
     return *static_cast<const ModelType *>(this);
   }
 
-public:
   template <class Archive>
   void save(Archive &archive, const std::uint32_t) const {
     archive(cereal::make_nvp("params", derived().get_params()));

--- a/include/albatross/core/traits.h
+++ b/include/albatross/core/traits.h
@@ -54,18 +54,16 @@ public:
 /*
  * Like std::is_base_of<T, U> except compares the first template parameter.  Ie,
  *
- *  first_template_param_is_base_of<C<T, X>, C<U, Y>>::value == is_base_of<T,
+ *  first_template_param_is_base_of<T, C<U, X>>::value == is_base_of<T,
  * U>::value
  */
 template <typename T, typename U>
 struct first_template_param_is_base_of : public std::false_type {};
 
 template <template <typename, typename> class Base, typename T, typename U,
-          typename P, typename Q>
-struct first_template_param_is_base_of<Base<T, P>, Base<U, Q>>
+          typename P>
+struct first_template_param_is_base_of<T, Base<U, P>>
     : public std::is_base_of<T, U> {};
-
-struct is_valid_fit_type_dummy_type {};
 
 /*
  * A valid fit for a ModelType is defined as Fit<AnyBaseOfModelType,
@@ -73,8 +71,7 @@ struct is_valid_fit_type_dummy_type {};
  */
 template <typename ModelType, typename FitType>
 struct is_valid_fit_type
-    : public first_template_param_is_base_of<
-          FitType, Fit<ModelType, is_valid_fit_type_dummy_type>> {};
+    : public first_template_param_is_base_of<ModelBase<ModelType>, FitType> {};
 
 /*
  * This determines whether or not a class (T) has a method defined for,

--- a/include/albatross/models/least_squares.h
+++ b/include/albatross/models/least_squares.h
@@ -36,8 +36,7 @@ template <typename ImplType> struct Fit<LeastSquares<ImplType>> {
  *
  * The FeatureType in this case is a single row from the design matrix.
  */
-template <typename ImplType>
-class LeastSquares : public ModelBase<LeastSquares<ImplType>> {
+template <typename ImplType> class LeastSquares : public ModelBase<ImplType> {
 public:
   using FitType = Fit<LeastSquares<ImplType>>;
 
@@ -60,14 +59,6 @@ public:
     return model_fit;
   }
 
-  template <typename FeatureType,
-            typename std::enable_if<has_valid_fit<ImplType, FeatureType>::value,
-                                    int>::type = 0>
-  FitType _fit_impl(const std::vector<FeatureType> &features,
-                    const MarginalDistribution &targets) const {
-    return impl()._fit_impl(features, targets);
-  }
-
   Eigen::VectorXd _predict_impl(const std::vector<Eigen::VectorXd> &features,
                                 const FitType &least_squares_fit,
                                 PredictTypeIdentity<Eigen::VectorXd>) const {
@@ -80,18 +71,6 @@ public:
     return Eigen::VectorXd(mean);
   }
 
-  template <
-      typename FeatureType, typename FitType, typename PredictType,
-      typename std::enable_if<
-          has_valid_predict<ImplType, FeatureType, FitType, PredictType>::value,
-          int>::type = 0>
-  PredictType _predict_impl(const std::vector<FeatureType> &features,
-                            const FitType &least_squares_fit,
-                            PredictTypeIdentity<PredictType>) const {
-    return impl()._predict_impl(features, least_squares_fit,
-                                PredictTypeIdentity<PredictType>());
-  }
-
   /*
    * This lets you customize the least squares approach if need be,
    * default uses the QR decomposition.
@@ -100,12 +79,6 @@ public:
                                        const Eigen::VectorXd &b) const {
     return A.colPivHouseholderQr().solve(b);
   }
-
-  /*
-   * CRTP Helpers
-   */
-  ImplType &impl() { return *static_cast<ImplType *>(this); }
-  const ImplType &impl() const { return *static_cast<const ImplType *>(this); }
 };
 
 /*

--- a/include/albatross/models/sparse_gp.h
+++ b/include/albatross/models/sparse_gp.h
@@ -221,11 +221,7 @@ public:
     return typename Base::template GPFitType<FeatureType>(u, C.ldlt(), v);
   }
 
-  // This hides the inherited _predict_impl definitions from the base class
-  // Which makes the base class think nothing is defined and in turn leads
-  // it to using the default GP `_predict_impl`.
-  void _predict_impl() = delete;
-  void cross_validated_predictions() = delete;
+  using Base::_predict_impl;
 
   InducingPointStrategy inducing_point_strategy;
   IndexingFunction independent_group_indexing_function;

--- a/tests/test_model_adapter.cc
+++ b/tests/test_model_adapter.cc
@@ -38,9 +38,8 @@ public:
     return converted;
   }
 
-  typename fit_type<Base, double>::type
-  _fit_impl(const std::vector<AdaptedFeature> &features,
-            const MarginalDistribution &targets) const {
+  auto _fit_impl(const std::vector<AdaptedFeature> &features,
+                 const MarginalDistribution &targets) const {
     return Base::_fit_impl(convert(features), targets);
   }
 

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -43,9 +43,16 @@ TYPED_TEST_P(RegressionModelTester, test_predict_variants) {
   expect_predict_variants_consistent(pred);
 }
 
+TYPED_TEST_P(RegressionModelTester, test_currect_derived_type) {
+  const auto model = this->test_case.get_model();
+  const auto derived = model.derived();
+  bool same = std::is_same<decltype(model), decltype(derived)>::value;
+  EXPECT_TRUE(same);
+}
+
 REGISTER_TYPED_TEST_CASE_P(RegressionModelTester,
                            test_performs_reasonably_on_linear_data,
-                           test_predict_variants);
+                           test_predict_variants, test_currect_derived_type);
 
 INSTANTIATE_TYPED_TEST_CASE_P(test_models, RegressionModelTester,
                               ExampleModels);

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -65,14 +65,24 @@ public:
   using Base = GaussianProcessBase<CovarianceFunc,
                                    AdaptedGaussianProcess<CovarianceFunc>>;
 
+  using Base::_fit_impl;
+  using Base::_predict_impl;
   using Base::Base;
+
+  template <typename FeatureType, typename PredictType>
+  std::map<std::string, PredictType>
+  cross_validated_predictions(const RegressionDataset<FeatureType> &dataset,
+                              const FoldIndexer &fold_indexer,
+                              PredictTypeIdentity<PredictType> identity) const {
+    return gp_cross_validated_predictions(dataset, fold_indexer, *this,
+                                          identity);
+  }
 
   template <typename FitFeatureType>
   using GPFitType = Fit<Base, FitFeatureType>;
 
-  typename fit_type<Base, double>::type
-  _fit_impl(const std::vector<AdaptedFeature> &features,
-            const MarginalDistribution &targets) const {
+  auto _fit_impl(const std::vector<AdaptedFeature> &features,
+                 const MarginalDistribution &targets) const {
     std::vector<double> converted;
     for (const auto &f : features) {
       converted.push_back(f.value);

--- a/tests/test_traits_core.cc
+++ b/tests/test_traits_core.cc
@@ -153,17 +153,13 @@ TEST(test_traits_core, test_fit_type) {
   //                        fit_type<HasPrivateValidFitImpl, X>::type>::value));
 }
 
-template <typename T> struct Base {};
+template <typename T> struct Base : public ModelBase<T> {};
 
 struct Derived : public Base<Derived> {};
 
 TEST(test_traits_core, test_is_valid_fit_type) {
   EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Derived, X>>::value));
   EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Derived, Y>>::value));
-  EXPECT_TRUE(
-      bool(is_valid_fit_type<Base<Derived>, Fit<Base<Derived>, X>>::value));
-  EXPECT_TRUE(
-      bool(is_valid_fit_type<Base<Derived>, Fit<Base<Derived>, Y>>::value));
   // If a Derived class which inherits from Base<Derived> has a fit
   // which returns Fit<Base<Derived>> consider that a valid fit type.
   EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Base<Derived>, X>>::value));
@@ -178,36 +174,18 @@ template <typename T> struct Adaptable;
 template <typename T, typename FeatureType>
 struct Fit<Adaptable<T>, FeatureType> {};
 
-template <typename ImplType>
-struct Adaptable : public ModelBase<Adaptable<ImplType>> {
+template <typename ImplType> struct Adaptable : public ModelBase<ImplType> {
 
   Fit<Adaptable<ImplType>, X> _fit_impl(const std::vector<X> &,
                                         const MarginalDistribution &) const {
     return Fit<Adaptable<ImplType>, X>();
   }
-
-  /*
-   * This forwards on `fit` definitions from the implementing class
-   * to this class so it can be picked up by ModelBase.
-   */
-  template <typename FeatureType,
-            typename std::enable_if<has_valid_fit<ImplType, FeatureType>::value,
-                                    int>::type = 0>
-  auto _fit_impl(const std::vector<FeatureType> &features,
-                 const MarginalDistribution &targets) const {
-    return impl()._fit_impl(features, targets);
-  }
-
-  /*
-   * CRTP Helpers
-   */
-  ImplType &impl() { return *static_cast<ImplType *>(this); }
-  const ImplType &impl() const { return *static_cast<const ImplType *>(this); }
 };
 
 struct Extended : public Adaptable<Extended> {
 
   using Base = Adaptable<Extended>;
+  using Base::_fit_impl;
 
   auto _fit_impl(const std::vector<Y> &,
                  const MarginalDistribution &targets) const {
@@ -233,8 +211,17 @@ TEST(test_traits_core, test_adaptable_fit_type) {
 }
 
 TEST(test_traits_core, test_adaptable_has_valid_fit) {
-  EXPECT_FALSE(bool(has_valid_fit<Extended, X>::value));
+  EXPECT_TRUE(bool(has_valid_fit<Extended, X>::value));
   EXPECT_TRUE(bool(has_valid_fit<Extended, Y>::value));
+
+  EXPECT_TRUE(bool(has_valid_fit<OtherExtended, X>::value));
+  EXPECT_FALSE(bool(has_valid_fit<OtherExtended, Y>::value));
+
+  EXPECT_FALSE(bool(has_valid_fit<Adaptable<Extended>, X>::value));
+  EXPECT_FALSE(bool(has_valid_fit<Adaptable<Extended>, Y>::value));
+}
+
+TEST(test_traits_core, test_adaptable_is_valid_fit) {
   EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Extended, X>>::value));
   EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Extended, Y>>::value));
   EXPECT_TRUE(


### PR DESCRIPTION
This PR switches from using an inheritance pattern that looks like `Base<Derived<Impl>>` to one that looks like `Base<Impl>`.  Or more specifically:
```
template <typename X>
struct Base {
  X &derived() { return *static_cast<X *>(this); }
};

template <typename Y>
struct Derived : public Base<Derived<Y>> {
  Y &impl() { return *static_cast<Y *>(this); }
};
```
To one that looks like:
```
template <typename X>
struct Base {
  X &derived() { return *static_cast<X *>(this); }
};

template <typename Y>
struct Derived : public Base<Y> {};
```
The reason for this is that in the first situation (the way it is now) calling `derived()` gives you an instance of `Derived<Y>` which is *almost* useful, but means that the `Derived` class needs to know about anything that could possibly be implemented in `Y` and needs to be sure to subsequently define and forward on those methods.  Ie, if we want to have `foo` available to the `Base` class methods then we'd need to define:
```
template <typename Y>
struct Derived : public Base<Derived<Y>> {
  auto foo() {
    // specialized to use a default value.
    return impl()._foo_impl(0.);
  }
  Y &impl() { return *static_cast<Y *>(this); }
};
```
This pattern also led to some confusing name hiding situations (see the `GaussianProcessRegression` class).  By switching to direct (or forwarded?) inheritance we avoid these problems since `derived()` in the new approach will return an object of type `Y`.

Effectively this ends up pushing the responsibility of what methods should be available from intermediary classes (such as `Derived`) to the final implementations `Y` so that before some final implementation might have looked like,
```
template <typename Y>
struct Derived : public Base<Derived<Y>> {
  auto foo() {
    // specialized to use a default value.
    return impl()._foo_impl(0.);
  }
  Y &impl() { return *static_cast<Y *>(this); }
};

struct Impl : public Derived<Impl> {
  double _foo_impl(double x) {return x};
}
```
But can now look like:
```
template <typename Y>
struct Derived : public Base<Derived<Y>> {
  auto foo() {
    // specialized to use a default value.
    return impl()._foo_impl(0.);
  }
  Y &impl() { return *static_cast<Y *>(this); }
};

struct Impl : public Derived<Impl> {
  using Base = Derived<Impl>;
  // unhide foo
  using Base::foo;

  double foo(double x) {return x};
}
```