### PR TITLE
Improve Compiler Errors

### DIFF
--- a/include/albatross/Common
+++ b/include/albatross/Common
@@ -43,4 +43,8 @@
 #include "src/utils/map_utils.hpp"
 #include "src/cereal/eigen.hpp"
 
+#include "src/details/traits.hpp"
+#include "src/details/has_any_macros.hpp"
+#include "src/details/error_handling.hpp"
+
 #endif

--- a/include/albatross/src/cereal/traits.hpp
+++ b/include/albatross/src/cereal/traits.hpp
@@ -16,15 +16,6 @@
 namespace albatross {
 
 /*
- * This little trick was borrowed from cereal, you can think of it as
- * a function that will always return false ... but that doesn't
- * get resolved until template instantiation, which when combined
- * with a static assert let's you include a static assert that
- * only triggers with a particular template parameter is used.
- */
-template <class T> struct delay_static_assert : std::false_type {};
-
-/*
  * The following helper functions let you inspect a type and cereal Archive
  * and determine if the type has a valid serialization method for that Archive
  * type.

--- a/include/albatross/src/core/model.hpp
+++ b/include/albatross/src/core/model.hpp
@@ -46,7 +46,10 @@ protected:
                                   !has_valid_fit<ModelType, FeatureType>::value,
                               int>::type = 0>
   void _fit(const std::vector<FeatureType> &features,
-            const MarginalDistribution &targets) const = delete; // Invalid fit
+            const MarginalDistribution &targets) const
+      ALBATROSS_FAIL(FeatureType,
+                     "The ModelType *almost* has a _fit_impl method for "
+                     "FeatureType, but it appears to be invalid");
 
   template <typename FeatureType,
             typename std::enable_if<
@@ -54,7 +57,10 @@ protected:
                     !has_valid_fit<ModelType, FeatureType>::value,
                 int>::type = 0>
   void _fit(const std::vector<FeatureType> &features,
-            const MarginalDistribution &targets) const = delete;
+            const MarginalDistribution &targets) const
+      ALBATROSS_FAIL(
+          FeatureType,
+          "The ModelType is missing a _fit_impl method for FeatureType.");
 
   template <
       typename PredictFeatureType, typename FitType, typename PredictType,
@@ -73,9 +79,12 @@ protected:
       typename std::enable_if<!has_valid_predict<ModelType, PredictFeatureType,
                                                  FitType, PredictType>::value,
                               int>::type = 0>
-  PredictType predict_(
-      const std::vector<PredictFeatureType> &features, const FitType &fit,
-      PredictTypeIdentity<PredictType> &&) const = delete; // No valid predict.
+  PredictType predict_(const std::vector<PredictFeatureType> &features,
+                       const FitType &fit,
+                       PredictTypeIdentity<PredictType> &&) const
+      ALBATROSS_FAIL(PredictFeatureType,
+                     "The ModelType is missing a _predict_impl method for "
+                     "PredictFeatureType, FitType, PredictType.");
 
 public:
   /*

--- a/include/albatross/src/core/model.hpp
+++ b/include/albatross/src/core/model.hpp
@@ -19,7 +19,9 @@ using Insights = std::map<std::string, std::string>;
 
 template <typename ModelType> class ModelBase : public ParameterHandlingMixin {
 
-  template <typename X, typename Y, typename Z> friend class Prediction;
+  friend class JointPredictor;
+  friend class MarginalPredictor;
+  friend class MeanPredictor;
 
   template <typename T, typename FeatureType> friend class fit_model_type;
 

--- a/include/albatross/src/core/prediction.hpp
+++ b/include/albatross/src/core/prediction.hpp
@@ -143,7 +143,7 @@ public:
       typename std::enable_if<!can_predict_mean<MeanPredictor, ModelType,
                                                 DummyType, FitType>::value,
                               int>::type = 0>
-  auto mean() const
+  void mean() const
       ALBATROSS_FAIL(DummyType, "No valid predict method in ModelType for the "
                                 "mean with FitType and FeatureType.");
 
@@ -164,7 +164,7 @@ public:
                 !can_predict_marginal<MarginalPredictor, ModelType, DummyType,
                                       FitType>::value,
                 int>::type = 0>
-  auto marginal() const
+  void marginal() const
       ALBATROSS_FAIL(DummyType, "No valid predict method in ModelType for the "
                                 "marginal with FitType and FeatureType.");
 
@@ -185,7 +185,7 @@ public:
       typename std::enable_if<!can_predict_joint<JointPredictor, ModelType,
                                                  DummyType, FitType>::value,
                               int>::type = 0>
-  auto joint() const
+  void joint() const
       ALBATROSS_FAIL(DummyType, "No valid predict method in ModelType for the "
                                 "joint with FitType and FeatureType.");
 

--- a/include/albatross/src/core/prediction.hpp
+++ b/include/albatross/src/core/prediction.hpp
@@ -19,6 +19,102 @@ namespace albatross {
 // which behave different conditional on the type of predictions desired.
 template <typename T> struct PredictTypeIdentity { typedef T type; };
 
+/*
+ * MeanPredictor is responsible for determining if a valid form of
+ * predicting exists for a given set of model, feature, fit.  The
+ * primary goal of the class is to consolidate all the logic required
+ * to decide if different predict types are available.  For example,
+ * by inspecting this class for a _mean method you can determine if
+ * any valid mean prediction method exists.
+ */
+class MeanPredictor {
+public:
+  template <typename ModelType, typename FeatureType, typename FitType,
+            typename std::enable_if<
+                has_valid_predict_mean<ModelType, FeatureType, FitType>::value,
+                int>::type = 0>
+  Eigen::VectorXd _mean(const ModelType &model, const FitType &fit,
+                        const std::vector<FeatureType> &features) const {
+    return model.predict_(features, fit,
+                          PredictTypeIdentity<Eigen::VectorXd>());
+  }
+
+  template <
+      typename ModelType, typename FeatureType, typename FitType,
+      typename std::enable_if<
+          !has_valid_predict_mean<ModelType, FeatureType, FitType>::value &&
+              has_valid_predict_marginal<ModelType, FeatureType,
+                                         FitType>::value,
+          int>::type = 0>
+  Eigen::VectorXd _mean(const ModelType &model, const FitType &fit,
+                        const std::vector<FeatureType> &features) const {
+    return model
+        .predict_(features, fit, PredictTypeIdentity<MarginalDistribution>())
+        .mean;
+  }
+
+  template <
+      typename ModelType, typename FeatureType, typename FitType,
+      typename std::enable_if<
+          !has_valid_predict_mean<ModelType, FeatureType, FitType>::value &&
+              !has_valid_predict_marginal<ModelType, FeatureType,
+                                          FitType>::value &&
+              has_valid_predict_joint<ModelType, FeatureType, FitType>::value,
+          int>::type = 0>
+  Eigen::VectorXd _mean(const ModelType &model, const FitType &fit,
+                        const std::vector<FeatureType> &features) const {
+    return model
+        .predict_(features, fit, PredictTypeIdentity<JointDistribution>())
+        .mean;
+  }
+};
+
+class MarginalPredictor {
+public:
+  template <typename ModelType, typename FeatureType, typename FitType,
+            typename std::enable_if<has_valid_predict_marginal<
+                                        ModelType, FeatureType, FitType>::value,
+                                    int>::type = 0>
+  MarginalDistribution
+  _marginal(const ModelType &model, const FitType &fit,
+            const std::vector<FeatureType> &features) const {
+    return model.predict_(features, fit,
+                          PredictTypeIdentity<MarginalDistribution>());
+  }
+
+  template <
+      typename ModelType, typename FeatureType, typename FitType,
+      typename std::enable_if<
+          !has_valid_predict_marginal<ModelType, FeatureType, FitType>::value &&
+              has_valid_predict_joint<ModelType, FeatureType, FitType>::value,
+          int>::type = 0>
+  MarginalDistribution
+  _marginal(const ModelType &model, const FitType &fit,
+            const std::vector<FeatureType> &features) const {
+    const auto joint_pred =
+        model.predict_(features, fit, PredictTypeIdentity<JointDistribution>());
+    if (joint_pred.has_covariance()) {
+      Eigen::VectorXd diag = joint_pred.covariance.diagonal();
+      return MarginalDistribution(joint_pred.mean, diag.asDiagonal());
+    } else {
+      return MarginalDistribution(joint_pred.mean);
+    }
+  }
+};
+
+class JointPredictor {
+public:
+  template <typename ModelType, typename FeatureType, typename FitType,
+            typename std::enable_if<
+                has_valid_predict_joint<ModelType, FeatureType, FitType>::value,
+                int>::type = 0>
+  JointDistribution _joint(const ModelType &model, const FitType &fit,
+                           const std::vector<FeatureType> &features) const {
+    return model.predict_(features, fit,
+                          PredictTypeIdentity<JointDistribution>());
+  }
+};
+
 template <typename ModelType, typename FeatureType, typename FitType>
 class Prediction {
 
@@ -33,115 +129,65 @@ public:
 
   // Mean
   template <typename DummyType = FeatureType,
-            typename std::enable_if<
-                has_valid_predict_mean<ModelType, DummyType, FitType>::value,
-                int>::type = 0>
+            typename std::enable_if<can_predict_mean<MeanPredictor, ModelType,
+                                                     DummyType, FitType>::value,
+                                    int>::type = 0>
   Eigen::VectorXd mean() const {
     static_assert(std::is_same<DummyType, FeatureType>::value,
                   "never do prediction.mean<T>()");
-    return model_.predict_(features_, fit_,
-                           PredictTypeIdentity<Eigen::VectorXd>());
+    return MeanPredictor()._mean(model_, fit_, features_);
   }
 
   template <
       typename DummyType = FeatureType,
-      typename std::enable_if<
-          !has_valid_predict_mean<ModelType, DummyType, FitType>::value &&
-              has_valid_predict_marginal<ModelType, DummyType, FitType>::value,
-          int>::type = 0>
-  Eigen::VectorXd mean() const {
-    static_assert(std::is_same<DummyType, FeatureType>::value,
-                  "never do prediction.mean<T>()");
-    return model_
-        .predict_(features_, fit_, PredictTypeIdentity<MarginalDistribution>())
-        .mean;
-  }
-
-  template <
-      typename DummyType = FeatureType,
-      typename std::enable_if<
-          !has_valid_predict_mean<ModelType, DummyType, FitType>::value &&
-              !has_valid_predict_marginal<ModelType, DummyType,
-                                          FitType>::value &&
-              has_valid_predict_joint<ModelType, DummyType, FitType>::value,
-          int>::type = 0>
-  Eigen::VectorXd mean() const {
-    static_assert(std::is_same<DummyType, FeatureType>::value,
-                  "never do prediction.mean<T>()");
-    return model_
-        .predict_(features_, fit_, PredictTypeIdentity<JointDistribution>())
-        .mean;
-  }
+      typename std::enable_if<!can_predict_mean<MeanPredictor, ModelType,
+                                                DummyType, FitType>::value,
+                              int>::type = 0>
+  auto mean() const
+      ALBATROSS_FAIL(DummyType, "No valid predict method in ModelType for the "
+                                "mean with FitType and FeatureType.");
 
   // Marginal
-  template <typename DummyType = FeatureType,
-            typename std::enable_if<has_valid_predict_marginal<
-                                        ModelType, DummyType, FitType>::value,
-                                    int>::type = 0>
-  MarginalDistribution marginal() const {
-    static_assert(std::is_same<DummyType, FeatureType>::value,
-                  "never do prediction.marginal<T>()");
-    return model_.predict_(features_, fit_,
-                           PredictTypeIdentity<MarginalDistribution>());
-  }
-
   template <
       typename DummyType = FeatureType,
-      typename std::enable_if<
-          !has_valid_predict_marginal<ModelType, DummyType, FitType>::value &&
-              has_valid_predict_joint<ModelType, DummyType, FitType>::value,
-          int>::type = 0>
+      typename std::enable_if<can_predict_marginal<MarginalPredictor, ModelType,
+                                                   DummyType, FitType>::value,
+                              int>::type = 0>
   MarginalDistribution marginal() const {
     static_assert(std::is_same<DummyType, FeatureType>::value,
-                  "never do prediction.marginal<T>()");
-    const auto joint_pred = model_.predict_(
-        features_, fit_, PredictTypeIdentity<JointDistribution>());
-    if (joint_pred.has_covariance()) {
-      Eigen::VectorXd diag = joint_pred.covariance.diagonal();
-      return MarginalDistribution(joint_pred.mean, diag.asDiagonal());
-    } else {
-      return MarginalDistribution(joint_pred.mean);
-    }
+                  "never do prediction.mean<T>()");
+    return MarginalPredictor()._marginal(model_, fit_, features_);
   }
+
+  template <typename DummyType = FeatureType,
+            typename std::enable_if<
+                !can_predict_marginal<MarginalPredictor, ModelType, DummyType,
+                                      FitType>::value,
+                int>::type = 0>
+  auto marginal() const
+      ALBATROSS_FAIL(DummyType, "No valid predict method in ModelType for the "
+                                "marginal with FitType and FeatureType.");
 
   // Joint
-  template <typename DummyType = FeatureType,
-            typename std::enable_if<
-                has_valid_predict_joint<ModelType, DummyType, FitType>::value,
-                int>::type = 0>
+  template <
+      typename DummyType = FeatureType,
+      typename std::enable_if<can_predict_joint<JointPredictor, ModelType,
+                                                DummyType, FitType>::value,
+                              int>::type = 0>
   JointDistribution joint() const {
     static_assert(std::is_same<DummyType, FeatureType>::value,
-                  "never do prediction.joint<T>()");
-    return model_.predict_(features_, fit_,
-                           PredictTypeIdentity<JointDistribution>());
+                  "never do prediction.mean<T>()");
+    return JointPredictor()._joint(model_, fit_, features_);
   }
 
-  // CATCH FAILURE MODES
   template <
       typename DummyType = FeatureType,
-      typename std::enable_if<
-          !has_valid_predict_mean<ModelType, DummyType, FitType>::value &&
-              !has_valid_predict_marginal<ModelType, DummyType,
-                                          FitType>::value &&
-              !has_valid_predict_joint<ModelType, DummyType, FitType>::value,
-          int>::type = 0>
-  Eigen::VectorXd mean() const = delete; // No valid predict method found.
-
-  template <
-      typename DummyType = FeatureType,
-      typename std::enable_if<
-          !has_valid_predict_marginal<ModelType, DummyType, FitType>::value &&
-              !has_valid_predict_joint<ModelType, DummyType, FitType>::value,
-          int>::type = 0>
-  Eigen::VectorXd
-  marginal() const = delete; // No valid predict marginal method found.
-
-  template <typename DummyType = FeatureType,
-            typename std::enable_if<
-                !has_valid_predict_joint<ModelType, DummyType, FitType>::value,
-                int>::type = 0>
-  Eigen::VectorXd
-  joint() const = delete; // No valid predict joint method found.
+      typename std::enable_if<!can_predict_joint<JointPredictor, ModelType,
+                                                 DummyType, FitType>::value,
+                              int>::type = 0>
+  auto joint() const
+      ALBATROSS_FAIL(DummyType, "No valid predict method in ModelType for the "
+                                "joint with FitType and FeatureType.");
 
   template <typename PredictType>
   PredictType get(PredictTypeIdentity<PredictType> =

--- a/include/albatross/src/details/error_handling.hpp
+++ b/include/albatross/src/details/error_handling.hpp
@@ -18,6 +18,16 @@ namespace albatross {
 #define ALBATROSS_FAIL(dummy, msg)                                             \
   { static_assert(delay_static_assert<dummy>::value, msg); }
 
+/*
+ * Setting ALBATROSS_FAIL to "= delete" as below will slightly
+ * change the behavior of failures.  In some situations
+ * inspection of return types can trigger the delay_static_assert
+ * approach above, while the deleted function approach may
+ * work fine.  In general however the deleted function approach
+ * leads to slightly more confusing compile errors since it
+ * isn't possible to include an error message.
+ */
+
 //#define ALBATROSS_FAIL(dummy, msg) = delete
 
 } // namespace albatross

--- a/include/albatross/src/details/error_handling.hpp
+++ b/include/albatross/src/details/error_handling.hpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef INCLUDE_ALBATROSS_SRC_DETAILS_ERROR_HANDLING_HPP_
+#define INCLUDE_ALBATROSS_SRC_DETAILS_ERROR_HANDLING_HPP_
+
+namespace albatross {
+
+//#define ALBATROSS_FAIL(dummy, msg)
+//   {static_assert(delay_static_assert<dummy>::value, msg);}
+
+#define ALBATROSS_FAIL(dummy, msg) = delete
+
+} // namespace albatross
+
+#endif /* INCLUDE_ALBATROSS_SRC_DETAILS_ERROR_HANDLING_HPP_ */

--- a/include/albatross/src/details/error_handling.hpp
+++ b/include/albatross/src/details/error_handling.hpp
@@ -15,10 +15,10 @@
 
 namespace albatross {
 
-//#define ALBATROSS_FAIL(dummy, msg)
-//   {static_assert(delay_static_assert<dummy>::value, msg);}
+#define ALBATROSS_FAIL(dummy, msg)                                             \
+  { static_assert(delay_static_assert<dummy>::value, msg); }
 
-#define ALBATROSS_FAIL(dummy, msg) = delete
+//#define ALBATROSS_FAIL(dummy, msg) = delete
 
 } // namespace albatross
 

--- a/include/albatross/src/details/has_any_macros.hpp
+++ b/include/albatross/src/details/has_any_macros.hpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef INCLUDE_ALBATROSS_SRC_DETAILS_HAS_ANY_MACROS_HPP_
+#define INCLUDE_ALBATROSS_SRC_DETAILS_HAS_ANY_MACROS_HPP_
+
+namespace albatross {
+
+#define HAS_METHOD(fname)                                                      \
+  template <typename T, typename... Args> class has_##fname {                  \
+    template <typename C, typename = decltype(std::declval<C>().fname(         \
+                              std::declval<Args>()...))>                       \
+    static std::true_type test(C *);                                           \
+    template <typename> static std::false_type test(...);                      \
+                                                                               \
+  public:                                                                      \
+    static constexpr bool value = decltype(test<T>(0))::value;                 \
+  };
+
+#define HAS_METHOD_WITH_RETURN_TYPE(fname)                                     \
+  template <typename T, typename ReturnType, typename... Args>                 \
+  class has_##fname##_with_return_type {                                       \
+    template <typename C,                                                      \
+              typename ActualReturnType = decltype(                            \
+                  std::declval<const C>().fname(std::declval<Args>()...))>     \
+    static typename std::is_same<ActualReturnType, ReturnType>::type           \
+    test(C *);                                                                 \
+    template <typename> static std::false_type test(...);                      \
+                                                                               \
+  public:                                                                      \
+    static constexpr bool value = decltype(test<T>(0))::value;                 \
+  };
+
+/*
+ * This set of macros creates a trait which can check for the existence
+ * of any method with some name `fname` (including private methods).
+ * This is done by hijacking name hiding, Namely if a derived class overloads a
+ * method the base methods will be hidden.  So by starting with a base class
+ * with a known method then extending that class you can determine if the
+ * derived class included any other methods with that name.
+ * https://stackoverflow.com/questions/1628768/why-does-an-overridden-function-in-the-derived-class-hide-other-overloads-of-the
+ */
+
+namespace detail {
+struct DummyType {};
+} // namespace detail
+
+/*
+ * Creates a base class with a public method with name `fname` this is
+ * included via inheritance to check for name hiding.
+ */
+#define BASE_WITH_PUBLIC_METHOD(fname)                                         \
+  namespace detail {                                                           \
+  struct BaseWithPublic##fname {                                               \
+    DummyType fname() const { return DummyType(); }                            \
+  };                                                                           \
+  }
+
+/*
+ * Creates a templated class which inherits from a given class as well
+ * as the Base class above.  If U contains a method with name `fname` then
+ * the Base class definition of that function will be hidden.
+ */
+#define MULTI_INHERIT(fname)                                                   \
+  namespace detail {                                                           \
+  template <typename U>                                                        \
+  struct MultiInherit##fname : public U, public BaseWithPublic##fname {};      \
+  }
+
+/*
+ * Creates a trait which checks to see if the dummy implementation in
+ * the Base class exists or not, used to determine if name hiding is
+ * active.
+ */
+#define HAS_DUMMY_DEFINITION(fname)                                            \
+  namespace detail {                                                           \
+  template <typename T> class has_dummy_definition_##fname {                   \
+    template <typename C>                                                      \
+    static typename std::is_same<decltype(std::declval<const C>().fname()),    \
+                                 DummyType>::type                              \
+    test(C *);                                                                 \
+    template <typename> static std::false_type test(...);                      \
+                                                                               \
+  public:                                                                      \
+    static constexpr bool value = decltype(test<T>(0))::value;                 \
+  };                                                                           \
+  }
+
+/*
+ * This creates the final trait which will check if any method named
+ * `fname` exists in type U.
+ */
+#define HAS_ANY_DEFINITION(fname)                                              \
+  template <typename U> class has_any_##fname {                                \
+    template <typename T>                                                      \
+    static typename std::enable_if<detail::has_dummy_definition_##fname<       \
+                                       detail::MultiInherit##fname<T>>::value, \
+                                   std::false_type>::type                      \
+    test(int);                                                                 \
+    template <typename T> static std::true_type test(...);                     \
+                                                                               \
+  public:                                                                      \
+    static constexpr bool value = decltype(test<U>(0))::value;                 \
+  }
+
+#define MAKE_HAS_ANY_TRAIT(fname)                                              \
+  BASE_WITH_PUBLIC_METHOD(fname);                                              \
+  MULTI_INHERIT(fname);                                                        \
+  HAS_DUMMY_DEFINITION(fname);                                                 \
+  HAS_ANY_DEFINITION(fname);
+
+} // namespace albatross
+
+#endif /* INCLUDE_ALBATROSS_SRC_DETAILS_HAS_ANY_MACROS_HPP_ */

--- a/include/albatross/src/details/traits.hpp
+++ b/include/albatross/src/details/traits.hpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef INCLUDE_ALBATROSS_SRC_DETAILS_TRAITS_HPP_
+#define INCLUDE_ALBATROSS_SRC_DETAILS_TRAITS_HPP_
+
+namespace albatross {
+
+/*
+ * We frequently inspect for definitions of functions which
+ * must be defined for const references to objects
+ * (so that repeated evaluations return the same thing
+ *  and so the computations are not repeatedly copying.)
+ * This type conversion utility will turn a type `T` into `const T&`
+ */
+template <class T> struct const_ref {
+  typedef
+      typename std::add_lvalue_reference<typename std::add_const<T>::type>::type
+          type;
+};
+
+/*
+ * This little trick was borrowed from cereal, you can think of it as
+ * a function that will always return false ... but that doesn't
+ * get resolved until template instantiation, which when combined
+ * with a static assert let's you include a static assert that
+ * only triggers with a particular template parameter is used.
+ */
+template <class T> struct delay_static_assert : std::false_type {};
+
+/*
+ * Checks if a class type is complete by using sizeof.
+ *
+ * https://stackoverflow.com/questions/25796126/static-assert-that-template-typename-t-is-not-complete
+ */
+template <typename X> class is_complete {
+  template <typename T, typename = decltype(!sizeof(T))>
+  static std::true_type test(int);
+  template <typename T> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<X>(0))::value;
+};
+
+template <typename T> struct is_vector : public std::false_type {};
+
+template <typename T>
+struct is_vector<std::vector<T>> : public std::true_type {};
+
+} // namespace albatross
+
+#endif /* INCLUDE_ALBATROSS_SRC_DETAILS_TRAITS_HPP_ */

--- a/include/albatross/src/details/traits.hpp
+++ b/include/albatross/src/details/traits.hpp
@@ -48,7 +48,8 @@ template <typename X> class is_complete {
   template <typename T> static std::false_type test(...);
 
 public:
-  static constexpr bool value = decltype(test<X>(0))::value;
+  static constexpr bool value =
+      decltype(test<typename std::decay<X>::type>(0))::value;
 };
 
 template <typename T> struct is_vector : public std::false_type {};

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -215,8 +215,7 @@ public:
     return ss.str();
   }
 
-  // If the implementing class doesn't have a fit method for this
-  // FeatureType but the CovarianceFunction does.
+  // If the CovarianceFunction is defined.
   template <typename FeatureType,
             typename std::enable_if<
                 has_call_operator<CovFunc, FeatureType, FeatureType>::value,
@@ -226,6 +225,15 @@ public:
     Eigen::MatrixXd cov = covariance_function_(features);
     return GPFitType<FeatureType>(features, cov, targets);
   }
+
+  // If the CovarianceFunction is NOT defined.
+  template <typename FeatureType,
+            typename std::enable_if<
+                !has_call_operator<CovFunc, FeatureType, FeatureType>::value,
+                int>::type = 0>
+  auto _fit_impl(const std::vector<FeatureType> &features,
+                 const MarginalDistribution &targets) const
+      ALBATROSS_FAIL(FeatureType, "CovFunc is not defined for FeatureType");
 
   template <
       typename FeatureType, typename FitFeaturetype,
@@ -284,10 +292,10 @@ public:
           !has_call_operator<CovFunc, FeatureType, FeatureType>::value ||
               !has_call_operator<CovFunc, FeatureType, FitFeatureType>::value,
           int>::type = 0>
-  PredictType _predict_impl(const std::vector<FeatureType> &features,
-                            const GPFitType<FitFeatureType> &gp_fit,
-                            PredictTypeIdentity<PredictType> &&) const =
-      delete; // Covariance Function isn't defined for FeatureType.
+  auto _predict_impl(const std::vector<FeatureType> &features,
+                     const GPFitType<FitFeatureType> &gp_fit,
+                     PredictTypeIdentity<PredictType> &&) const
+    ALBATROSS_FAIL(FeatureType, "CovFunc is not defined for FeatureType and FitFeatureType");
 
   CovFunc get_covariance() const { return covariance_function_; }
 

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -295,7 +295,9 @@ public:
   auto _predict_impl(const std::vector<FeatureType> &features,
                      const GPFitType<FitFeatureType> &gp_fit,
                      PredictTypeIdentity<PredictType> &&) const
-    ALBATROSS_FAIL(FeatureType, "CovFunc is not defined for FeatureType and FitFeatureType");
+      ALBATROSS_FAIL(
+          FeatureType,
+          "CovFunc is not defined for FeatureType and FitFeatureType");
 
   CovFunc get_covariance() const { return covariance_function_; }
 


### PR DESCRIPTION
One of the more difficult issues when iterating on `albatross` is the often cryptic compiler errors that are produced when developing.  The current approach to this problem is to insert a bunch of static checks which explicitly delete functions that aren't valid which then leads the compiler to dump all the information about the templated types used which lead to the selection of the deleted function.  The problem with this is that there isn't a way to add a human readable description of what the problem was.

This change attempts to improve the situation slightly by defining a macro `ALBATROSS_FAIL` which lets you use the `= delete` approach or switch to a `delay_static_assert` approach similar to cereal.  Using `delay_static_assert` let's you provide a human readable message along with the resolved template parameters which should make debugging issues easier.

In addition to the these changes I've adding a few additional macros which build some of the frequently used trait inspection routines.  This made it easier to create even more `has_any_*` methods which in turn should make it easier to add more `ALBATROSS_FAIL` instances.

BEFORE:
```
/home/kleeman/dev/swift/albatross/tests/test_core_model.cc:35:74: error: use of deleted function ‘void albatross::Prediction<ModelType, FeatureType, FitType>::mean() const [with DummyType = albatross::MockFeature; typename std::enable_if<(! albatross::can_predict_mean<albatross::MeanPredictor, ModelType, DummyType, FitType>::value), int>::type <anonymous> = 0; ModelType = albatross::MockModel; FeatureType = albatross::MockFeature; FitType = albatross::Fit<albatross::MockModel>]’
   Eigen::VectorXd predictions = fit_model.predict(dataset.features).mean();
                                                                          ^
In file included from /home/kleeman/dev/swift/albatross/include/albatross/Core:26:0,
                 from /home/kleeman/dev/swift/albatross/tests/test_utils.h:16,
                 from /home/kleeman/dev/swift/albatross/tests/test_core_model.cc:15:
/home/kleeman/dev/swift/albatross/include/albatross/src/core/prediction.hpp:146:8: note: declared here
   void mean() const
```

AFTER:
```
In file included from /home/kleeman/dev/swift/albatross/include/albatross/Core:26:0,
                 from /home/kleeman/dev/swift/albatross/tests/test_utils.h:16,
                 from /home/kleeman/dev/swift/albatross/tests/test_core_model.cc:15:
/home/kleeman/dev/swift/albatross/include/albatross/src/core/prediction.hpp: In instantiation of ‘void albatross::Prediction<ModelType, FeatureType, FitType>::mean() const [with DummyType = albatross::MockFeature; typename std::enable_if<(! albatross::can_predict_mean<albatross::MeanPredictor, ModelType, DummyType, FitType>::value), int>::type <anonymous> = 0; ModelType = albatross::MockModel; FeatureType = albatross::MockFeature; FitType = albatross::Fit<albatross::MockModel>]’:
/home/kleeman/dev/swift/albatross/tests/test_core_model.cc:35:74:   required from here
/home/kleeman/dev/swift/albatross/include/albatross/src/core/prediction.hpp:147:9: error: static assertion failed: No valid predict method in ModelType for the mean with FitType and FeatureType.
       ALBATROSS_FAIL(DummyType, "No valid predict method in ModelType for the "
         ^~~~~~~~~~~~~
```
