### PR TITLE
Use mapbox/variant

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,4 @@
 	url = https://github.com/swift-nav/cmake.git
 [submodule "third_party/variant"]
 	path = third_party/variant
-	url = git@github.com:swift-nav/variant
+	url = https://github.com/swift-nav/variant.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "cmake/cmake"]
 	path = cmake/common
 	url = https://github.com/swift-nav/cmake.git
+[submodule "third_party/variant"]
+	path = third_party/variant
+	url = git@github.com:swift-nav/variant

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(Cereal REQUIRED)
 find_package(Eigen REQUIRED)
 find_package(FastCSV REQUIRED)
 find_package(Gzip-Hpp REQUIRED)
+find_package(Variant REQUIRED)
 
 add_library(albatross INTERFACE)
 target_include_directories(albatross INTERFACE
@@ -37,6 +38,7 @@ target_link_libraries(albatross
     cereal
     fast-csv
     gzip-hpp
+    variant
     )
 
 set(albatross_COMPILE_OPTIONS

--- a/cmake/FindVariant.cmake
+++ b/cmake/FindVariant.cmake
@@ -1,0 +1,4 @@
+include("GenericFindDependency")
+GenericFindDependency(
+    TARGET variant
+    )

--- a/include/albatross/CovarianceFunctions
+++ b/include/albatross/CovarianceFunctions
@@ -21,6 +21,8 @@
 #include "src/core/parameter_handling_mixin.hpp"
 #include "src/core/parameter_macros.hpp"
 
+#include <mapbox/variant.hpp>
+
 #include "src/covariance_functions/traits.hpp"
 #include "src/covariance_functions/covariance_function.hpp"
 #include "src/covariance_functions/call_trace.hpp"

--- a/tests/test_covariance_function.cc
+++ b/tests/test_covariance_function.cc
@@ -52,11 +52,11 @@ class HasNone : public CovarianceFunction<HasNone> {};
 
 class HasMultiple : public CovarianceFunction<HasMultiple> {
 public:
-  double _call_impl(const X &, const Y &) const { return 1.; };
-
   double _call_impl(const X &, const X &) const { return 1.; };
 
-  double _call_impl(const Y &, const Y &) const { return 1.; };
+  double _call_impl(const X &, const Y &) const { return 3.; };
+
+  double _call_impl(const Y &, const Y &) const { return 5.; };
 
   std::string name_ = "has_multiple";
 };
@@ -127,6 +127,37 @@ TEST(test_covariance_function, test_covariance_matrix) {
   EXPECT_EQ(cov(std::vector<Y>({{}, {}})).size(), 4);
   EXPECT_EQ(cov(std::vector<X>({{}, {}, {}}), std::vector<Y>({{}, {}})).size(),
             6);
+}
+
+TEST(test_covariance_function, test_works_with_variants) {
+  HasMultiple cov;
+
+  X x;
+  Y y;
+
+  EXPECT_EQ(cov(x, x), 1.);
+  EXPECT_EQ(cov(x, y), 3.);
+  EXPECT_EQ(cov(y, x), 3.);
+  EXPECT_EQ(cov(y, y), 5.);
+
+  variant<X, Y> vx = x;
+  variant<X, Y> vy = y;
+
+  EXPECT_EQ(cov(vx, x), cov(x, x));
+  EXPECT_EQ(cov(vx, vx), cov(x, x));
+  EXPECT_EQ(cov(x, vx), cov(x, x));
+
+  EXPECT_EQ(cov(vx, y), cov(x, y));
+  EXPECT_EQ(cov(vx, vy), cov(x, y));
+  EXPECT_EQ(cov(x, vy), cov(x, y));
+
+  EXPECT_EQ(cov(vy, x), cov(x, y));
+  EXPECT_EQ(cov(vy, vx), cov(x, y));
+  EXPECT_EQ(cov(y, vx), cov(x, y));
+
+  EXPECT_EQ(cov(vy, y), cov(y, y));
+  EXPECT_EQ(cov(vy, vy), cov(y, y));
+  EXPECT_EQ(cov(y, vy), cov(y, y));
 }
 
 } // namespace albatross


### PR DESCRIPTION
This change let's you use `variant<X, Y>` as an argument to a covariance function as long as that function supports operations on both `X` and `Y`.