### PR TITLE
Variant Forwarding Bug.

### DIFF
--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -65,6 +65,11 @@ public:
 
 HAS_METHOD(solve);
 
+template <typename T> struct is_variant : public std::false_type {};
+
+template <typename... Ts>
+struct is_variant<variant<Ts...>> : public std::true_type {};
+
 } // namespace albatross
 
 #endif

--- a/tests/test_variant.cc
+++ b/tests/test_variant.cc
@@ -10,13 +10,12 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <albatross/Common>
+#include <albatross/CovarianceFunctions>
 #include <gtest/gtest.h>
 
 namespace albatross {
 
 TEST(test_variant, test_details) {
-
   const auto one =
       cereal::mapbox_variant_detail::variant_size<variant<int>>::value;
   EXPECT_EQ(one, 1);
@@ -29,6 +28,15 @@ TEST(test_variant, test_details) {
   const auto three = cereal::mapbox_variant_detail::variant_size<
       variant<int, double, X>>::value;
   EXPECT_EQ(three, 3);
+}
+
+TEST(test_variant, test_variant_forwarder) {
+  EXPECT_TRUE(is_variant<variant<int>>::value);
+
+  bool int_double = is_variant<variant<int, double>>::value;
+  EXPECT_TRUE(int_double);
+  EXPECT_FALSE(is_variant<int>::value);
+  EXPECT_FALSE(is_variant<double>::value);
 }
 
 } // namespace albatross


### PR DESCRIPTION
Fix a bug in which the VariantForwarder recurrsively walked down the tree of covariance functions until it found one defined for all types in a variant.  This led to it ignoring several terms.

As a result of this change a `CovarianceFunction` can't be given a `_call_impl` which uses `variant` types.