### PR TITLE
Allow Ransac For Adapted GPs

### DIFF
--- a/include/albatross/models/gp.h
+++ b/include/albatross/models/gp.h
@@ -291,6 +291,12 @@ public:
 
   CovFunc get_covariance() const { return covariance_function_; }
 
+  template <typename FeatureType>
+  Eigen::MatrixXd
+  compute_covariance(const std::vector<FeatureType> &features) const {
+    return covariance_function_(features);
+  }
+
 protected:
   /*
    * CRTP Helpers

--- a/include/albatross/models/ransac_gp.h
+++ b/include/albatross/models/ransac_gp.h
@@ -91,7 +91,7 @@ get_gp_ransac_functions(const ModelType &model,
   static_assert(is_prediction_metric<InlierMetric>::value,
                 "InlierMetric must be an PredictionMetric.");
 
-  const auto full_cov = model.get_covariance()(dataset.features);
+  const auto full_cov = model.compute_covariance(dataset.features);
 
   const auto fitter =
       get_gp_ransac_fitter<ModelType, FeatureType>(dataset, indexer, full_cov);
@@ -135,7 +135,7 @@ struct GaussianProcessRansacStrategy {
     archive(cereal::make_nvp("indexing_function", indexing_function_));
   }
 
-private:
+protected:
   InlierMetric inlier_metric_;
   IndexingFunction indexing_function_;
 };


### PR DESCRIPTION
This fixes an issue in which an adapted Gaussian process was unable to use the RANSAC methods.

Here `AdaptedGaussianProcess` means a Gaussian process for which the covariance function doesn't support a give feature type, but which provides a conversion layer to pre-convert any features before they hit the covariance function.  See the example in `test_models.h` for details.

The problem boils down to the fact that `RANSAC` precomputes the covariance matrix in an attempt to save computation, but it was trying to do so with the higher level (unsupported) feature type.

To get around this, this change exposes a `compute_covariance` method which allows the `AdaptedGaussianProcess` to provide a specialized version of that function which applies the conversion.

The actual changes for this amount to 8 lines ... but testing it required more boilerplate.