### PR TITLE
Revert GP fit serialization change.

### DIFF
--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -73,7 +73,7 @@ struct Fit<GPFit<CovarianceRepresentation, FeatureType>> {
 
   template <typename Archive> void serialize(Archive &archive) {
     archive(cereal::make_nvp("information", information));
-    archive(cereal::make_nvp("train_covariance", train_covariance));
+    archive(cereal::make_nvp("train_ldlt", train_covariance));
     archive(cereal::make_nvp("train_features", train_features));
   }
 


### PR DESCRIPTION
Unfortunately some of the serialization methods didn't end up with versioning (!!) so we have to use all the same keyword names when storing the GP fit.