### PR TITLE
Add truncated_psd_solve method

### DIFF
--- a/include/albatross/SparseGP
+++ b/include/albatross/SparseGP
@@ -16,6 +16,7 @@
 #include "GP"
 
 #include "src/utils/block_utils.hpp"
+#include "src/utils/eigen_utils.hpp"
 #include "src/models/sparse_gp.hpp"
 
 #endif

--- a/include/albatross/src/utils/eigen_utils.hpp
+++ b/include/albatross/src/utils/eigen_utils.hpp
@@ -104,6 +104,44 @@ inline auto vertical_stack(
   return output;
 }
 
+/*
+ * This helper function performs a matrix solve using the eigen
+ * decomposition of a positive semi-definite matrix.
+ *
+ * Ie it solves for x in:
+ *
+ *    A x = rhs
+ *
+ * With A = A^T, eigenvalues(A) >= 0
+ *
+ * This is done by using the truncated SVD (which for symmetric
+ * matrices is equivalent to the truncated eigen decomposition).
+ *
+ * https://en.wikipedia.org/wiki/Singular_value_decomposition#Truncated_SVD
+ */
+template <typename _Scalar, int _Rows, int _Cols>
+inline auto truncated_psd_solve(
+    const Eigen::SelfAdjointEigenSolver<
+        Eigen::Matrix<_Scalar, Eigen::Dynamic, Eigen::Dynamic>> &lhs_evd,
+    const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs, double threshold = 1e-8) {
+  const auto V = lhs_evd.eigenvectors();
+  auto d = lhs_evd.eigenvalues();
+
+  std::vector<Eigen::Index> inds;
+  for (Eigen::Index i = 0; i < d.size(); ++i) {
+    if (d[i] >= threshold) {
+      inds.push_back(i);
+    }
+  }
+
+  const auto V_sub = subset_cols(V, inds);
+  const auto d_sub = subset(d, inds);
+
+  Eigen::Matrix<_Scalar, _Rows, _Cols> output =
+      V_sub * d_sub.asDiagonal().inverse() * V_sub.transpose() * rhs;
+  return output;
+}
+
 } // namespace albatross
 
 #endif


### PR DESCRIPTION
The `truncated_psd_solve` method let's you solve symmetric but numerically negative (or nearly negative) definite systems by implicitly using the pseudo inverse.

Ie, given a matrix with eigen decomposition `A = V D V^T` and set of equations `A x = b` this will solve for `x` using `x = V D'^-1 V^T b` where `D'^-1` is a diagonal matrix which is equal to `D^-1` but where any values in `D` which are below `threshold` are zeroed.