### PR TITLE
Reintroduce metadata to the Distributions

### DIFF
--- a/include/albatross/src/core/distribution.hpp
+++ b/include/albatross/src/core/distribution.hpp
@@ -23,11 +23,13 @@ namespace albatross {
 template <typename CovarianceType> struct Distribution {
   Eigen::VectorXd mean;
   CovarianceType covariance;
+  std::map<std::string, std::string> metadata;
 
-  Distribution() : mean(), covariance(){};
-  Distribution(const Eigen::VectorXd &mean_) : mean(mean_), covariance(){};
+  Distribution() : mean(), covariance(), metadata(){};
+  Distribution(const Eigen::VectorXd &mean_)
+      : mean(mean_), covariance(), metadata(){};
   Distribution(const Eigen::VectorXd &mean_, const CovarianceType &covariance_)
-      : mean(mean_), covariance(covariance_){};
+      : mean(mean_), covariance(covariance_), metadata(){};
 
   std::size_t size() const;
 
@@ -57,6 +59,7 @@ template <typename CovarianceType> struct Distribution {
   serialize(Archive &archive, const std::uint32_t) {
     archive(cereal::make_nvp("mean", mean));
     archive(cereal::make_nvp("covariance", covariance));
+    archive(cereal::make_nvp("metadata", metadata));
   }
 };
 

--- a/include/albatross/src/utils/csv_utils.hpp
+++ b/include/albatross/src/utils/csv_utils.hpp
@@ -157,6 +157,7 @@ to_map(const RegressionDataset<FeatureType> &dataset,
                     target_variance, predictions.mean[ei], predict_variance);
 
   row = map_join(row, dataset.metadata);
+  row = map_join(row, predictions.metadata);
 
   return row;
 }


### PR DESCRIPTION
In the recent refactor I removed the metadata field from the `Distribution` class.  Turns out that's actually pretty useful from time to time, so now it's back!