### PR TITLE
Add BlockSymmetric

### DIFF
--- a/include/albatross/GP
+++ b/include/albatross/GP
@@ -18,6 +18,7 @@
 
 #include "src/evaluation/likelihood.hpp"
 #include "src/eigen/serializable_ldlt.hpp"
+#include "src/utils/block_utils.hpp"
 #include "src/covariance_functions/representations.hpp"
 #include "src/models/gp.hpp"
 

--- a/include/albatross/src/utils/block_utils.hpp
+++ b/include/albatross/src/utils/block_utils.hpp
@@ -65,8 +65,23 @@ struct BlockSymmetric {
    * use case is for a situation where you have a pre computed LDLT of
    * a submatrix (A) and you'd like to perform a solve of the larger
    * matrix (X)
+   *
+   * To do so the rules for block inversion are used:
+   *
+   * https://en.wikipedia.org/wiki/Block_matrix#Block_matrix_inversion
+   *
+   * which leads to:
+   *
+   *   X^-1 = |A   B|^-1
+   *          |B.T C|
+   *
+   *        = |A^-1 + Ai_B S^-1 Ai_B^T    -Ai_B S^-1|
+   *          |S^-1 Ai_B^T                    S^-1  |
+   *
+   * where Ai_B = A^-1 B  and S = C - B^T A^_1 B.
+   *
+   * In this particular implementation Ai_B and S^-1 are pre-computed.
    */
-
   BlockSymmetric(){};
 
   BlockSymmetric(const Eigen::SerializableLDLT &A_, const Eigen::MatrixXd &B_,
@@ -79,9 +94,6 @@ struct BlockSymmetric {
             A_, B_,
             Eigen::SerializableLDLT(C - B_.transpose() * A_.solve(B_))){};
 
-  /*
-   * https://en.wikipedia.org/wiki/Block_matrix#Block_matrix_inversion
-   */
   template <class _Scalar, int _Rows, int _Cols>
   Eigen::Matrix<_Scalar, _Rows, _Cols>
   solve(const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const;

--- a/tests/test_block_utils.cc
+++ b/tests/test_block_utils.cc
@@ -16,6 +16,8 @@
 
 #include <albatross/GP>
 
+#include "test_utils.h"
+
 namespace albatross {
 
 struct BlockExample {
@@ -109,10 +111,7 @@ TEST(test_block_utils, test_matrix_l) {
 
 TEST(test_block_utils, test_block_symmetric) {
 
-  Eigen::Index k = 5;
-  Eigen::MatrixXd X = Eigen::MatrixXd::Random(k, k);
-  X = X.transpose() * X;
-  X.diagonal() += 0.1 * Eigen::VectorXd::Ones(k);
+  const auto X = random_covariance_matrix(5);
 
   const Eigen::MatrixXd rhs = Eigen::MatrixXd::Random(X.cols(), 3);
   const Eigen::MatrixXd expected = X.ldlt().solve(rhs);

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -240,10 +240,8 @@ struct VariantAsDouble : public SerializableType<variant<int, double>> {
 struct BlockSymmetricMatrix : public SerializableType<BlockSymmetric> {
 
   RepresentationType create() const override {
-    Eigen::Index k = 5;
-    Eigen::MatrixXd X = Eigen::MatrixXd::Random(k, k);
-    X = X.transpose() * X;
-    X.diagonal() += 0.1 * Eigen::VectorXd::Ones(k);
+
+    const auto X = random_covariance_matrix(5);
 
     const Eigen::MatrixXd A = X.topLeftCorner(3, 3);
     const Eigen::MatrixXd B = X.topRightCorner(3, 2);

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -237,6 +237,23 @@ struct VariantAsDouble : public SerializableType<variant<int, double>> {
   }
 };
 
+struct BlockSymmetricMatrix : public SerializableType<BlockSymmetric> {
+
+  RepresentationType create() const override {
+    Eigen::Index k = 5;
+    Eigen::MatrixXd X = Eigen::MatrixXd::Random(k, k);
+    X = X.transpose() * X;
+    X.diagonal() += 0.1 * Eigen::VectorXd::Ones(k);
+
+    const Eigen::MatrixXd A = X.topLeftCorner(3, 3);
+    const Eigen::MatrixXd B = X.topRightCorner(3, 2);
+    const Eigen::MatrixXd C = X.bottomRightCorner(2, 2);
+
+    // Test when constructing from the actual blocks.
+    return BlockSymmetric(A.ldlt(), B, C);
+  }
+};
+
 REGISTER_TYPED_TEST_CASE_P(SerializeTest, test_roundtrip_serialize_json,
                            test_roundtrip_serialize_binary);
 
@@ -247,7 +264,7 @@ typedef ::testing::Types<LDLT, ExplainedCovarianceRepresentation, EigenMatrix3d,
                          FullMarginalDistribution, MeanOnlyMarginalDistribution,
                          ParameterStoreType, Dataset, DatasetWithMetadata,
                          SerializableType<MockModel>, VariantAsInt,
-                         VariantAsDouble>
+                         VariantAsDouble, BlockSymmetricMatrix>
     ToTest;
 
 INSTANTIATE_TYPED_TEST_CASE_P(Albatross, SerializeTest, ToTest);

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -163,6 +163,13 @@ inline auto random_spherical_points(std::size_t n = 10, double radius = 1.,
   return points;
 }
 
+inline auto random_covariance_matrix(Eigen::Index k = 5) {
+  Eigen::MatrixXd X = Eigen::MatrixXd::Random(k, k);
+  X = X.transpose() * X;
+  X.diagonal() += 0.1 * Eigen::VectorXd::Ones(k);
+  return X;
+}
+
 } // namespace albatross
 
 #endif


### PR DESCRIPTION
This adds an additional class to the existing block matrix utilities which allows you to invert a block symmetric matrix.

This should prove useful in a follow up PR in which I plan to add the ability to update a model which has already been fit.  Ie, consider the situation where you have a GP which has already been fit.  In that situation you have features `f` and a covariance matrix `A` for which the LDLT has already been computed.  This gives you:

```
 f] ~ N(0, A)
```
Now say you want to update the model to include new features `u`, you'd end up with something like:
```
 f]  ~ N(0, [A    B])
 u]         [B.T  C]
```
One way to do so would be to re-form the entire covariance matrix and compute the full LDLT, but this block matrix utility will let you re-use `A.ldlt()` to effeciently perform the resulting augmented solves required when using a GP to predict.