### PR TITLE
Fit From Prediction Stability

### DIFF
--- a/include/albatross/GP
+++ b/include/albatross/GP
@@ -18,6 +18,7 @@
 
 #include "src/evaluation/likelihood.hpp"
 #include "src/eigen/serializable_ldlt.hpp"
+#include "src/covariance_functions/representations.hpp"
 #include "src/models/gp.hpp"
 
 #endif

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -35,7 +35,7 @@ class Prediction;
 
 template <typename ModelType, typename FitType> class FitModel;
 
-template <typename ModelType, typename FeatureType = void> class Fit {};
+template <typename Derived> class Fit {};
 
 /*
  * Parameter Handling

--- a/include/albatross/src/core/model.hpp
+++ b/include/albatross/src/core/model.hpp
@@ -141,9 +141,9 @@ public:
 
   CrossValidation<ModelType> cross_validate() const;
 
-  template <typename MetricType>
-  Ransac<ModelType, MetricType>
-  ransac(const MetricType &metric, double inlier_threshold,
+  template <typename Strategy>
+  Ransac<ModelType, Strategy>
+  ransac(const Strategy &strategy, double inlier_threshold,
          std::size_t random_sample_size, std::size_t min_consensus_size,
          std::size_t max_iteration) const;
 };

--- a/include/albatross/src/core/traits.hpp
+++ b/include/albatross/src/core/traits.hpp
@@ -32,27 +32,35 @@ public:
   static constexpr bool value = decltype(test<T>(0))::value;
 };
 
-/*
- * Like std::is_base_of<T, U> except compares the first template parameter.  Ie,
- *
- *  first_template_param_is_base_of<T, C<U, X>>::value == is_base_of<T,
- * U>::value
- */
-template <typename T, typename U>
-struct first_template_param_is_base_of : public std::false_type {};
+///*
+// * Like std::is_base_of<T, U> except compares the first template parameter.
+// Ie,
+// *
+// *  first_template_param_is_base_of<T, C<U, X>>::value == is_base_of<T,
+// * U>::value
+// */
+// template <typename T, typename U>
+// struct first_template_param_is_base_of : public std::false_type {};
+//
+// template <template <typename, typename> class Base, typename T, typename U,
+//          typename P>
+// struct first_template_param_is_base_of<T, Base<U, P>>
+//    : public std::is_base_of<T, U> {};
+//
+///*
+// * A valid fit for a ModelType is defined as Fit<AnyBaseOfModelType,
+// * AnyFeatureType>.
+// */
+// template <typename ModelType, typename FitType>
+// struct is_valid_fit_type
+//    : public first_template_param_is_base_of<ModelBase<ModelType>, FitType>
+//    {};
 
-template <template <typename, typename> class Base, typename T, typename U,
-          typename P>
-struct first_template_param_is_base_of<T, Base<U, P>>
-    : public std::is_base_of<T, U> {};
+template <typename FitType>
+struct is_valid_fit_type : public std::false_type {};
 
-/*
- * A valid fit for a ModelType is defined as Fit<AnyBaseOfModelType,
- * AnyFeatureType>.
- */
-template <typename ModelType, typename FitType>
-struct is_valid_fit_type
-    : public first_template_param_is_base_of<ModelBase<ModelType>, FitType> {};
+template <typename FitParameter>
+struct is_valid_fit_type<Fit<FitParameter>> : public std::true_type {};
 
 /*
  * This determines whether or not a class (T) has a method defined for,
@@ -65,7 +73,7 @@ template <typename T, typename FeatureType> class has_valid_fit {
             typename FitType = decltype(std::declval<const C>()._fit_impl(
                 std::declval<const std::vector<FeatureType> &>(),
                 std::declval<const MarginalDistribution &>()))>
-  static typename is_valid_fit_type<T, FitType>::type test(C *);
+  static typename is_valid_fit_type<FitType>::type test(C *);
   template <typename> static std::false_type test(...);
 
 public:

--- a/include/albatross/src/core/traits.hpp
+++ b/include/albatross/src/core/traits.hpp
@@ -32,30 +32,11 @@ public:
   static constexpr bool value = decltype(test<T>(0))::value;
 };
 
-///*
-// * Like std::is_base_of<T, U> except compares the first template parameter.
-// Ie,
-// *
-// *  first_template_param_is_base_of<T, C<U, X>>::value == is_base_of<T,
-// * U>::value
-// */
-// template <typename T, typename U>
-// struct first_template_param_is_base_of : public std::false_type {};
-//
-// template <template <typename, typename> class Base, typename T, typename U,
-//          typename P>
-// struct first_template_param_is_base_of<T, Base<U, P>>
-//    : public std::is_base_of<T, U> {};
-//
-///*
-// * A valid fit for a ModelType is defined as Fit<AnyBaseOfModelType,
-// * AnyFeatureType>.
-// */
-// template <typename ModelType, typename FitType>
-// struct is_valid_fit_type
-//    : public first_template_param_is_base_of<ModelBase<ModelType>, FitType>
-//    {};
-
+/*
+ * A valid fit is defined as simply anything which matches the pattern:
+ *
+ *     Fit<Anything>.
+ */
 template <typename FitType>
 struct is_valid_fit_type : public std::false_type {};
 

--- a/include/albatross/src/covariance_functions/representations.hpp
+++ b/include/albatross/src/covariance_functions/representations.hpp
@@ -63,9 +63,10 @@ namespace albatross {
  */
 struct ExplainedCovariance {
 
-  ExplainedCovariance() {};
+  ExplainedCovariance(){};
 
-  ExplainedCovariance(const Eigen::MatrixXd &outer, const Eigen::MatrixXd &inner_) {
+  ExplainedCovariance(const Eigen::MatrixXd &outer,
+                      const Eigen::MatrixXd &inner_) {
     outer_ldlt = outer.ldlt();
     inner = inner_;
   }
@@ -81,6 +82,6 @@ struct ExplainedCovariance {
   Eigen::MatrixXd inner;
 };
 
-}
+} // namespace albatross
 
 #endif /* ALBATROSS_COVARIANCE_FUNCTION_REPRESENTATIONS_HPP_ */

--- a/include/albatross/src/covariance_functions/representations.hpp
+++ b/include/albatross/src/covariance_functions/representations.hpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_COVARIANCE_FUNCTION_REPRESENTATIONS_HPP_
+#define ALBATROSS_COVARIANCE_FUNCTION_REPRESENTATIONS_HPP_
+
+/*
+ * These "Representations" relate to matrices build from covariance
+ * functions, namely Positive Semi Definite (PSD) matrices.
+ *
+ * The most popular representation for such matrices is the
+ * Cholesky, or related LDLT decomposition:
+ *
+ *   A = L D L^T
+ *
+ * But sometimes there are more efficient, or numerically
+ * stable approaches which depend on the application.
+ *
+ * A covariance Representation is effectively just an
+ * approach for efficiently storing and inverting the matrix
+ * in question.
+ */
+namespace albatross {
+
+/*
+ * The ExplainedCovariance represents a matrix of the form,
+ *
+ *     S = A B^{-1} A
+ *
+ * Where A is referred to as the outer and B as the inner matrix.
+ * The solve (inverse) can then be performed by taking,
+ *
+ *     x = A^-1 B A^-1 rhs
+ *
+ * One example of where this sort of form shows up is in posterior
+ * distributions of Gaussian processes.  Posterior covariances
+ * often take the form:
+ *
+ *     post = prior - cross^T dependent^-1 cross
+ *
+ * Ie, the posterior covariance would be the prior covariance minus
+ * the explained ( cross^T dependent^-1 cross ) covariance.
+ * Here the explained covariance consists of the cross term which
+ * may represent the relationship between the variable in
+ * question and some dependent variable, and the dependent^-1 term
+ * represents the inverse of the prior on the dependent variable.
+ *
+ * While (typically) the prior covariances are positive definite
+ * it's much more likely that the explained covariance would be
+ * positive SEMI definite which would happen in the case of an
+ * underdetermined set of observations.  This particular
+ * CovarianceRepresentation therefore avoids the inversion of B
+ * if possible, under the assumption that it may be singular.
+ */
+struct ExplainedCovariance {
+
+  ExplainedCovariance() {};
+
+  ExplainedCovariance(const Eigen::MatrixXd &outer, const Eigen::MatrixXd &inner_) {
+    outer_ldlt = outer.ldlt();
+    inner = inner_;
+  }
+
+  /*
+   * Returns S^-1 rhs by using S^-1 = A^-1 B A^-1
+   */
+  Eigen::MatrixXd solve(const Eigen::MatrixXd &rhs) const {
+    return outer_ldlt.solve(inner * outer_ldlt.solve(rhs));
+  }
+
+  Eigen::SerializableLDLT outer_ldlt;
+  Eigen::MatrixXd inner;
+};
+
+}
+
+#endif /* ALBATROSS_COVARIANCE_FUNCTION_REPRESENTATIONS_HPP_ */

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -55,6 +55,8 @@ public:
                                  !has_valid_call_impl<T, Args...>::value);
 };
 
+HAS_METHOD(solve);
+
 } // namespace albatross
 
 #endif

--- a/include/albatross/src/eigen/serializable_ldlt.hpp
+++ b/include/albatross/src/eigen/serializable_ldlt.hpp
@@ -62,6 +62,8 @@ class SerializableLDLT : public LDLT<MatrixXd, Lower> {
 public:
   SerializableLDLT() : LDLT<MatrixXd, Lower>(){};
 
+  SerializableLDLT(const MatrixXd &x) : LDLT<MatrixXd, Lower>(x.ldlt()){};
+
   SerializableLDLT(const LDLT<MatrixXd, Lower> &ldlt)
       // Can we get around copying here?
       : LDLT<MatrixXd, Lower>(ldlt){};

--- a/include/albatross/src/models/ransac.hpp
+++ b/include/albatross/src/models/ransac.hpp
@@ -208,7 +208,7 @@ struct GenericRansacStrategy {
     archive(cereal::make_nvp("indexing_function", indexing_function_));
   }
 
-private:
+protected:
   InlierMetric inlier_metric_;
   ConsensusMetric consensus_metric_;
   IndexingFunction indexing_function_;
@@ -228,11 +228,14 @@ auto get_generic_ransac_strategy(const InlierMetric &inlier_metric,
       inlier_metric, consensus_metric, indexing_function);
 }
 
+template <typename ModelType, typename StrategyType, typename FeatureType>
+struct RansacFit {};
+
 /*
  * Ransac Model Implementation.
  */
 template <typename ModelType, typename StrategyType, typename FeatureType>
-struct Fit<Ransac<ModelType, StrategyType>, FeatureType> {
+struct Fit<RansacFit<ModelType, StrategyType, FeatureType>> {
 
   using FitModelType = typename fit_model_type<ModelType, FeatureType>::type;
 
@@ -288,7 +291,7 @@ public:
   }
 
   template <typename FeatureType>
-  Fit<Ransac<ModelType, StrategyType>, FeatureType>
+  Fit<RansacFit<ModelType, StrategyType, FeatureType>>
   _fit_impl(const std::vector<FeatureType> &features,
             const MarginalDistribution &targets) const {
 
@@ -316,7 +319,7 @@ public:
     }
 
     // Then generate a fit.
-    return Fit<Ransac<ModelType, StrategyType>, FeatureType>(
+    return Fit<RansacFit<ModelType, StrategyType, FeatureType>>(
         sub_model_.fit(consensus_set), inliers, outliers);
   }
 

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -240,7 +240,7 @@ public:
     const Eigen::MatrixXd C = K_uu_llt.matrixL() * B * RtR.ldlt().solve(LT);
 
     using InducingPointFeatureType = typename std::decay<decltype(u[0])>::type;
-    return typename Base::template GPFitType<InducingPointFeatureType>(
+    return typename Base::template CholeskyFit<InducingPointFeatureType>(
         u, C.ldlt(), v);
   }
 

--- a/tests/test_eigen_utils.cc
+++ b/tests/test_eigen_utils.cc
@@ -1,5 +1,5 @@
 /*
-h * Copyright (C) 2018 Swift Navigation Inc.
+ * Copyright (C) 2018 Swift Navigation Inc.
  * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must

--- a/tests/test_eigen_utils.cc
+++ b/tests/test_eigen_utils.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Swift Navigation Inc.
+h * Copyright (C) 2018 Swift Navigation Inc.
  * Contact: Swift Navigation <dev@swiftnav.com>
  *
  * This source is subject to the license found in the file 'LICENSE' which must

--- a/tests/test_model_adapter.cc
+++ b/tests/test_model_adapter.cc
@@ -21,9 +21,8 @@ class TestAdaptedModel
 public:
   using Base = GaussianProcessBase<CovFunc, TestAdaptedModel<CovFunc>>;
 
-  template <typename FitFeatureType>
-  using FitType = Fit<GaussianProcessBase<CovFunc, TestAdaptedModel<CovFunc>>,
-                      FitFeatureType>;
+  template <typename FeatureType>
+  using FitType = typename Base::template GPFitType<FeatureType>;
 
   TestAdaptedModel() {
     this->params_["center"] = {1., std::make_shared<UniformPrior>(-10., 10.)};
@@ -99,6 +98,6 @@ TEST(test_model_adapter, test_fit) {
   // The train_features will actually be different because the adapted model
   // subtracts off a center value.
   EXPECT_EQ(adapted_fit.information, fit.information);
-  EXPECT_EQ(adapted_fit.train_ldlt, fit.train_ldlt);
+  EXPECT_EQ(adapted_fit.train_covariance, fit.train_covariance);
 }
 } // namespace albatross

--- a/tests/test_model_adapter.cc
+++ b/tests/test_model_adapter.cc
@@ -22,7 +22,7 @@ public:
   using Base = GaussianProcessBase<CovFunc, TestAdaptedModel<CovFunc>>;
 
   template <typename FeatureType>
-  using FitType = typename Base::template GPFitType<FeatureType>;
+  using FitType = typename Base::template CholeskyFit<FeatureType>;
 
   TestAdaptedModel() {
     this->params_["center"] = {1., std::make_shared<UniformPrior>(-10., 10.)};

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -86,21 +86,21 @@ TEST(test_models, test_expect_predict_variants_consistent_fails) {
   expect_predict_variants_inconsistent(pred);
 }
 
-// TEST(test_models, test_model_from_prediction) {
-//  MakeGaussianProcess test_case;
-//  auto dataset = test_case.get_dataset();
-//  auto model = test_case.get_model();
-//  std::vector<double> test_features = {0.1, 1.1, 2.2};
-//  auto joint_prediction = model.fit(dataset).predict(test_features).joint();
-//  auto joint_prediction_from_prediction =
-//      model.fit_from_prediction(test_features, joint_prediction)
-//          .predict(test_features)
-//          .joint();
-//  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
-//      joint_prediction.mean, 1e-12));
-//  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
-//      joint_prediction.covariance, 1e-8));
-//}
+ TEST(test_models, test_model_from_prediction) {
+  MakeGaussianProcess test_case;
+  auto dataset = test_case.get_dataset();
+  auto model = test_case.get_model();
+  std::vector<double> test_features = {0.1, 1.1, 2.2};
+  auto joint_prediction = model.fit(dataset).predict(test_features).joint();
+  auto joint_prediction_from_prediction =
+      model.fit_from_prediction(test_features, joint_prediction)
+          .predict(test_features)
+          .joint();
+  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
+      joint_prediction.mean, 1e-12));
+  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
+      joint_prediction.covariance, 1e-8));
+}
 
 /*
  * In what follows we create a small problem which contains unobservable
@@ -118,153 +118,153 @@ TEST(test_models, test_expect_predict_variants_consistent_fails) {
  * errors.  This simply makes sure those errors are properly dealth with.
  */
 
-// enum InducingFeatureType {
-//  ConstantEverywhereType,
-//  ConstantPerIntervalType
-//};
-//
-// struct InducingFeature {
-//  InducingFeatureType type;
-//  long location;
-//};
-//
-// std::vector<InducingFeature> create_inducing_points(const std::vector<double>
-// &features) {
-//
-//  std::vector<InducingFeature> inducing_points;
-//  double min = *std::min_element(features.begin(), features.end());
-//  double max = *std::max_element(features.begin(), features.end());
-//
-//  InducingFeature everywhere = {ConstantEverywhereType, 0};
-//  inducing_points.push_back(everywhere);
-//
-//  InducingFeature interval_feature = {ConstantPerIntervalType, 0};
-//  long interval = lround(min);
-//  while (interval <= lround(max)) {
-//    std::cout << interval << std::endl;
-//    interval_feature.location = interval;
-//    inducing_points.push_back(interval_feature);
-//    interval += 1;
-//  }
-//
-//  return inducing_points;
-//}
-//
-// class ConstantEverywhere : public CovarianceFunction<ConstantEverywhere> {
-// public:
-//  ConstantEverywhere() {};
-//  ~ConstantEverywhere(){};
-//
-//  double variance = 10.;
-//
-//  /*
-//   * This will create a covariance matrix that looks like,
-//   *     sigma_mean^2 * ones(m, n)
-//   * which is saying all observations are perfectly correlated,
-//   * so you can move one if you move the rest the same amount.
-//   */
-//  double _call_impl(const double &x, const double &y) const {
-//    return variance;
-//  }
-//
-//  double _call_impl(const InducingFeature &x, const double &y) const {
-//    if (x.type == ConstantEverywhereType) {
-//      return variance;
-//    } else {
-//      return 0.;
-//    }
-//  }
-//
-//  double _call_impl(const InducingFeature &x, const InducingFeature &y) const
-//  {
-//    if (x.type == ConstantEverywhereType && y.type == ConstantEverywhereType)
-//    {
-//      return variance;
-//    } else {
-//      return 0.;
-//    }
-//  }
-//
-//};
-//
-// class ConstantPerInterval : public CovarianceFunction<ConstantPerInterval> {
-// public:
-//  ConstantPerInterval() {};
-//  ~ConstantPerInterval(){};
-//
-//  double variance = 5.;
-//
-//  /*
-//   * This will create a covariance matrix that looks like,
-//   *     sigma_mean^2 * ones(m, n)
-//   * which is saying all observations are perfectly correlated,
-//   * so you can move one if you move the rest the same amount.
-//   */
-//  double _call_impl(const double &x, const double &y) const {
-//    if (lround(x) == lround(y)) {
-//      return variance;
-//    } else {
-//      return 0.;
-//    }
-//  }
-//
-//  double _call_impl(const InducingFeature &x, const double &y) const {
-//    if (x.type == ConstantPerIntervalType && x.location == lround(y)) {
-//      return variance;
-//    } else {
-//      return 0.;
-//    }
-//  }
-//
-//  double _call_impl(const InducingFeature &x, const InducingFeature &y) const
-//  {
-//    if (x.type == ConstantPerIntervalType &&
-//        y.type == ConstantPerIntervalType &&
-//        x.location == y.location) {
-//      return variance;
-//    } else {
-//      return 0.;
-//    }
-//  }
-//
-//};
-//
-// TEST(test_models, test_model_from_prediction_low_rank) {
-//  MakeGaussianProcess test_case;
-//
-//  Eigen::Index k = 10;
-//  Eigen::VectorXd mean = 3.14159 * Eigen::VectorXd::Ones(k);
-//  Eigen::VectorXd variance = 0.1 * Eigen::VectorXd::Ones(k);
-//  MarginalDistribution targets(mean, variance.asDiagonal());
-//
-//  std::vector<double> train_features;
-//  for (Eigen::Index i = 0; i < k; ++i) {
-//    train_features.push_back(static_cast<double>(i) * 0.3);
-//  }
-//
-//  ConstantEverywhere constant;
-//  ConstantPerInterval per_interval;
-//
-//  auto model = gp_from_covariance(constant + per_interval, "unobservable");
-//  const auto fit_model = model.fit(train_features, targets);
-//
-//  const auto inducing_points = create_inducing_points(train_features);
-//
-//  auto joint_prediction = fit_model.predict(inducing_points).joint();
-//
-//  std::vector<double> perturbed_features = {50.01, 51.01, 52.01};
-//
-//  const auto model_pred = fit_model.predict(perturbed_features).joint();
-//
-//  auto joint_prediction_from_prediction =
-//      model.fit_from_prediction(inducing_points, joint_prediction)
-//          .predict(perturbed_features)
-//          .joint();
-//
-//  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
-//      model_pred.mean, 1e-12));
-//  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
-//      model_pred.covariance, 1e-8));
-//}
+ enum InducingFeatureType {
+  ConstantEverywhereType,
+  ConstantPerIntervalType
+};
+
+ struct InducingFeature {
+  InducingFeatureType type;
+  long location;
+};
+
+ std::vector<InducingFeature> create_inducing_points(const std::vector<double>
+ &features) {
+
+  std::vector<InducingFeature> inducing_points;
+  double min = *std::min_element(features.begin(), features.end());
+  double max = *std::max_element(features.begin(), features.end());
+
+  InducingFeature everywhere = {ConstantEverywhereType, 0};
+  inducing_points.push_back(everywhere);
+
+  InducingFeature interval_feature = {ConstantPerIntervalType, 0};
+  long interval = lround(min);
+  while (interval <= lround(max)) {
+    std::cout << interval << std::endl;
+    interval_feature.location = interval;
+    inducing_points.push_back(interval_feature);
+    interval += 1;
+  }
+
+  return inducing_points;
+}
+
+ class ConstantEverywhere : public CovarianceFunction<ConstantEverywhere> {
+ public:
+  ConstantEverywhere() {};
+  ~ConstantEverywhere(){};
+
+  double variance = 10.;
+
+  /*
+   * This will create a covariance matrix that looks like,
+   *     sigma_mean^2 * ones(m, n)
+   * which is saying all observations are perfectly correlated,
+   * so you can move one if you move the rest the same amount.
+   */
+  double _call_impl(const double &x, const double &y) const {
+    return variance;
+  }
+
+  double _call_impl(const InducingFeature &x, const double &y) const {
+    if (x.type == ConstantEverywhereType) {
+      return variance;
+    } else {
+      return 0.;
+    }
+  }
+
+  double _call_impl(const InducingFeature &x, const InducingFeature &y) const
+  {
+    if (x.type == ConstantEverywhereType && y.type == ConstantEverywhereType)
+    {
+      return variance;
+    } else {
+      return 0.;
+    }
+  }
+
+};
+
+ class ConstantPerInterval : public CovarianceFunction<ConstantPerInterval> {
+ public:
+  ConstantPerInterval() {};
+  ~ConstantPerInterval(){};
+
+  double variance = 5.;
+
+  /*
+   * This will create a covariance matrix that looks like,
+   *     sigma_mean^2 * ones(m, n)
+   * which is saying all observations are perfectly correlated,
+   * so you can move one if you move the rest the same amount.
+   */
+  double _call_impl(const double &x, const double &y) const {
+    if (lround(x) == lround(y)) {
+      return variance;
+    } else {
+      return 0.;
+    }
+  }
+
+  double _call_impl(const InducingFeature &x, const double &y) const {
+    if (x.type == ConstantPerIntervalType && x.location == lround(y)) {
+      return variance;
+    } else {
+      return 0.;
+    }
+  }
+
+  double _call_impl(const InducingFeature &x, const InducingFeature &y) const
+  {
+    if (x.type == ConstantPerIntervalType &&
+        y.type == ConstantPerIntervalType &&
+        x.location == y.location) {
+      return variance;
+    } else {
+      return 0.;
+    }
+  }
+
+};
+
+ TEST(test_models, test_model_from_prediction_low_rank) {
+  MakeGaussianProcess test_case;
+
+  Eigen::Index k = 10;
+  Eigen::VectorXd mean = 3.14159 * Eigen::VectorXd::Ones(k);
+  Eigen::VectorXd variance = 0.1 * Eigen::VectorXd::Ones(k);
+  MarginalDistribution targets(mean, variance.asDiagonal());
+
+  std::vector<double> train_features;
+  for (Eigen::Index i = 0; i < k; ++i) {
+    train_features.push_back(static_cast<double>(i) * 0.3);
+  }
+
+  ConstantEverywhere constant;
+  ConstantPerInterval per_interval;
+
+  auto model = gp_from_covariance(constant + per_interval, "unobservable");
+  const auto fit_model = model.fit(train_features, targets);
+
+  const auto inducing_points = create_inducing_points(train_features);
+
+  auto joint_prediction = fit_model.predict(inducing_points).joint();
+
+  std::vector<double> perturbed_features = {50.01, 51.01, 52.01};
+
+  const auto model_pred = fit_model.predict(perturbed_features).joint();
+
+  auto joint_prediction_from_prediction =
+      model.fit_from_prediction(inducing_points, joint_prediction)
+          .predict(perturbed_features)
+          .joint();
+
+  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
+      model_pred.mean, 1e-12));
+  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
+      model_pred.covariance, 1e-8));
+}
 
 } // namespace albatross

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -102,4 +102,150 @@ TEST(test_models, test_model_from_prediction) {
       joint_prediction.covariance, 1e-8));
 }
 
+enum InducingFeatureType {
+  ConstantEverywhereType,
+  ConstantPerIntervalType
+};
+
+struct InducingFeature {
+  InducingFeatureType type;
+  long location;
+};
+
+std::vector<InducingFeature> create_inducing_points(const std::vector<double> &features) {
+
+  std::vector<InducingFeature> inducing_points;
+  double min = *std::min_element(features.begin(), features.end());
+  double max = *std::max_element(features.begin(), features.end());
+
+  InducingFeature everywhere = {ConstantEverywhereType, 0};
+  inducing_points.push_back(everywhere);
+
+  InducingFeature interval_feature = {ConstantPerIntervalType, 0};
+  long interval = lround(min);
+  std::cout << "min: " << min << " max: " << max << std::endl;
+  while (interval <= lround(max)) {
+    std::cout << interval << std::endl;
+    interval_feature.location = interval;
+    inducing_points.push_back(interval_feature);
+    interval += 1;
+  }
+
+  return inducing_points;
+}
+
+class ConstantEverywhere : public CovarianceFunction<ConstantEverywhere> {
+public:
+  ConstantEverywhere() {};
+  ~ConstantEverywhere(){};
+
+  double variance = 10.;
+
+  /*
+   * This will create a covariance matrix that looks like,
+   *     sigma_mean^2 * ones(m, n)
+   * which is saying all observations are perfectly correlated,
+   * so you can move one if you move the rest the same amount.
+   */
+  double _call_impl(const double &x, const double &y) const {
+    return variance;
+  }
+
+  double _call_impl(const InducingFeature &x, const double &y) const {
+    if (x.type == ConstantEverywhereType) {
+      return variance;
+    } else {
+      return 0.;
+    }
+  }
+
+  double _call_impl(const InducingFeature &x, const InducingFeature &y) const {
+    if (x.type == ConstantEverywhereType && y.type == ConstantEverywhereType) {
+      return variance;
+    } else {
+      return 0.;
+    }
+  }
+
+};
+
+class ConstantPerInterval : public CovarianceFunction<ConstantPerInterval> {
+public:
+  ConstantPerInterval() {};
+  ~ConstantPerInterval(){};
+
+  double variance = 5.;
+
+  /*
+   * This will create a covariance matrix that looks like,
+   *     sigma_mean^2 * ones(m, n)
+   * which is saying all observations are perfectly correlated,
+   * so you can move one if you move the rest the same amount.
+   */
+  double _call_impl(const double &x, const double &y) const {
+    if (lround(x) == lround(y)) {
+      return variance;
+    } else {
+      return 0.;
+    }
+  }
+
+  double _call_impl(const InducingFeature &x, const double &y) const {
+    if (x.type == ConstantPerIntervalType && x.location == lround(y)) {
+      return variance;
+    } else {
+      return 0.;
+    }
+  }
+
+  double _call_impl(const InducingFeature &x, const InducingFeature &y) const {
+    if (x.type == ConstantPerIntervalType &&
+        y.type == ConstantPerIntervalType &&
+        x.location == y.location) {
+      return variance;
+    } else {
+      return 0.;
+    }
+  }
+
+};
+
+TEST(test_models, test_model_from_prediction_low_rank) {
+  MakeGaussianProcess test_case;
+
+  Eigen::Index k = 10;
+  Eigen::VectorXd mean = 3.14159 * Eigen::VectorXd::Ones(k);
+  Eigen::VectorXd variance = 0.1 * Eigen::VectorXd::Ones(k);
+  MarginalDistribution targets(mean, variance.asDiagonal());
+
+  std::vector<double> train_features;
+  for (Eigen::Index i = 0; i < k; ++i) {
+    train_features.push_back(static_cast<double>(i) * 0.3);
+  }
+
+  ConstantEverywhere constant;
+  ConstantPerInterval per_interval;
+
+  auto model = gp_from_covariance(constant + per_interval, "unobservable");
+  const auto fit_model = model.fit(train_features, targets);
+
+  const auto inducing_points = create_inducing_points(train_features);
+
+  auto joint_prediction = fit_model.predict(inducing_points).joint();
+
+  std::vector<double> perturbed_features = {50.01, 51.01, 52.01};
+
+  const auto model_pred = fit_model.predict(perturbed_features).joint();
+
+  auto joint_prediction_from_prediction =
+      model.fit_from_prediction(inducing_points, joint_prediction)
+          .predict(perturbed_features)
+          .joint();
+
+  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
+      model_pred.mean, 1e-12));
+  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
+      model_pred.covariance, 1e-8));
+}
+
 } // namespace albatross

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -86,7 +86,7 @@ TEST(test_models, test_expect_predict_variants_consistent_fails) {
   expect_predict_variants_inconsistent(pred);
 }
 
- TEST(test_models, test_model_from_prediction) {
+TEST(test_models, test_model_from_prediction) {
   MakeGaussianProcess test_case;
   auto dataset = test_case.get_dataset();
   auto model = test_case.get_model();
@@ -118,18 +118,15 @@ TEST(test_models, test_expect_predict_variants_consistent_fails) {
  * errors.  This simply makes sure those errors are properly dealth with.
  */
 
- enum InducingFeatureType {
-  ConstantEverywhereType,
-  ConstantPerIntervalType
-};
+enum InducingFeatureType { ConstantEverywhereType, ConstantPerIntervalType };
 
- struct InducingFeature {
+struct InducingFeature {
   InducingFeatureType type;
   long location;
 };
 
- std::vector<InducingFeature> create_inducing_points(const std::vector<double>
- &features) {
+std::vector<InducingFeature>
+create_inducing_points(const std::vector<double> &features) {
 
   std::vector<InducingFeature> inducing_points;
   double min = *std::min_element(features.begin(), features.end());
@@ -150,9 +147,9 @@ TEST(test_models, test_expect_predict_variants_consistent_fails) {
   return inducing_points;
 }
 
- class ConstantEverywhere : public CovarianceFunction<ConstantEverywhere> {
- public:
-  ConstantEverywhere() {};
+class ConstantEverywhere : public CovarianceFunction<ConstantEverywhere> {
+public:
+  ConstantEverywhere(){};
   ~ConstantEverywhere(){};
 
   double variance = 10.;
@@ -163,9 +160,7 @@ TEST(test_models, test_expect_predict_variants_consistent_fails) {
    * which is saying all observations are perfectly correlated,
    * so you can move one if you move the rest the same amount.
    */
-  double _call_impl(const double &x, const double &y) const {
-    return variance;
-  }
+  double _call_impl(const double &x, const double &y) const { return variance; }
 
   double _call_impl(const InducingFeature &x, const double &y) const {
     if (x.type == ConstantEverywhereType) {
@@ -175,21 +170,18 @@ TEST(test_models, test_expect_predict_variants_consistent_fails) {
     }
   }
 
-  double _call_impl(const InducingFeature &x, const InducingFeature &y) const
-  {
-    if (x.type == ConstantEverywhereType && y.type == ConstantEverywhereType)
-    {
+  double _call_impl(const InducingFeature &x, const InducingFeature &y) const {
+    if (x.type == ConstantEverywhereType && y.type == ConstantEverywhereType) {
       return variance;
     } else {
       return 0.;
     }
   }
-
 };
 
- class ConstantPerInterval : public CovarianceFunction<ConstantPerInterval> {
- public:
-  ConstantPerInterval() {};
+class ConstantPerInterval : public CovarianceFunction<ConstantPerInterval> {
+public:
+  ConstantPerInterval(){};
   ~ConstantPerInterval(){};
 
   double variance = 5.;
@@ -216,20 +208,17 @@ TEST(test_models, test_expect_predict_variants_consistent_fails) {
     }
   }
 
-  double _call_impl(const InducingFeature &x, const InducingFeature &y) const
-  {
+  double _call_impl(const InducingFeature &x, const InducingFeature &y) const {
     if (x.type == ConstantPerIntervalType &&
-        y.type == ConstantPerIntervalType &&
-        x.location == y.location) {
+        y.type == ConstantPerIntervalType && x.location == y.location) {
       return variance;
     } else {
       return 0.;
     }
   }
-
 };
 
- TEST(test_models, test_model_from_prediction_low_rank) {
+TEST(test_models, test_model_from_prediction_low_rank) {
   MakeGaussianProcess test_case;
 
   Eigen::Index k = 10;
@@ -261,8 +250,8 @@ TEST(test_models, test_expect_predict_variants_consistent_fails) {
           .predict(perturbed_features)
           .joint();
 
-  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
-      model_pred.mean, 1e-12));
+  EXPECT_TRUE(
+      joint_prediction_from_prediction.mean.isApprox(model_pred.mean, 1e-12));
   EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
       model_pred.covariance, 1e-8));
 }

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -86,166 +86,185 @@ TEST(test_models, test_expect_predict_variants_consistent_fails) {
   expect_predict_variants_inconsistent(pred);
 }
 
-TEST(test_models, test_model_from_prediction) {
-  MakeGaussianProcess test_case;
-  auto dataset = test_case.get_dataset();
-  auto model = test_case.get_model();
-  std::vector<double> test_features = {0.1, 1.1, 2.2};
-  auto joint_prediction = model.fit(dataset).predict(test_features).joint();
-  auto joint_prediction_from_prediction =
-      model.fit_from_prediction(test_features, joint_prediction)
-          .predict(test_features)
-          .joint();
-  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
-      joint_prediction.mean, 1e-12));
-  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
-      joint_prediction.covariance, 1e-8));
-}
+// TEST(test_models, test_model_from_prediction) {
+//  MakeGaussianProcess test_case;
+//  auto dataset = test_case.get_dataset();
+//  auto model = test_case.get_model();
+//  std::vector<double> test_features = {0.1, 1.1, 2.2};
+//  auto joint_prediction = model.fit(dataset).predict(test_features).joint();
+//  auto joint_prediction_from_prediction =
+//      model.fit_from_prediction(test_features, joint_prediction)
+//          .predict(test_features)
+//          .joint();
+//  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
+//      joint_prediction.mean, 1e-12));
+//  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
+//      joint_prediction.covariance, 1e-8));
+//}
 
-enum InducingFeatureType {
-  ConstantEverywhereType,
-  ConstantPerIntervalType
-};
+/*
+ * In what follows we create a small problem which contains unobservable
+ * components.  The model consists of a constant term for each nearest
+ * integer, and another constant term for all values.  Ie, measurements
+ * from the same integer wide bin will share a bias and all measurements
+ * will share another bias.  The result is that the model can't
+ * differentiate between the global bias and the average of all integer
+ * biases (if you add 1 to the global bias and subtract 1 from all interval
+ * biases you end up with the same measurements).  This is handled
+ * properly by the direct Gaussian process, but if you first make a
+ * prediction of each of the biases, then try to use that prediction to
+ * make a new model you end up dealing with a low rank system of
+ * equations which if not handled properly can lead to very large
+ * errors.  This simply makes sure those errors are properly dealth with.
+ */
 
-struct InducingFeature {
-  InducingFeatureType type;
-  long location;
-};
-
-std::vector<InducingFeature> create_inducing_points(const std::vector<double> &features) {
-
-  std::vector<InducingFeature> inducing_points;
-  double min = *std::min_element(features.begin(), features.end());
-  double max = *std::max_element(features.begin(), features.end());
-
-  InducingFeature everywhere = {ConstantEverywhereType, 0};
-  inducing_points.push_back(everywhere);
-
-  InducingFeature interval_feature = {ConstantPerIntervalType, 0};
-  long interval = lround(min);
-  std::cout << "min: " << min << " max: " << max << std::endl;
-  while (interval <= lround(max)) {
-    std::cout << interval << std::endl;
-    interval_feature.location = interval;
-    inducing_points.push_back(interval_feature);
-    interval += 1;
-  }
-
-  return inducing_points;
-}
-
-class ConstantEverywhere : public CovarianceFunction<ConstantEverywhere> {
-public:
-  ConstantEverywhere() {};
-  ~ConstantEverywhere(){};
-
-  double variance = 10.;
-
-  /*
-   * This will create a covariance matrix that looks like,
-   *     sigma_mean^2 * ones(m, n)
-   * which is saying all observations are perfectly correlated,
-   * so you can move one if you move the rest the same amount.
-   */
-  double _call_impl(const double &x, const double &y) const {
-    return variance;
-  }
-
-  double _call_impl(const InducingFeature &x, const double &y) const {
-    if (x.type == ConstantEverywhereType) {
-      return variance;
-    } else {
-      return 0.;
-    }
-  }
-
-  double _call_impl(const InducingFeature &x, const InducingFeature &y) const {
-    if (x.type == ConstantEverywhereType && y.type == ConstantEverywhereType) {
-      return variance;
-    } else {
-      return 0.;
-    }
-  }
-
-};
-
-class ConstantPerInterval : public CovarianceFunction<ConstantPerInterval> {
-public:
-  ConstantPerInterval() {};
-  ~ConstantPerInterval(){};
-
-  double variance = 5.;
-
-  /*
-   * This will create a covariance matrix that looks like,
-   *     sigma_mean^2 * ones(m, n)
-   * which is saying all observations are perfectly correlated,
-   * so you can move one if you move the rest the same amount.
-   */
-  double _call_impl(const double &x, const double &y) const {
-    if (lround(x) == lround(y)) {
-      return variance;
-    } else {
-      return 0.;
-    }
-  }
-
-  double _call_impl(const InducingFeature &x, const double &y) const {
-    if (x.type == ConstantPerIntervalType && x.location == lround(y)) {
-      return variance;
-    } else {
-      return 0.;
-    }
-  }
-
-  double _call_impl(const InducingFeature &x, const InducingFeature &y) const {
-    if (x.type == ConstantPerIntervalType &&
-        y.type == ConstantPerIntervalType &&
-        x.location == y.location) {
-      return variance;
-    } else {
-      return 0.;
-    }
-  }
-
-};
-
-TEST(test_models, test_model_from_prediction_low_rank) {
-  MakeGaussianProcess test_case;
-
-  Eigen::Index k = 10;
-  Eigen::VectorXd mean = 3.14159 * Eigen::VectorXd::Ones(k);
-  Eigen::VectorXd variance = 0.1 * Eigen::VectorXd::Ones(k);
-  MarginalDistribution targets(mean, variance.asDiagonal());
-
-  std::vector<double> train_features;
-  for (Eigen::Index i = 0; i < k; ++i) {
-    train_features.push_back(static_cast<double>(i) * 0.3);
-  }
-
-  ConstantEverywhere constant;
-  ConstantPerInterval per_interval;
-
-  auto model = gp_from_covariance(constant + per_interval, "unobservable");
-  const auto fit_model = model.fit(train_features, targets);
-
-  const auto inducing_points = create_inducing_points(train_features);
-
-  auto joint_prediction = fit_model.predict(inducing_points).joint();
-
-  std::vector<double> perturbed_features = {50.01, 51.01, 52.01};
-
-  const auto model_pred = fit_model.predict(perturbed_features).joint();
-
-  auto joint_prediction_from_prediction =
-      model.fit_from_prediction(inducing_points, joint_prediction)
-          .predict(perturbed_features)
-          .joint();
-
-  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
-      model_pred.mean, 1e-12));
-  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
-      model_pred.covariance, 1e-8));
-}
+// enum InducingFeatureType {
+//  ConstantEverywhereType,
+//  ConstantPerIntervalType
+//};
+//
+// struct InducingFeature {
+//  InducingFeatureType type;
+//  long location;
+//};
+//
+// std::vector<InducingFeature> create_inducing_points(const std::vector<double>
+// &features) {
+//
+//  std::vector<InducingFeature> inducing_points;
+//  double min = *std::min_element(features.begin(), features.end());
+//  double max = *std::max_element(features.begin(), features.end());
+//
+//  InducingFeature everywhere = {ConstantEverywhereType, 0};
+//  inducing_points.push_back(everywhere);
+//
+//  InducingFeature interval_feature = {ConstantPerIntervalType, 0};
+//  long interval = lround(min);
+//  while (interval <= lround(max)) {
+//    std::cout << interval << std::endl;
+//    interval_feature.location = interval;
+//    inducing_points.push_back(interval_feature);
+//    interval += 1;
+//  }
+//
+//  return inducing_points;
+//}
+//
+// class ConstantEverywhere : public CovarianceFunction<ConstantEverywhere> {
+// public:
+//  ConstantEverywhere() {};
+//  ~ConstantEverywhere(){};
+//
+//  double variance = 10.;
+//
+//  /*
+//   * This will create a covariance matrix that looks like,
+//   *     sigma_mean^2 * ones(m, n)
+//   * which is saying all observations are perfectly correlated,
+//   * so you can move one if you move the rest the same amount.
+//   */
+//  double _call_impl(const double &x, const double &y) const {
+//    return variance;
+//  }
+//
+//  double _call_impl(const InducingFeature &x, const double &y) const {
+//    if (x.type == ConstantEverywhereType) {
+//      return variance;
+//    } else {
+//      return 0.;
+//    }
+//  }
+//
+//  double _call_impl(const InducingFeature &x, const InducingFeature &y) const
+//  {
+//    if (x.type == ConstantEverywhereType && y.type == ConstantEverywhereType)
+//    {
+//      return variance;
+//    } else {
+//      return 0.;
+//    }
+//  }
+//
+//};
+//
+// class ConstantPerInterval : public CovarianceFunction<ConstantPerInterval> {
+// public:
+//  ConstantPerInterval() {};
+//  ~ConstantPerInterval(){};
+//
+//  double variance = 5.;
+//
+//  /*
+//   * This will create a covariance matrix that looks like,
+//   *     sigma_mean^2 * ones(m, n)
+//   * which is saying all observations are perfectly correlated,
+//   * so you can move one if you move the rest the same amount.
+//   */
+//  double _call_impl(const double &x, const double &y) const {
+//    if (lround(x) == lround(y)) {
+//      return variance;
+//    } else {
+//      return 0.;
+//    }
+//  }
+//
+//  double _call_impl(const InducingFeature &x, const double &y) const {
+//    if (x.type == ConstantPerIntervalType && x.location == lround(y)) {
+//      return variance;
+//    } else {
+//      return 0.;
+//    }
+//  }
+//
+//  double _call_impl(const InducingFeature &x, const InducingFeature &y) const
+//  {
+//    if (x.type == ConstantPerIntervalType &&
+//        y.type == ConstantPerIntervalType &&
+//        x.location == y.location) {
+//      return variance;
+//    } else {
+//      return 0.;
+//    }
+//  }
+//
+//};
+//
+// TEST(test_models, test_model_from_prediction_low_rank) {
+//  MakeGaussianProcess test_case;
+//
+//  Eigen::Index k = 10;
+//  Eigen::VectorXd mean = 3.14159 * Eigen::VectorXd::Ones(k);
+//  Eigen::VectorXd variance = 0.1 * Eigen::VectorXd::Ones(k);
+//  MarginalDistribution targets(mean, variance.asDiagonal());
+//
+//  std::vector<double> train_features;
+//  for (Eigen::Index i = 0; i < k; ++i) {
+//    train_features.push_back(static_cast<double>(i) * 0.3);
+//  }
+//
+//  ConstantEverywhere constant;
+//  ConstantPerInterval per_interval;
+//
+//  auto model = gp_from_covariance(constant + per_interval, "unobservable");
+//  const auto fit_model = model.fit(train_features, targets);
+//
+//  const auto inducing_points = create_inducing_points(train_features);
+//
+//  auto joint_prediction = fit_model.predict(inducing_points).joint();
+//
+//  std::vector<double> perturbed_features = {50.01, 51.01, 52.01};
+//
+//  const auto model_pred = fit_model.predict(perturbed_features).joint();
+//
+//  auto joint_prediction_from_prediction =
+//      model.fit_from_prediction(inducing_points, joint_prediction)
+//          .predict(perturbed_features)
+//          .joint();
+//
+//  EXPECT_TRUE(joint_prediction_from_prediction.mean.isApprox(
+//      model_pred.mean, 1e-12));
+//  EXPECT_TRUE(joint_prediction_from_prediction.covariance.isApprox(
+//      model_pred.covariance, 1e-8));
+//}
 
 } // namespace albatross

--- a/tests/test_traits_core.cc
+++ b/tests/test_traits_core.cc
@@ -26,84 +26,83 @@ struct Z {};
 
 class HasValidFitImpl : public ModelBase<HasValidFitImpl> {
 public:
-  Fit<HasValidFitImpl, X> _fit_impl(const std::vector<X> &,
-                                    const MarginalDistribution &) const {
+  Fit<HasValidFitImpl> _fit_impl(const std::vector<X> &,
+                                 const MarginalDistribution &) const {
     return {};
   };
 };
 
 class HasWrongReturnTypeFitImpl : public ModelBase<HasWrongReturnTypeFitImpl> {
 public:
-  Fit<X, X> _fit_impl(const std::vector<X> &,
-                      const MarginalDistribution &) const {
+  double _fit_impl(const std::vector<X> &, const MarginalDistribution &) const {
     return {};
   };
 };
 
 class HasNonConstFitImpl : public ModelBase<HasNonConstFitImpl> {
 public:
-  Fit<HasNonConstFitImpl, X> _fit_impl(const std::vector<X> &,
-                                       const MarginalDistribution &) {
+  Fit<HasNonConstFitImpl> _fit_impl(const std::vector<X> &,
+                                    const MarginalDistribution &) {
     return {};
   };
 };
 
 class HasNonConstArgsFitImpl : public ModelBase<HasNonConstFitImpl> {
 public:
-  Fit<HasNonConstArgsFitImpl, X> _fit_impl(std::vector<X> &,
-                                           const MarginalDistribution &) const {
+  Fit<HasNonConstArgsFitImpl> _fit_impl(std::vector<X> &,
+                                        const MarginalDistribution &) const {
     return {};
   };
 
-  Fit<HasNonConstArgsFitImpl, X> _fit_impl(const std::vector<X> &,
-                                           MarginalDistribution &) const {
+  Fit<HasNonConstArgsFitImpl> _fit_impl(const std::vector<X> &,
+                                        MarginalDistribution &) const {
     return {};
   };
 
-  Fit<HasNonConstArgsFitImpl, X> _fit_impl(std::vector<X> &,
-                                           MarginalDistribution &) const {
+  Fit<HasNonConstArgsFitImpl> _fit_impl(std::vector<X> &,
+                                        MarginalDistribution &) const {
     return {};
   };
 };
 
 class HasProtectedValidFitImpl : public ModelBase<HasNonConstFitImpl> {
 protected:
-  Fit<HasProtectedValidFitImpl, X>
-  _fit_impl(const std::vector<X> &, const MarginalDistribution &) const {
+  Fit<HasProtectedValidFitImpl> _fit_impl(const std::vector<X> &,
+                                          const MarginalDistribution &) const {
     return {};
   };
 };
 
 class HasPrivateValidFitImpl : public ModelBase<HasPrivateValidFitImpl> {
 private:
-  Fit<HasPrivateValidFitImpl, X> _fit_impl(const std::vector<X> &,
-                                           const MarginalDistribution &) const {
+  Fit<HasPrivateValidFitImpl> _fit_impl(const std::vector<X> &,
+                                        const MarginalDistribution &) const {
     return {};
   };
 };
 
 class HasValidAndInvalidFitImpl : public ModelBase<HasValidAndInvalidFitImpl> {
 public:
-  Fit<HasValidAndInvalidFitImpl, X>
-  _fit_impl(const std::vector<X> &, const MarginalDistribution &) const {
+  Fit<HasValidAndInvalidFitImpl> _fit_impl(const std::vector<X> &,
+                                           const MarginalDistribution &) const {
     return {};
   };
 
-  Fit<HasValidAndInvalidFitImpl, X> _fit_impl(const std::vector<X> &,
-                                              const MarginalDistribution &) {
+  Fit<HasValidAndInvalidFitImpl> _fit_impl(const std::vector<X> &,
+                                           const MarginalDistribution &) {
     return {};
   };
 };
 
 class HasValidXYFitImpl : public ModelBase<HasValidXYFitImpl> {
 public:
-  Fit<HasValidXYFitImpl, X> _fit_impl(const std::vector<X> &,
-                                      const MarginalDistribution &) const {
+  Fit<HasValidXYFitImpl> _fit_impl(const std::vector<X> &,
+                                   const MarginalDistribution &) const {
     return {};
   };
 
-  Fit<HasValidXYFitImpl, Y> _fit_impl(const std::vector<Y> &,
-                                      const MarginalDistribution &) const {
+  Fit<HasValidXYFitImpl> _fit_impl(const std::vector<Y> &,
+                                   const MarginalDistribution &) const {
     return {};
   };
 };
@@ -121,7 +120,6 @@ TEST(test_traits_core, test_has_valid_fit) {
   EXPECT_TRUE(bool(has_valid_fit<HasValidXYFitImpl, X>::value));
   EXPECT_TRUE(bool(has_valid_fit<HasValidXYFitImpl, Y>::value));
   EXPECT_FALSE(bool(has_valid_fit<HasNoFitImpl, X>::value));
-  //  EXPECT_TRUE(bool(has_valid_fit<HasInheritedFitImpl, Y>::value));
 }
 
 TEST(test_traits_core, test_has_possible_fit_impl) {
@@ -139,18 +137,15 @@ TEST(test_traits_core, test_has_possible_fit_impl) {
 
 TEST(test_traits_core, test_fit_type) {
   EXPECT_TRUE(bool(std::is_same<Z, fit_type<FitModel<X, Z>, Y>::type>::value));
-  EXPECT_TRUE(bool(std::is_same<Fit<HasValidFitImpl, X>,
+  EXPECT_TRUE(bool(std::is_same<Fit<HasValidFitImpl>,
                                 fit_type<HasValidFitImpl, X>::type>::value));
-  EXPECT_TRUE(bool(std::is_same<Fit<HasValidXYFitImpl, X>,
+  EXPECT_TRUE(bool(std::is_same<Fit<HasValidXYFitImpl>,
                                 fit_type<HasValidXYFitImpl, X>::type>::value));
-  EXPECT_TRUE(bool(std::is_same<Fit<HasValidXYFitImpl, Y>,
+  EXPECT_TRUE(bool(std::is_same<Fit<HasValidXYFitImpl>,
                                 fit_type<HasValidXYFitImpl, Y>::type>::value));
   EXPECT_TRUE(
-      bool(std::is_same<Fit<HasValidAndInvalidFitImpl, X>,
+      bool(std::is_same<Fit<HasValidAndInvalidFitImpl>,
                         fit_type<HasValidAndInvalidFitImpl, X>::type>::value));
-  //  EXPECT_FALSE(
-  //      bool(std::is_same<Fit<HasPrivateValidFitImpl, X>,
-  //                        fit_type<HasPrivateValidFitImpl, X>::type>::value));
 }
 
 template <typename T> struct Base : public ModelBase<T> {};
@@ -158,27 +153,26 @@ template <typename T> struct Base : public ModelBase<T> {};
 struct Derived : public Base<Derived> {};
 
 TEST(test_traits_core, test_is_valid_fit_type) {
-  EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Derived, X>>::value));
-  EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Derived, Y>>::value));
-  // If a Derived class which inherits from Base<Derived> has a fit
-  // which returns Fit<Base<Derived>> consider that a valid fit type.
-  EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Base<Derived>, X>>::value));
-  EXPECT_TRUE(bool(is_valid_fit_type<Derived, Fit<Base<Derived>, Y>>::value));
-  // However a fit_impl which returns
-  EXPECT_FALSE(bool(is_valid_fit_type<Base<Derived>, Fit<Derived, X>>::value));
-  EXPECT_FALSE(bool(is_valid_fit_type<Base<Derived>, Fit<Derived, Y>>::value));
+  EXPECT_TRUE(bool(is_valid_fit_type<Fit<Derived>>::value));
+  EXPECT_TRUE(bool(is_valid_fit_type<Fit<Derived>>::value));
+
+  EXPECT_TRUE(bool(is_valid_fit_type<Fit<Base<Derived>>>::value));
+  EXPECT_TRUE(bool(is_valid_fit_type<Fit<Base<Derived>>>::value));
+
+  EXPECT_FALSE(bool(is_valid_fit_type<Derived>::value));
+  EXPECT_FALSE(bool(is_valid_fit_type<Base<Derived>>::value));
 }
 
-template <typename T> struct Adaptable;
+template <typename T, typename FeatureType> struct AdaptableFit;
 
 template <typename T, typename FeatureType>
-struct Fit<Adaptable<T>, FeatureType> {};
+struct Fit<AdaptableFit<T, FeatureType>> {};
 
 template <typename ImplType> struct Adaptable : public ModelBase<ImplType> {
 
-  Fit<Adaptable<ImplType>, X> _fit_impl(const std::vector<X> &,
-                                        const MarginalDistribution &) const {
-    return Fit<Adaptable<ImplType>, X>();
+  Fit<AdaptableFit<ImplType, X>> _fit_impl(const std::vector<X> &,
+                                           const MarginalDistribution &) const {
+    return Fit<AdaptableFit<ImplType, X>>();
   }
 };
 
@@ -193,7 +187,8 @@ struct Extended : public Adaptable<Extended> {
     return Base::_fit_impl(xs, targets);
   }
 
-  Z _predict_impl(const std::vector<Y> &, const Fit<Adaptable<Extended>, X> &,
+  Z _predict_impl(const std::vector<Y> &,
+                  const Fit<AdaptableFit<Extended, X>> &,
                   PredictTypeIdentity<Z>) const {
     return {};
   }
@@ -201,37 +196,12 @@ struct Extended : public Adaptable<Extended> {
 
 struct OtherExtended : public Adaptable<OtherExtended> {};
 
-TEST(test_traits_core, test_adaptable_fit_type) {
-  EXPECT_TRUE(bool(std::is_base_of<Fit<Adaptable<Extended>, X>,
-                                   fit_type<Extended, Y>::type>::value));
-  EXPECT_TRUE(bool(std::is_base_of<Fit<Adaptable<Extended>, X>,
-                                   fit_type<Extended, X>::type>::value));
-  EXPECT_TRUE(bool(
-      has_valid_predict<Extended, Y, Fit<Adaptable<Extended>, X>, Z>::value));
-}
-
 TEST(test_traits_core, test_adaptable_has_valid_fit) {
   EXPECT_TRUE(bool(has_valid_fit<Extended, X>::value));
   EXPECT_TRUE(bool(has_valid_fit<Extended, Y>::value));
 
   EXPECT_TRUE(bool(has_valid_fit<OtherExtended, X>::value));
   EXPECT_FALSE(bool(has_valid_fit<OtherExtended, Y>::value));
-
-  EXPECT_FALSE(bool(has_valid_fit<Adaptable<Extended>, X>::value));
-  EXPECT_FALSE(bool(has_valid_fit<Adaptable<Extended>, Y>::value));
-}
-
-TEST(test_traits_core, test_adaptable_is_valid_fit) {
-  EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Extended, X>>::value));
-  EXPECT_TRUE(bool(is_valid_fit_type<Extended, Fit<Extended, Y>>::value));
-  EXPECT_TRUE(
-      bool(is_valid_fit_type<Extended, Fit<Adaptable<Extended>, X>>::value));
-  EXPECT_TRUE(
-      bool(is_valid_fit_type<Extended, Fit<Adaptable<Extended>, Y>>::value));
-  EXPECT_FALSE(bool(
-      is_valid_fit_type<OtherExtended, Fit<Adaptable<Extended>, Y>>::value));
-  EXPECT_FALSE(bool(
-      is_valid_fit_type<Extended, Fit<Adaptable<OtherExtended>, Y>>::value));
 }
 
 /*


### PR DESCRIPTION
This fixes an issue in which `fit_from_prediction` becomes unstable when the prediction used as unobservable direction.

The `fit_from_prediction` method produces a matrix `C` and vector `v` when take the form,
```
v = prior^-1 y
C = prior (prior - prediction)^-1 prior
```
These are then used in the standard Gaussian process prediction formula,
```
m* = cross * v
S* = prior_S - cross * C^-1 * cross^T
``` 
such that when `cross = prior` and `prior_S = prior` you end up recovering the original prediction.  As mentioned this all works fine until `prediction` has an unobserved direction.  As an extreme case consider when `prediction = prior` (ie, nothing was observed).  Computing `C` in this case would require inverting a zero and since the current code computes `C` then uses it's cholesky decomposition to perform the resulting inversion we end up with an extremely unstable situation.

This change fixes this by allowing various options for storing the `C` matrix.  These are named `CovarianceRepresentations` and their only requirement (for now) is that they contain a `solve` method which computes the inversion.  This lets us preserve the existing approach for direct Gaussian processes, then when creating a fit from a prediction we can use a different `CovarianceRepresentation` which I've named the `ExplainedVariance` representation which stores both `prior` and `(prior-prediction)`.  The resulting solve can then use the formula `C^-1 = prior^-1 (prior - prediction) prior^-1` and avoids inverting the potentially singular inner matrix.

Doing so required a few larger changes:

- The `Fit` class is no longer templated on the `ModelType` and `FeatureType` and instead takes a single  template parameter.
- Because `Fit` is no longer tied to a specific model the `is_valid_fit` traits had to be reworked.
- The `Ransac` and in turn `AdaptedRansac` test models had to be modified.
- A test case was set up which fails on master but passes with this modification.