### PR TITLE
Add Measurement Noise

### DIFF
--- a/examples/example_utils.h
+++ b/examples/example_utils.h
@@ -147,7 +147,8 @@ void write_predictions_to_csv(
   const std::size_t k = 161;
   auto grid_xs = uniform_points_on_line(k, low - 2., high + 2.);
 
-  auto prediction = fit_model.predict(grid_xs).marginal();
+  auto prediction =
+      fit_model.predict_with_measurement_noise(grid_xs).marginal();
 
   Eigen::VectorXd targets(static_cast<Eigen::Index>(k));
   for (std::size_t i = 0; i < k; i++) {

--- a/examples/sinc_example.cc
+++ b/examples/sinc_example.cc
@@ -48,12 +48,12 @@ int main(int argc, char *argv[]) {
   int n = std::stoi(FLAGS_n);
   const double low = -3.;
   const double high = 13.;
-  const double meas_noise = 1.;
+  const double meas_noise_sd = 1.;
 
   if (FLAGS_input == "") {
     FLAGS_input = "input.csv";
   }
-  maybe_create_training_data(FLAGS_input, n, low, high, meas_noise);
+  maybe_create_training_data(FLAGS_input, n, low, high, meas_noise_sd);
 
   using namespace albatross;
 
@@ -65,9 +65,10 @@ int main(int argc, char *argv[]) {
   using SquaredExp = SquaredExponential<EuclideanDistance>;
 
   Polynomial<1> polynomial(100.);
-  Noise noise(meas_noise);
+
+  Noise indep_noise(meas_noise_sd);
   SquaredExp squared_exponential(3.5, 5.7);
-  auto cov = polynomial + noise + squared_exponential;
+  auto cov = polynomial + squared_exponential + measurement_only(noise);
 
   std::cout << cov.pretty_string() << std::endl;
 

--- a/examples/sinc_example.cc
+++ b/examples/sinc_example.cc
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
 
   Noise indep_noise(meas_noise_sd);
   SquaredExp squared_exponential(3.5, 5.7);
-  auto cov = polynomial + squared_exponential + measurement_only(noise);
+  auto cov = polynomial + squared_exponential + measurement_only(indep_noise);
 
   std::cout << cov.pretty_string() << std::endl;
 

--- a/include/albatross/CovarianceFunctions
+++ b/include/albatross/CovarianceFunctions
@@ -24,6 +24,7 @@
 #include "src/covariance_functions/traits.hpp"
 #include "src/covariance_functions/covariance_function.hpp"
 #include "src/covariance_functions/call_trace.hpp"
+#include "src/covariance_functions/measurement.hpp"
 #include "src/covariance_functions/distance_metrics.hpp"
 #include "src/covariance_functions/noise.hpp"
 #include "src/covariance_functions/polynomials.hpp"

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -37,6 +37,13 @@ template <typename ModelType, typename FitType> class FitModel;
 
 template <typename Derived> class Fit {};
 
+template <typename X> struct Measurement {
+
+  Measurement(const X &x) { value = x; }
+
+  X value;
+};
+
 /*
  * Parameter Handling
  */

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -37,13 +37,7 @@ template <typename ModelType, typename FitType> class FitModel;
 
 template <typename Derived> class Fit {};
 
-template <typename X> struct Measurement {
-
-  Measurement(const X &x) { value = x; }
-
-  X value;
-};
-
+template <typename X> struct Measurement;
 /*
  * Parameter Handling
  */

--- a/include/albatross/src/core/fit_model.hpp
+++ b/include/albatross/src/core/fit_model.hpp
@@ -43,6 +43,18 @@ public:
                                                           features);
   }
 
+  template <typename PredictFeatureType>
+  Prediction<ModelType, Measurement<PredictFeatureType>, Fit>
+  predict_with_measurement_noise(
+      const std::vector<PredictFeatureType> &features) const {
+    std::vector<Measurement<PredictFeatureType>> measurements;
+    for (const auto &f : features) {
+      measurements.emplace_back(Measurement<PredictFeatureType>(f));
+    }
+    return Prediction<ModelType, Measurement<PredictFeatureType>, Fit>(
+        model_, fit_, measurements);
+  }
+
   Fit get_fit() const { return fit_; }
 
   ModelType get_model() const { return model_; };

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -21,6 +21,98 @@ template <typename X, typename Y> class ProductOfCovarianceFunctions;
 
 template <typename Derived> class CallTrace;
 
+template <typename Derived> class CovarianceFunction;
+
+namespace internal {
+
+template <typename CovFunc> struct CovarianceCaller {
+
+  /*
+   * CovFunc has a direct call implementation for X and Y
+   */
+  template <typename X, typename Y,
+            typename std::enable_if<
+                has_valid_call_impl<CovFunc, X &, Y &>::value, int>::type = 0>
+  static double call(const CovFunc &cov_func, const X &x, const Y &y) {
+    return cov_func._call_impl(x, y);
+  }
+
+  /*
+   * CovFunc has a call for Y and X but not X and Y
+   */
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(has_valid_call_impl<CovFunc, Y &, X &>::value &&
+                               !has_valid_call_impl<CovFunc, X &, Y &>::value),
+                              int>::type = 0>
+  static double call(const CovFunc &cov_func, const X &x, const Y &y) {
+    return cov_func._call_impl(y, x);
+  }
+};
+
+template <typename U, typename Caller, typename... Args>
+class has_valid_cov_caller
+    : public has_call_with_return_type<Caller, double,
+                                       typename const_ref<U>::type,
+                                       typename const_ref<Args>::type...> {};
+
+template <typename CovFunc, typename Caller> struct MeasurementForwarder {
+
+  template <
+      typename X, typename Y,
+      typename std::enable_if<
+          has_valid_cov_caller<CovFunc, Caller, X, Y>::value, int>::type = 0>
+  static double call(const CovFunc &cov_func, const X &x, const Y &y) {
+    return Caller::call(cov_func, x, y);
+  }
+
+  template <typename X, typename Y,
+            typename std::enable_if<
+                (has_valid_cov_caller<CovFunc, Caller, X, Y>::value &&
+                 !has_valid_cov_caller<CovFunc, Caller, Measurement<X>,
+                                       Measurement<Y>>::value),
+                int>::type = 0>
+  static double call(const CovFunc &cov_func, const Measurement<X> &x,
+                     const Measurement<Y> &y) {
+    return Caller::call(cov_func, x.value, y.value);
+  }
+
+  template <
+      typename X, typename Y,
+      typename std::enable_if<
+          (has_valid_cov_caller<CovFunc, Caller, X, Y>::value &&
+           !has_valid_cov_caller<CovFunc, Caller, Measurement<X>, Y>::value),
+          int>::type = 0>
+  static double call(const CovFunc &cov_func, const Measurement<X> &x,
+                     const Y &y) {
+    return Caller::call(cov_func, x.value, y);
+  }
+
+  template <
+      typename X, typename Y,
+      typename std::enable_if<
+          (has_valid_cov_caller<CovFunc, Caller, X, Y>::value &&
+           !has_valid_cov_caller<CovFunc, Caller, X, Measurement<Y>>::value),
+          int>::type = 0>
+  static double call(const CovFunc &cov_func, const X &x,
+                     const Measurement<Y> &y) {
+    return Caller::call(cov_func, x, y.value);
+  }
+};
+
+} // namespace internal
+
+template <typename CovFunc>
+using Caller =
+    internal::MeasurementForwarder<CovFunc,
+                                   internal::CovarianceCaller<CovFunc>>;
+
+template <typename CovFunc, typename... Args>
+class has_valid_caller
+    : public has_call_with_return_type<Caller<CovFunc>, double,
+                                       typename const_ref<CovFunc>::type,
+                                       typename const_ref<Args>::type...> {};
+
 /*
  * CovarianceFunction is a CRTP base class which can be used in a
  * way similar to a polymorphic abstract class.  For example if
@@ -79,6 +171,10 @@ private:
   CovarianceFunction() : ParameterHandlingMixin(){};
   friend Derived;
 
+  template <typename X, typename Y> double call(const X &x, const Y &y) const {
+    return Caller<Derived>::call(derived(), x, y);
+  }
+
 public:
   static_assert(!is_complete<Derived>::value,
                 "\n\nPassing a complete type in as template parameter "
@@ -119,41 +215,18 @@ public:
    * are 0. and ones that are just not defined (read: possibly bugs).
    */
   template <typename X, typename Y,
-            typename std::enable_if<
-                has_valid_call_impl<Derived, X &, Y &>::value, int>::type = 0>
+            typename std::enable_if<has_valid_caller<Derived, X, Y>::value,
+                                    int>::type = 0>
   auto operator()(const X &x, const Y &y) const {
-    return derived()._call_impl(x, y);
-  }
-
-  /*
-   * Use the symmetric property of covariance functions to find C(X, Y)
-   * when only C(Y, X) is defined.
-   */
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(has_valid_call_impl<Derived, Y &, X &>::value &&
-                               !has_valid_call_impl<Derived, X &, Y &>::value),
-                              int>::type = 0>
-  auto operator()(const X &x, const Y &y) const {
-    return derived()._call_impl(y, x);
+    return call(x, y);
   }
 
   /*
    * Covariance between each element and every other in a vector.
    */
   template <typename X,
-            typename std::enable_if<
-                has_valid_call_impl<Derived, X &, X &>::value, int>::type = 0>
-  double operator()(const X &x) const {
-    return derived()._call_impl(x, x);
-  }
-
-  /*
-   * Covariance between each element and every other in a vector.
-   */
-  template <typename X,
-            typename std::enable_if<
-                has_valid_call_impl<Derived, X &, X &>::value, int>::type = 0>
+            typename std::enable_if<has_valid_caller<Derived, X, X>::value,
+                                    int>::type = 0>
   Eigen::MatrixXd operator()(const std::vector<X> &xs) const {
     int n = static_cast<int>(xs.size());
     Eigen::MatrixXd C(n, n);
@@ -164,7 +237,7 @@ public:
       si = static_cast<std::size_t>(i);
       for (j = 0; j <= i; j++) {
         sj = static_cast<std::size_t>(j);
-        C(i, j) = this->operator()(xs[si], xs[sj]);
+        C(i, j) = call(xs[si], xs[sj]);
         C(j, i) = C(i, j);
       }
     }
@@ -175,8 +248,8 @@ public:
    * Cross covariance between two vectors of (possibly) different types.
    */
   template <typename X, typename Y,
-            typename std::enable_if<
-                (has_valid_call_impl<Derived, X &, Y &>::value), int>::type = 0>
+            typename std::enable_if<has_valid_caller<Derived, X, Y>::value,
+                                    int>::type = 0>
   Eigen::MatrixXd operator()(const std::vector<X> &xs,
                              const std::vector<Y> &ys) const {
     int m = static_cast<int>(xs.size());
@@ -189,31 +262,18 @@ public:
       si = static_cast<std::size_t>(i);
       for (j = 0; j < n; j++) {
         sj = static_cast<std::size_t>(j);
-        C(i, j) = this->operator()(xs[si], ys[sj]);
+        C(i, j) = call(xs[si], ys[sj]);
       }
     }
     return C;
   }
 
   /*
-   * Use the symmetric property to compute the cross covariance.
-   */
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(has_valid_call_impl<Derived, Y &, X &>::value &&
-                               !has_valid_call_impl<Derived, X &, Y &>::value),
-                              int>::type = 0>
-  Eigen::MatrixXd operator()(const std::vector<X> &xs,
-                             const std::vector<Y> &ys) const {
-    return this->operator()(ys, xs).transpose();
-  }
-
-  /*
    * Diagonal of the covariance matrix.
    */
   template <typename X,
-            typename std::enable_if<
-                has_valid_call_impl<Derived, X &, X &>::value, int>::type = 0>
+            typename std::enable_if<has_valid_caller<Derived, X, X>::value,
+                                    int>::type = 0>
   Eigen::VectorXd diagonal(const std::vector<X> &xs) const {
     int n = static_cast<int>(xs.size());
     Eigen::VectorXd diag(n);
@@ -222,7 +282,7 @@ public:
     std::size_t si;
     for (i = 0; i < n; i++) {
       si = static_cast<std::size_t>(i);
-      diag[i] = this->operator()(xs[si], xs[si]);
+      diag[i] = call(xs[si], xs[si]);
     }
     return diag;
   }
@@ -239,62 +299,56 @@ public:
    */
 
   template <typename X, typename std::enable_if<
-                            (!has_valid_call_impl<Derived, X &, X &>::value &&
-                             !has_possible_call_impl<Derived, X &, X &>::value),
+                            (!has_valid_caller<Derived, X, X>::value &&
+                             !has_possible_call_impl<Derived, X, X>::value),
                             int>::type = 0>
-  // There don't appear to be any _call_impl( methods with signature
-  // `double _call_impl(const X&, const X&) const`.
-  double operator()(const X &x) const =
-      delete; // No _call_impl(.  See comments for help.
+  void operator()(const X &x) const
+      ALBATROSS_FAIL(X, "No public method with signature 'double "
+                        "Derived::_call_impl(const X&, const X&) const'");
 
-  /*
-   * Stubs to catch the case where a covariance function was called
-   * with arguments that aren't supported.
-   */
   template <typename X, typename std::enable_if<
-                            (!has_valid_call_impl<Derived, X &, X &>::value &&
-                             has_invalid_call_impl<Derived, X &, X &>::value),
+                            (!has_valid_caller<Derived, X, X>::value &&
+                             has_invalid_call_impl<Derived, X, X>::value),
                             int>::type = 0>
-  // Here it seems there are no valid _call_impl( methods for these types
-  // but there are some invalid ones.  Be sure that the _call_impl( is
-  // defined in the form: `double _call_impl(const X&, const X&) const`.
-  double operator()(const X &x) const =
-      delete; // Invalid _call_impl(.  See comments for help.
+  void operator()(const X &x) const
+      ALBATROSS_FAIL(X, "Incorrectly defined method 'double "
+                        "Derived::_call_impl(const X&, const X&) const'");
 
-  template <typename X, typename Y,
-            typename std::enable_if<
-                (!has_valid_call_impl<Derived, X &, Y &>::value &&
-                 !has_valid_call_impl<Derived, Y &, X &>::value) &&
-                    (!has_possible_call_impl<Derived, X &, Y &>::value &&
-                     !has_possible_call_impl<Derived, Y &, X &>::value),
-                int>::type = 0>
-  // There don't appear to be any _call_impl( methods with signature
-  // `double _call_impl(const X&, const Y&) const`.
-  double operator()(const X &x,
-                    const Y &y) const =
-      delete; // No _call_impl(.  See comments for help.
-
-  template <typename X, typename Y,
-            typename std::enable_if<
-                (!has_valid_call_impl<Derived, X &, Y &>::value &&
-                 !has_valid_call_impl<Derived, Y &, X &>::value) &&
-                    (has_invalid_call_impl<Derived, X &, Y &>::value ||
-                     has_invalid_call_impl<Derived, Y &, X &>::value),
-                int>::type = 0>
-  // Here it seems there are no valid _call_impl( methods for these types
-  // but there are some invalid ones.  Be sure that the _call_impl( is
-  // defined in the form: `double _call_impl(const X&, const X&) const`.
-  double operator()(const X &x,
-                    const Y &y) const =
-      delete; // Invalid _call_impl(.  See comments for help.
+  //  template <typename X, typename Y,
+  //            typename std::enable_if<
+  //                (!has_valid_caller<Derived, X &, Y &>::value &&
+  //                 !has_valid_call_impl<Derived, Y &, X &>::value) &&
+  //                    (!has_possible_call_impl<Derived, X &, Y &>::value &&
+  //                     !has_possible_call_impl<Derived, Y &, X &>::value),
+  //                int>::type = 0>
+  //  void operator()(const X &x,
+  //                    const Y &y) const
+  //    ALBATROSS_FAIL(X, "No public method with signature 'double
+  //    Derived::_call_impl(const X&, const Y&) const'");
+  //
+  //  template <typename X, typename Y,
+  //            typename std::enable_if<
+  //                (!has_valid_call_impl<Derived, X &, Y &>::value &&
+  //                 !has_valid_call_impl<Derived, Y &, X &>::value) &&
+  //                    (has_invalid_call_impl<Derived, X &, Y &>::value ||
+  //                     has_invalid_call_impl<Derived, Y &, X &>::value),
+  //                int>::type = 0>
+  //  // Here it seems there are no valid _call_impl( methods for these types
+  //  // but there are some invalid ones.  Be sure that the _call_impl( is
+  //  // defined in the form: `double _call_impl(const X&, const X&) const`.
+  //  void operator()(const X &x,
+  //                    const Y &y) const =
+  //      delete; // Invalid _call_impl(.  See comments for help.
 
   /*
    * Covariance between each element and every other in a vector.
    */
   template <typename X,
-            typename std::enable_if<
-                !has_valid_call_impl<Derived, X &, X &>::value, int>::type = 0>
-  DiagonalMatrixXd diagonal(const std::vector<X> &xs) const = delete;
+            typename std::enable_if<!has_valid_caller<Derived, X, X>::value,
+                                    int>::type = 0>
+  void diagonal(const std::vector<X> &xs) const
+      ALBATROSS_FAIL(X, "No public method with signature 'double "
+                        "Derived::_call_impl(const X&, const X&) const'");
 
   CallTrace<Derived> call_trace() const;
 
@@ -343,11 +397,10 @@ public:
    * If both LHS and RHS have a valid call method for the types X and Y
    * this will return the sum of the two.
    */
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
-                               has_valid_call_impl<RHS, X &, Y &>::value),
-                              int>::type = 0>
+  template <typename X, typename Y,
+            typename std::enable_if<(has_valid_caller<LHS, X &, Y &>::value &&
+                                     has_valid_caller<RHS, X &, Y &>::value),
+                                    int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->lhs_(x, y) + this->rhs_(x, y);
   }
@@ -355,11 +408,10 @@ public:
   /*
    * If only LHS has a valid call method we ignore R.
    */
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
-                               !has_valid_call_impl<RHS, X &, Y &>::value),
-                              int>::type = 0>
+  template <typename X, typename Y,
+            typename std::enable_if<(has_valid_caller<LHS, X &, Y &>::value &&
+                                     !has_valid_caller<RHS, X &, Y &>::value),
+                                    int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->lhs_(x, y);
   }
@@ -367,11 +419,10 @@ public:
   /*
    * If only RHS has a valid call method we ignore L.
    */
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(!has_valid_call_impl<LHS, X &, Y &>::value &&
-                               has_valid_call_impl<RHS, X &, Y &>::value),
-                              int>::type = 0>
+  template <typename X, typename Y,
+            typename std::enable_if<(!has_valid_caller<LHS, X &, Y &>::value &&
+                                     has_valid_caller<RHS, X &, Y &>::value),
+                                    int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->rhs_(x, y);
   }
@@ -415,11 +466,10 @@ public:
    * If both LHS and RHS have a valid call method for the types X and Y
    * this will return the product of the two.
    */
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
-                               has_valid_call_impl<RHS, X &, Y &>::value),
-                              int>::type = 0>
+  template <typename X, typename Y,
+            typename std::enable_if<(has_valid_caller<LHS, X &, Y &>::value &&
+                                     has_valid_caller<RHS, X &, Y &>::value),
+                                    int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     double output = this->lhs_(x, y);
     if (output != 0.) {
@@ -431,11 +481,10 @@ public:
   /*
    * If only LHS has a valid call method we ignore R.
    */
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(has_valid_call_impl<LHS, X &, Y &>::value &&
-                               !has_valid_call_impl<RHS, X &, Y &>::value),
-                              int>::type = 0>
+  template <typename X, typename Y,
+            typename std::enable_if<(has_valid_caller<LHS, X &, Y &>::value &&
+                                     !has_valid_caller<RHS, X &, Y &>::value),
+                                    int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->lhs_(x, y);
   }
@@ -443,11 +492,10 @@ public:
   /*
    * If only RHS has a valid call method we ignore L.
    */
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(!has_valid_call_impl<LHS, X &, Y &>::value &&
-                               has_valid_call_impl<RHS, X &, Y &>::value),
-                              int>::type = 0>
+  template <typename X, typename Y,
+            typename std::enable_if<(!has_valid_caller<LHS, X &, Y &>::value &&
+                                     has_valid_caller<RHS, X &, Y &>::value),
+                                    int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->rhs_(x, y);
   }

--- a/include/albatross/src/covariance_functions/measurement.hpp
+++ b/include/albatross/src/covariance_functions/measurement.hpp
@@ -15,15 +15,32 @@
 
 namespace albatross {
 
+template <typename X> struct Measurement {
+
+  Measurement(){};
+
+  Measurement(const X &x) { value = x; }
+
+  X value;
+};
+
 template <typename SubCovariance>
 class MeasurementOnly
     : public CovarianceFunction<MeasurementOnly<SubCovariance>> {
 
 public:
-  ~MeasurementOnly(){};
+  MeasurementOnly(){};
+  MeasurementOnly(const SubCovariance &sub_cov) : sub_cov_(sub_cov){};
 
   std::string name() const {
     return "measurement[" + sub_cov_.get_name() + "]";
+  }
+
+  ParameterStore get_params() const override { return sub_cov_.get_params(); }
+
+  void unchecked_set_param(const ParameterKey &name,
+                           const Parameter &param) override {
+    sub_cov_.set_param(name, param);
   }
 
   /*
@@ -53,6 +70,14 @@ public:
 private:
   SubCovariance sub_cov_;
 };
+
+/*
+ * Utility function to act as a constructor but with template param resolution.
+ */
+template <typename SubCovariance>
+MeasurementOnly<SubCovariance> measurement_only(const SubCovariance &cov) {
+  return MeasurementOnly<SubCovariance>(cov);
+}
 
 } // namespace albatross
 

--- a/include/albatross/src/covariance_functions/measurement.hpp
+++ b/include/albatross/src/covariance_functions/measurement.hpp
@@ -17,7 +17,7 @@ namespace albatross {
 
 template <typename X> struct Measurement {
 
-  Measurement() : value() {};
+  Measurement() : value(){};
 
   Measurement(const X &x) { value = x; }
 
@@ -29,7 +29,7 @@ class MeasurementOnly
     : public CovarianceFunction<MeasurementOnly<SubCovariance>> {
 
 public:
-  MeasurementOnly() : sub_cov_() {};
+  MeasurementOnly() : sub_cov_(){};
   MeasurementOnly(const SubCovariance &sub_cov) : sub_cov_(sub_cov){};
 
   std::string name() const {

--- a/include/albatross/src/covariance_functions/measurement.hpp
+++ b/include/albatross/src/covariance_functions/measurement.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef INCLUDE_ALBATROSS_SRC_COVARIANCE_FUNCTIONS_MEASUREMENT_HPP_
+#define INCLUDE_ALBATROSS_SRC_COVARIANCE_FUNCTIONS_MEASUREMENT_HPP_
+
+namespace albatross {
+
+template <typename SubCovariance>
+class MeasurementOnly
+    : public CovarianceFunction<MeasurementOnly<SubCovariance>> {
+
+public:
+  ~MeasurementOnly(){};
+
+  std::string name() const {
+    return "measurement[" + sub_cov_.get_name() + "]";
+  }
+
+  /*
+   * This will create a scaled identity matrix, but only between
+   * two different observations defined by the Observed type.
+   */
+  template <
+      typename X, typename Y,
+      typename std::enable_if<
+          has_valid_call_impl<SubCovariance, X &, Y &>::value, int>::type = 0>
+  double _call_impl(const X &x, const Y &y) const {
+    return 0.;
+  };
+
+  /*
+   * This will create a scaled identity matrix, but only between
+   * two different observations defined by the Observed type.
+   */
+  template <
+      typename X, typename Y,
+      typename std::enable_if<
+          has_valid_call_impl<SubCovariance, X &, Y &>::value, int>::type = 0>
+  double _call_impl(const Measurement<X> &x, const Measurement<Y> &y) const {
+    return sub_cov_(x.value, y.value);
+  };
+
+private:
+  SubCovariance sub_cov_;
+};
+
+} // namespace albatross
+
+#endif /* INCLUDE_ALBATROSS_SRC_COVARIANCE_FUNCTIONS_MEASUREMENT_HPP_ */

--- a/include/albatross/src/covariance_functions/measurement.hpp
+++ b/include/albatross/src/covariance_functions/measurement.hpp
@@ -17,7 +17,7 @@ namespace albatross {
 
 template <typename X> struct Measurement {
 
-  Measurement(){};
+  Measurement() : value() {};
 
   Measurement(const X &x) { value = x; }
 
@@ -29,7 +29,7 @@ class MeasurementOnly
     : public CovarianceFunction<MeasurementOnly<SubCovariance>> {
 
 public:
-  MeasurementOnly(){};
+  MeasurementOnly() : sub_cov_() {};
   MeasurementOnly(const SubCovariance &sub_cov) : sub_cov_(sub_cov){};
 
   std::string name() const {
@@ -43,10 +43,6 @@ public:
     sub_cov_.set_param(name, param);
   }
 
-  /*
-   * This will create a scaled identity matrix, but only between
-   * two different observations defined by the Observed type.
-   */
   template <
       typename X, typename Y,
       typename std::enable_if<
@@ -55,10 +51,6 @@ public:
     return 0.;
   };
 
-  /*
-   * This will create a scaled identity matrix, but only between
-   * two different observations defined by the Observed type.
-   */
   template <
       typename X, typename Y,
       typename std::enable_if<

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -32,6 +32,8 @@ HAS_METHOD(_call_impl);
 template <typename U, typename... Args>
 class has_possible_call_impl : public has__call_impl<U, Args &...> {};
 
+HAS_METHOD_WITH_RETURN_TYPE(call);
+
 /*
  * This determines whether or not a class has a method defined for,
  *   `operator() (const X &x, const Y &y, const Z &z, ...)`

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -34,6 +34,12 @@ class has_possible_call_impl : public has__call_impl<U, Args &...> {};
 
 HAS_METHOD_WITH_RETURN_TYPE(call);
 
+template <typename U, typename Caller, typename... Args>
+class has_valid_cov_caller
+    : public has_call_with_return_type<Caller, double,
+                                       typename const_ref<U>::type,
+                                       typename const_ref<Args>::type...> {};
+
 /*
  * This determines whether or not a class has a method defined for,
  *   `operator() (const X &x, const Y &y, const Z &z, ...)`

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -245,7 +245,11 @@ public:
   CholeskyFit<FeatureType>
   _fit_impl(const std::vector<FeatureType> &features,
             const MarginalDistribution &targets) const {
-    Eigen::MatrixXd cov = covariance_function_(features);
+    std::vector<Measurement<FeatureType>> measurement_features;
+    for (const auto &f : features) {
+      measurement_features.emplace_back(Measurement<FeatureType>(f));
+    }
+    Eigen::MatrixXd cov = covariance_function_(measurement_features);
     return CholeskyFit<FeatureType>(features, cov, targets);
   }
 

--- a/tests/test_covariance_functions.cc
+++ b/tests/test_covariance_functions.cc
@@ -27,6 +27,49 @@ std::vector<Eigen::Vector3d> points_on_a_line(const int n) {
   return xs;
 }
 
+TEST(test_covariance_functions, test_measurement_noise_wrapper) {
+
+  SquaredExponential<EuclideanDistance> radial;
+  MeasurementOnly<IndependentNoise<double>> meas_noise;
+  auto sum = radial + meas_noise;
+  auto prod = meas_noise * radial;
+
+  std::vector<double> features = {0., 1., 2.};
+
+  std::vector<Measurement<double>> measurements;
+  for (const auto &f : features) {
+    measurements.emplace_back(Measurement<double>(f));
+  }
+
+  const auto f = features[0];
+  const auto m = measurements[0];
+
+  // The measurement noise should only get applied to
+  // features marked as measurements.
+  EXPECT_EQ(meas_noise(f, f), 0.);
+  EXPECT_GT(meas_noise(m, m), 0.);
+
+  // The radial covariance function should behave the same
+  // regardless of whether it's given features or measurements.
+  EXPECT_GT(radial(f, f), 0.);
+  EXPECT_GT(radial(m, m), 0.);
+  EXPECT_EQ(radial(m, m), radial(f, f));
+
+  // When you add covariance functions you should get
+  // the sum of the individual calls.
+  EXPECT_GT(sum(f, f), 0.);
+  EXPECT_GT(sum(m, m), 0.);
+  EXPECT_GT(sum(m, m), sum(f, f));
+  EXPECT_EQ(sum(m, m), radial(m, m) + meas_noise(m, m));
+
+  // When you multiply a measurement only covariance with a
+  // fully defined one the measurement only property
+  // propagates
+  EXPECT_EQ(prod(f, f), 0.);
+  EXPECT_GT(prod(m, m), 0.);
+  EXPECT_EQ(prod(m, m), radial(m, m) * meas_noise(m, m));
+}
+
 TEST(test_covariance_functions, test_build_covariance) {
   using Feature = Eigen::Vector3d;
   IndependentNoise<Feature> noise;

--- a/tests/test_covariance_functions.cc
+++ b/tests/test_covariance_functions.cc
@@ -30,9 +30,11 @@ std::vector<Eigen::Vector3d> points_on_a_line(const int n) {
 TEST(test_covariance_functions, test_measurement_noise_wrapper) {
 
   SquaredExponential<EuclideanDistance> radial;
-  MeasurementOnly<IndependentNoise<double>> meas_noise;
+  IndependentNoise<double> noise;
+  auto meas_noise = measurement_only(noise);
   auto sum = radial + meas_noise;
   auto prod = meas_noise * radial;
+  auto prod_of_sum = noise * sum;
 
   std::vector<double> features = {0., 1., 2.};
 
@@ -47,13 +49,16 @@ TEST(test_covariance_functions, test_measurement_noise_wrapper) {
   // The measurement noise should only get applied to
   // features marked as measurements.
   EXPECT_EQ(meas_noise(f, f), 0.);
+  EXPECT_EQ(meas_noise(f, m), 0.);
+  EXPECT_EQ(meas_noise(m, f), 0.);
   EXPECT_GT(meas_noise(m, m), 0.);
 
   // The radial covariance function should behave the same
   // regardless of whether it's given features or measurements.
   EXPECT_GT(radial(f, f), 0.);
-  EXPECT_GT(radial(m, m), 0.);
   EXPECT_EQ(radial(m, m), radial(f, f));
+  EXPECT_EQ(radial(m, f), radial(f, f));
+  EXPECT_EQ(radial(f, m), radial(f, f));
 
   // When you add covariance functions you should get
   // the sum of the individual calls.
@@ -61,6 +66,8 @@ TEST(test_covariance_functions, test_measurement_noise_wrapper) {
   EXPECT_GT(sum(m, m), 0.);
   EXPECT_GT(sum(m, m), sum(f, f));
   EXPECT_EQ(sum(m, m), radial(m, m) + meas_noise(m, m));
+  EXPECT_EQ(sum(m, f), radial(m, f) + meas_noise(m, f));
+  EXPECT_EQ(sum(f, m), radial(f, m) + meas_noise(f, m));
 
   // When you multiply a measurement only covariance with a
   // fully defined one the measurement only property
@@ -68,6 +75,18 @@ TEST(test_covariance_functions, test_measurement_noise_wrapper) {
   EXPECT_EQ(prod(f, f), 0.);
   EXPECT_GT(prod(m, m), 0.);
   EXPECT_EQ(prod(m, m), radial(m, m) * meas_noise(m, m));
+  EXPECT_EQ(prod(m, f), 0.);
+  EXPECT_EQ(prod(f, m), 0.);
+
+  // Taking a product of a sum, the sum should drop the
+  // measurement only behavior, so the product should then
+  // still be non zero for non-measurement features.
+  EXPECT_GT(prod_of_sum(f, f), 0.);
+  EXPECT_GT(prod_of_sum(m, m), 0.);
+  EXPECT_EQ(prod_of_sum(f, f), noise(f, f) * sum(f, f));
+  EXPECT_EQ(prod_of_sum(m, m), noise(m, m) * sum(m, m));
+  EXPECT_EQ(prod_of_sum(m, f), prod_of_sum(f, f));
+  EXPECT_EQ(prod_of_sum(f, m), prod_of_sum(m, f));
 }
 
 TEST(test_covariance_functions, test_build_covariance) {

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -138,7 +138,6 @@ create_inducing_points(const std::vector<double> &features) {
   InducingFeature interval_feature = {ConstantPerIntervalType, 0};
   long interval = lround(min);
   while (interval <= lround(max)) {
-    std::cout << interval << std::endl;
     interval_feature.location = interval;
     inducing_points.push_back(interval_feature);
     interval += 1;

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -22,7 +22,7 @@ namespace albatross {
 inline auto make_simple_covariance_function() {
   SquaredExponential<EuclideanDistance> squared_exponential(100., 100.);
   IndependentNoise<double> noise(0.1);
-  return squared_exponential + noise;
+  return squared_exponential + measurement_only(noise);
 }
 
 class MakeGaussianProcess {
@@ -97,8 +97,7 @@ public:
   auto _fit_impl(const std::vector<AdaptedFeature> &features,
                  const MarginalDistribution &targets) const {
     const auto converted = adapted::convert_features(features);
-    Eigen::MatrixXd cov = this->covariance_function_(converted);
-    return FitType(converted, cov, targets);
+    return Base::_fit_impl(converted, targets);
   }
 
   template <typename PredictType>

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -76,9 +76,6 @@ TYPED_TEST(SparseGaussianProcessTest, test_sanity) {
   double really_sparse_cov_diff =
       (really_sparse_pred.covariance - direct_pred.covariance).norm();
 
-  std::cout << direct_pred.covariance << std::endl;
-  std::cout << sparse_pred.covariance << std::endl;
-
   EXPECT_LT(sparse_cov_diff, 1e-2);
   EXPECT_LT(really_sparse_cov_diff, 0.5);
   EXPECT_GT(really_sparse_cov_diff, sparse_cov_diff);

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -46,20 +46,23 @@ TYPED_TEST(SparseGaussianProcessTest, test_sanity) {
 
   auto direct = gp_from_covariance(covariance, "direct");
 
-  UniformlySpacedInducingPoints strategy(10);
+  UniformlySpacedInducingPoints strategy(8);
   auto sparse =
       sparse_gp_from_covariance(covariance, strategy, indexer, "sparse");
 
-  UniformlySpacedInducingPoints bad_strategy(4);
+  UniformlySpacedInducingPoints bad_strategy(3);
   auto really_sparse = sparse_gp_from_covariance(covariance, bad_strategy,
                                                  indexer, "really_sparse");
 
   auto test_features = linspace(0.01, 9.9, 11);
 
-  auto sparse_pred = sparse.fit(dataset).predict(test_features).joint();
-  auto really_sparse_pred =
-      really_sparse.fit(dataset).predict(test_features).joint();
-  auto direct_pred = direct.fit(dataset).predict(test_features).joint();
+  auto sparse_pred =
+      sparse.fit(dataset).predict_with_measurement_noise(test_features).joint();
+  auto really_sparse_pred = really_sparse.fit(dataset)
+                                .predict_with_measurement_noise(test_features)
+                                .joint();
+  auto direct_pred =
+      direct.fit(dataset).predict_with_measurement_noise(test_features).joint();
 
   double sparse_error = (sparse_pred.mean - direct_pred.mean).norm();
   double really_sparse_error =
@@ -72,6 +75,9 @@ TYPED_TEST(SparseGaussianProcessTest, test_sanity) {
       (sparse_pred.covariance - direct_pred.covariance).norm();
   double really_sparse_cov_diff =
       (really_sparse_pred.covariance - direct_pred.covariance).norm();
+
+  std::cout << direct_pred.covariance << std::endl;
+  std::cout << sparse_pred.covariance << std::endl;
 
   EXPECT_LT(sparse_cov_diff, 1e-2);
   EXPECT_LT(really_sparse_cov_diff, 0.5);


### PR DESCRIPTION
This change started as an attempt to kill a few birds with one stone.  In particular, I was hoping to fix Gaussian processes from breaking when duplicate observations are present AND add the ability to differentiate between the underlying process being modeled and measurements taken of the process.  In the end this change only accomplishes the later, but I think it's still worth bringing in.

This lets you know wrap a `FeatureType` with a `Measurement<FeatureType>` tag which let's you then create covariance functions which will only evaluate non-zero when building a training covariance, but which will then become null operations when testing.  See `test_measurement_noise_wrapper` for example behavior.

The motivation for this is that often when you make a prediction of some quantity you actually care about the underlying process NOT a measurement of that process.  Consider the temperature example.  You start with a bunch of stations all measuring the temperature then want to build a map of your best guess of the temperature.  Of course each station has measurement noise and it's important to  model this when training.  When predicting however you likely want to covariance to reflect the model's confidence in it's estimate of the actual temperature, not what a station would measure.

There are some exceptions to this (evaluation for example) in which you want to ask how well your model predicts held out measurements in which case you want the measurement noise to be a part of the prediction.  As a result the cross validation routines keep the measurement noise throughout.