### PR TITLE
Add the ability to serialize variants

### DIFF
--- a/include/albatross/Common
+++ b/include/albatross/Common
@@ -27,6 +27,8 @@
 #include <Eigen/Core>
 #include <Eigen/Dense>
 
+#include <mapbox/variant.hpp>
+
 #include <math.h>
 #include <iomanip>
 #include <map>
@@ -42,6 +44,8 @@
 #include "src/core/declarations.hpp"
 #include "src/utils/map_utils.hpp"
 #include "src/cereal/eigen.hpp"
+#include "src/cereal/traits.hpp"
+#include "src/cereal/variant.hpp"
 
 #include "src/details/traits.hpp"
 #include "src/details/has_any_macros.hpp"

--- a/include/albatross/CovarianceFunctions
+++ b/include/albatross/CovarianceFunctions
@@ -21,8 +21,6 @@
 #include "src/core/parameter_handling_mixin.hpp"
 #include "src/core/parameter_macros.hpp"
 
-#include <mapbox/variant.hpp>
-
 #include "src/covariance_functions/traits.hpp"
 #include "src/covariance_functions/covariance_function.hpp"
 #include "src/covariance_functions/call_trace.hpp"

--- a/include/albatross/src/cereal/variant.hpp
+++ b/include/albatross/src/cereal/variant.hpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef INCLUDE_ALBATROSS_SRC_CEREAL_VARIANT_HPP_
+#define INCLUDE_ALBATROSS_SRC_CEREAL_VARIANT_HPP_
+
+/*
+ * A lot of this is borrowed from cereal's std::variant.
+ */
+
+namespace cereal {
+
+namespace mapbox_variant_detail
+{
+
+  template <typename Variant>
+  struct variant_size {};
+
+  template <typename... VariantTypes>
+  struct variant_size<variant<VariantTypes...>> : public std::tuple_size<std::tuple<VariantTypes...>> {};
+
+  template<int N, class Variant, class ... Args, class Archive,
+           typename std::enable_if_t<N == variant_size<Variant>::value, int> = 0>
+  void load_variant(Archive &, int, Variant &) {
+    assert(false); // load_variant received an out of bounds index.
+  }
+
+  template<int N, class Variant, class H, class ... T, class Archive,
+           typename std::enable_if_t<N < variant_size<Variant>::value, int> = 0>
+  void load_variant(Archive & archive, int target, Variant & variant) {
+    // It can get extremely confusing figuring out which type is causing a variant
+    // to not be serializable, this static assert should help reveal the culprit.
+    static_assert(albatross::valid_input_serializer<H, Archive>::value,
+                  "Type is not serializable");
+    if(N == target) {
+      H value;
+      archive(cereal::make_nvp("data", value) );
+      variant = std::move(value);
+    } else {
+      load_variant<N+1, Variant, T...>(archive, target, variant);
+    }
+  }
+
+} // namespace variant_detail
+
+
+// This deleted function is here to make sure that rvalues of variants
+// can't be serialized, this prevents the compiler from thinking it
+// can convert a sub-type into a variant.  Ie, it prevents usage such
+// as:
+//     X x;
+//     save(archive, variant<X, Y>(x));
+// without this you'll see some pretty confusing cereal errors.
+template <class Archive, typename... VariantTypes>
+inline void save(Archive &archive, const variant<VariantTypes...> &&f,
+                                      const std::uint32_t) = delete;
+
+template <class Archive, typename... VariantTypes>
+inline void save(Archive &archive, const variant<VariantTypes...> &f,
+                                      const std::uint32_t) {
+
+  archive(cereal::make_nvp("which", f.which()));
+  f.match(
+      [&archive](const auto &x) {
+        archive(cereal::make_nvp("data", x));
+      }
+  );
+}
+
+template <class Archive, typename... VariantTypes>
+inline void load(Archive &archive, variant<VariantTypes...> &v,
+                                   const std::uint32_t) {
+  decltype(v.which()) which;
+  archive(cereal::make_nvp("which", which));
+  assert(which < static_cast<decltype(which)>(mapbox_variant_detail::variant_size<variant<VariantTypes...>>::value));
+  mapbox_variant_detail::load_variant<0, variant<VariantTypes...>, VariantTypes...>(archive, which, v);
+
+}
+
+}
+#endif /* INCLUDE_ALBATROSS_SRC_CEREAL_VARIANT_HPP_ */

--- a/include/albatross/src/cereal/variant.hpp
+++ b/include/albatross/src/cereal/variant.hpp
@@ -19,39 +19,38 @@
 
 namespace cereal {
 
-namespace mapbox_variant_detail
-{
+namespace mapbox_variant_detail {
 
-  template <typename Variant>
-  struct variant_size {};
+template <typename Variant> struct variant_size {};
 
-  template <typename... VariantTypes>
-  struct variant_size<variant<VariantTypes...>> : public std::tuple_size<std::tuple<VariantTypes...>> {};
+template <typename... VariantTypes>
+struct variant_size<variant<VariantTypes...>>
+    : public std::tuple_size<std::tuple<VariantTypes...>> {};
 
-  template<int N, class Variant, class ... Args, class Archive,
-           typename std::enable_if_t<N == variant_size<Variant>::value, int> = 0>
-  void load_variant(Archive &, int, Variant &) {
-    assert(false); // load_variant received an out of bounds index.
+template <int N, class Variant, class... Args, class Archive,
+          typename std::enable_if_t<N == variant_size<Variant>::value, int> = 0>
+void load_variant(Archive &, int, Variant &) {
+  assert(false); // load_variant received an out of bounds index.
+}
+
+template <
+    int N, class Variant, class H, class... T, class Archive,
+    typename std::enable_if_t<N<variant_size<Variant>::value, int> = 0> void
+        load_variant(Archive &archive, int target, Variant &variant) {
+  // It can get extremely confusing figuring out which type is causing a variant
+  // to not be serializable, this static assert should help reveal the culprit.
+  static_assert(albatross::valid_input_serializer<H, Archive>::value,
+                "Type is not serializable");
+  if (N == target) {
+    H value;
+    archive(cereal::make_nvp("data", value));
+    variant = std::move(value);
+  } else {
+    load_variant<N + 1, Variant, T...>(archive, target, variant);
   }
+}
 
-  template<int N, class Variant, class H, class ... T, class Archive,
-           typename std::enable_if_t<N < variant_size<Variant>::value, int> = 0>
-  void load_variant(Archive & archive, int target, Variant & variant) {
-    // It can get extremely confusing figuring out which type is causing a variant
-    // to not be serializable, this static assert should help reveal the culprit.
-    static_assert(albatross::valid_input_serializer<H, Archive>::value,
-                  "Type is not serializable");
-    if(N == target) {
-      H value;
-      archive(cereal::make_nvp("data", value) );
-      variant = std::move(value);
-    } else {
-      load_variant<N+1, Variant, T...>(archive, target, variant);
-    }
-  }
-
-} // namespace variant_detail
-
+} // namespace mapbox_variant_detail
 
 // This deleted function is here to make sure that rvalues of variants
 // can't be serialized, this prevents the compiler from thinking it
@@ -62,29 +61,25 @@ namespace mapbox_variant_detail
 // without this you'll see some pretty confusing cereal errors.
 template <class Archive, typename... VariantTypes>
 inline void save(Archive &archive, const variant<VariantTypes...> &&f,
-                                      const std::uint32_t) = delete;
+                 const std::uint32_t) = delete;
 
 template <class Archive, typename... VariantTypes>
 inline void save(Archive &archive, const variant<VariantTypes...> &f,
-                                      const std::uint32_t) {
+                 const std::uint32_t) {
 
   archive(cereal::make_nvp("which", f.which()));
-  f.match(
-      [&archive](const auto &x) {
-        archive(cereal::make_nvp("data", x));
-      }
-  );
+  f.match([&archive](const auto &x) { archive(cereal::make_nvp("data", x)); });
 }
 
 template <class Archive, typename... VariantTypes>
 inline void load(Archive &archive, variant<VariantTypes...> &v,
-                                   const std::uint32_t) {
-  decltype(v.which()) which;
+                 const std::uint32_t) {
+  int which;
   archive(cereal::make_nvp("which", which));
-  assert(which < static_cast<decltype(which)>(mapbox_variant_detail::variant_size<variant<VariantTypes...>>::value));
-  mapbox_variant_detail::load_variant<0, variant<VariantTypes...>, VariantTypes...>(archive, which, v);
-
+  assert(which < static_cast<int>(sizeof...(VariantTypes)));
+  mapbox_variant_detail::load_variant<0, variant<VariantTypes...>,
+                                      VariantTypes...>(archive, which, v);
 }
 
-}
+} // namespace cereal
 #endif /* INCLUDE_ALBATROSS_SRC_CEREAL_VARIANT_HPP_ */

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -13,6 +13,8 @@
 #ifndef ALBATROSS_CORE_DECLARATIONS_H
 #define ALBATROSS_CORE_DECLARATIONS_H
 
+using mapbox::util::variant;
+
 namespace Eigen {
 
 template <typename _Scalar, int SizeAtCompileTime>

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -13,8 +13,6 @@
 #ifndef ALBATROSS_COVARIANCE_FUNCTIONS_COVARIANCE_FUNCTION_H
 #define ALBATROSS_COVARIANCE_FUNCTIONS_COVARIANCE_FUNCTION_H
 
-using mapbox::util::variant;
-
 namespace albatross {
 
 template <typename X, typename Y> class SumOfCovarianceFunctions;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(albatross_unit_tests
   test_traits_covariance_functions.cc
   test_traits_evaluation.cc
   test_tune.cc
+  test_variant.cc
   )
 target_include_directories(albatross_unit_tests SYSTEM PRIVATE
   "${gtest_SOURCE_DIR}"

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -215,6 +215,28 @@ struct DatasetWithMetadata
   };
 };
 
+struct VariantAsInt : public SerializableType<variant<int, double>> {
+
+  RepresentationType create() const override {
+
+    variant<int, double> output;
+    int foo = 1;
+    output = foo;
+    return output;
+  }
+};
+
+struct VariantAsDouble : public SerializableType<variant<int, double>> {
+
+  RepresentationType create() const override {
+
+    variant<int, double> output;
+    double foo = 1.;
+    output = foo;
+    return output;
+  }
+};
+
 REGISTER_TYPED_TEST_CASE_P(SerializeTest, test_roundtrip_serialize_json,
                            test_roundtrip_serialize_binary);
 
@@ -224,7 +246,8 @@ typedef ::testing::Types<LDLT, ExplainedCovarianceRepresentation, EigenMatrix3d,
                          FullJointDistribution, MeanOnlyJointDistribution,
                          FullMarginalDistribution, MeanOnlyMarginalDistribution,
                          ParameterStoreType, Dataset, DatasetWithMetadata,
-                         SerializableType<MockModel>>
+                         SerializableType<MockModel>, VariantAsInt,
+                         VariantAsDouble>
     ToTest;
 
 INSTANTIATE_TYPED_TEST_CASE_P(Albatross, SerializeTest, ToTest);

--- a/tests/test_variant.cc
+++ b/tests/test_variant.cc
@@ -10,21 +10,23 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifndef ALBATROSS_CORE_H
-#define ALBATROSS_CORE_H
+#include <albatross/Common>
+#include <gtest/gtest.h>
 
-#include "Dataset"
+namespace albatross {
 
-#include <type_traits>
+TEST(test_variant, test_details) {
 
-#include "src/core/declarations.hpp"
-#include "src/core/indexing.hpp"
-#include "src/core/traits.hpp"
-#include "src/core/priors.hpp"
-#include "src/core/parameter_handling_mixin.hpp"
-#include "src/core/parameter_macros.hpp"
-#include "src/core/fit_model.hpp"
-#include "src/core/prediction.hpp"
-#include "src/core/model.hpp"
+  const auto one = cereal::mapbox_variant_detail::variant_size<variant<int>>::value;
+  EXPECT_EQ(one, 1);
 
-#endif
+  const auto two = cereal::mapbox_variant_detail::variant_size<variant<int, double>>::value;
+  EXPECT_EQ(two, 2);
+
+  struct X {};
+  const auto three = cereal::mapbox_variant_detail::variant_size<variant<int, double, X>>::value;
+  EXPECT_EQ(three, 3);
+
+}
+
+}

--- a/tests/test_variant.cc
+++ b/tests/test_variant.cc
@@ -17,16 +17,18 @@ namespace albatross {
 
 TEST(test_variant, test_details) {
 
-  const auto one = cereal::mapbox_variant_detail::variant_size<variant<int>>::value;
+  const auto one =
+      cereal::mapbox_variant_detail::variant_size<variant<int>>::value;
   EXPECT_EQ(one, 1);
 
-  const auto two = cereal::mapbox_variant_detail::variant_size<variant<int, double>>::value;
+  const auto two =
+      cereal::mapbox_variant_detail::variant_size<variant<int, double>>::value;
   EXPECT_EQ(two, 2);
 
   struct X {};
-  const auto three = cereal::mapbox_variant_detail::variant_size<variant<int, double, X>>::value;
+  const auto three = cereal::mapbox_variant_detail::variant_size<
+      variant<int, double, X>>::value;
   EXPECT_EQ(three, 3);
-
 }
 
-}
+} // namespace albatross


### PR DESCRIPTION
This let's you serialize `variant<X, Y>` assuming `X` and `Y` are serializable.