### PR TITLE
Sparse Gaussian Process Fix.

### DIFF
--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -239,7 +239,9 @@ public:
     const Eigen::MatrixXd LT = K_uu_llt.matrixL().transpose();
     const Eigen::MatrixXd C = K_uu_llt.matrixL() * B * RtR.ldlt().solve(LT);
 
-    return typename Base::template GPFitType<FeatureType>(u, C.ldlt(), v);
+    using InducingPointFeatureType = typename std::decay<decltype(u[0])>::type;
+    return typename Base::template GPFitType<InducingPointFeatureType>(
+        u, C.ldlt(), v);
   }
 
   InducingPointStrategy inducing_point_strategy;


### PR DESCRIPTION
The `SparseGaussianProcess` model was erroneously using `FeatureType` for a fit when it should actually be using the type of the inducing points, `u`.