### PR TITLE
Fit With Multiple Datasets

### DIFF
--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -81,6 +81,26 @@ subset(const RegressionDataset<FeatureType> &dataset,
                                         subset(dataset.targets, indices));
 }
 
+template <typename X>
+inline auto concatenate_datasets(const RegressionDataset<X> &x,
+                                 const RegressionDataset<X> &y) {
+  const auto targets = concatenate_distributions({x.targets, y.targets});
+  std::vector<X> features(x.features);
+  features.insert(features.end(), y.features.begin(), y.features.end());
+  return RegressionDataset<X>(features, targets);
+}
+
+template <typename X, typename Y>
+inline auto concatenate_datasets(const RegressionDataset<X> &x,
+                                 const RegressionDataset<Y> &y) {
+  std::vector<variant<X, Y>> features(x.features.begin(), x.features.end());
+  for (const auto &fy : y.features) {
+    features.emplace_back(fy);
+  }
+  const auto targets = concatenate_marginals(x.targets, y.targets);
+  return RegressionDataset<variant<X, Y>>(features, targets);
+}
+
 } // namespace albatross
 
 #endif

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -13,6 +13,12 @@
 #ifndef ALBATROSS_CORE_DECLARATIONS_H
 #define ALBATROSS_CORE_DECLARATIONS_H
 
+namespace mapbox {
+namespace util {
+template <typename... Ts> class variant;
+}
+} // namespace mapbox
+
 using mapbox::util::variant;
 
 namespace Eigen {

--- a/include/albatross/src/core/distribution.hpp
+++ b/include/albatross/src/core/distribution.hpp
@@ -113,6 +113,25 @@ void set_subset(const Distribution<CovarianceType> &from,
   }
 }
 
+inline MarginalDistribution
+concatenate_marginals(const MarginalDistribution &x,
+                      const MarginalDistribution &y) {
+  Eigen::VectorXd mean(x.mean.size() + y.mean.size());
+  mean.block(0, 0, x.mean.size(), 1) = x.mean;
+  mean.block(x.mean.size(), 0, y.mean.size(), 1) = y.mean;
+
+  Eigen::VectorXd variance = Eigen::VectorXd::Zero(mean.size());
+  if (x.has_covariance()) {
+    variance.block(0, 0, x.mean.size(), 1) = x.covariance.diagonal();
+  }
+  if (y.has_covariance()) {
+    variance.block(x.mean.size(), 0, y.mean.size(), 1) =
+        y.covariance.diagonal();
+  }
+
+  return MarginalDistribution(mean, variance.asDiagonal());
+}
+
 } // namespace albatross
 
 #endif

--- a/include/albatross/src/core/model.hpp
+++ b/include/albatross/src/core/model.hpp
@@ -139,6 +139,12 @@ public:
     return _fit(dataset.features, dataset.targets);
   }
 
+  template <typename FeatureX, typename FeatureY>
+  auto fit(const RegressionDataset<FeatureX> &x,
+           const RegressionDataset<FeatureY> &y) const {
+    return fit(concatenate_datasets(x, y));
+  }
+
   CrossValidation<ModelType> cross_validate() const;
 
   template <typename Strategy>


### PR DESCRIPTION
This introduces a new method to `ModelBase` which let's you call:

 `model.fit(dataset_x, dataset_y)`

where the two datasets don't necessarily need to be the same type.  If they are the same type then it's equivalent to fitting with a concatenation of the features and targets.  If they are different types a new dataset is created with type `variant<X, Y>`.

This should let us do things like fit to a bunch of training data and apply pseudo-observation constraints to any other type.