### PR TITLE
Add Serialization to the ExplainedCovariance class

### DIFF
--- a/include/albatross/src/covariance_functions/representations.hpp
+++ b/include/albatross/src/covariance_functions/representations.hpp
@@ -78,6 +78,16 @@ struct ExplainedCovariance {
     return outer_ldlt.solve(inner * outer_ldlt.solve(rhs));
   }
 
+  bool operator==(const ExplainedCovariance &rhs) const {
+    return (outer_ldlt == rhs.outer_ldlt && inner == rhs.inner);
+  }
+
+  template <typename Archive>
+  void serialize(Archive &archive, const std::uint32_t) {
+    archive(cereal::make_nvp("outer_ldlt", outer_ldlt),
+            cereal::make_nvp("inner", inner));
+  }
+
   Eigen::SerializableLDLT outer_ldlt;
   Eigen::MatrixXd inner;
 };

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -113,11 +113,11 @@ struct LDLT : public SerializableType<Eigen::SerializableLDLT> {
   Eigen::Index n = 3;
 
   RepresentationType create() const override {
-    // This looks weird, but without forcing this to a Eigen::MatrixXd
+    // Without forcing this to a Eigen::MatrixXd
     // type every time `part` is accessed it'll have new random values!
     // so part.tranpose() will not be the transpose of `part` but the
     // transpose of some new random matrix.  Seems like a bug to me.
-    const auto part = Eigen::MatrixXd(Eigen::MatrixXd::Random(n, n));
+    const Eigen::MatrixXd part = Eigen::MatrixXd::Random(n, n);
     auto cov = part * part.transpose();
     auto ldlt = cov.ldlt();
     auto information = Eigen::VectorXd::Ones(n);
@@ -141,11 +141,11 @@ struct ExplainedCovarianceRepresentation
   Eigen::Index n = 3;
 
   RepresentationType create() const override {
-    // This looks weird, but without forcing this to a Eigen::MatrixXd
+    // Without forcing this to a Eigen::MatrixXd
     // type every time `part` is accessed it'll have new random values!
     // so part.tranpose() will not be the transpose of `part` but the
     // transpose of some new random matrix.  Seems like a bug to me.
-    const auto part = Eigen::MatrixXd(Eigen::MatrixXd::Random(n, n));
+    const Eigen::MatrixXd part = Eigen::MatrixXd::Random(n, n);
     auto cov = part * part.transpose();
 
     ExplainedCovariance representation(cov, cov);


### PR DESCRIPTION
This makes it so a Gaussian process built from `fit_from_prediction` can be serialized.