### PR TITLE
Expand BlockSymmetric

### DIFF
--- a/include/albatross/src/utils/block_utils.hpp
+++ b/include/albatross/src/utils/block_utils.hpp
@@ -52,7 +52,7 @@ struct BlockDiagonal {
   Eigen::MatrixXd toDense() const;
 };
 
-struct BlockSymmetric {
+template <typename Solver> struct BlockSymmetric {
 
   /*
    * Stores a covariance matrix which takes the form:
@@ -84,11 +84,11 @@ struct BlockSymmetric {
    */
   BlockSymmetric(){};
 
-  BlockSymmetric(const Eigen::SerializableLDLT &A_, const Eigen::MatrixXd &B_,
+  BlockSymmetric(const Solver &A_, const Eigen::MatrixXd &B_,
                  const Eigen::SerializableLDLT &S_)
       : A(A_), Ai_B(A_.solve(B_)), S(S_) {}
 
-  BlockSymmetric(const Eigen::SerializableLDLT &A_, const Eigen::MatrixXd &B_,
+  BlockSymmetric(const Solver &A_, const Eigen::MatrixXd &B_,
                  const Eigen::MatrixXd &C)
       : BlockSymmetric(
             A_, B_,
@@ -107,7 +107,7 @@ struct BlockSymmetric {
 
   Eigen::Index cols() const;
 
-  Eigen::SerializableLDLT A;
+  Solver A;
   Eigen::MatrixXd Ai_B;
   Eigen::SerializableLDLT S;
 };
@@ -239,9 +239,10 @@ inline Eigen::Index BlockDiagonal::cols() const {
  *
  */
 
+template <typename Solver>
 template <class _Scalar, int _Rows, int _Cols>
-inline Eigen::Matrix<_Scalar, _Rows, _Cols>
-BlockSymmetric::solve(const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
+inline Eigen::Matrix<_Scalar, _Rows, _Cols> BlockSymmetric<Solver>::solve(
+    const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
   // https://en.wikipedia.org/wiki/Block_matrix#Block_matrix_inversion
   Eigen::Index n = A.rows() + S.rows();
   assert(rhs.rows() == n);
@@ -261,19 +262,43 @@ BlockSymmetric::solve(const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
   return output;
 }
 
-inline bool BlockSymmetric::operator==(const BlockSymmetric &rhs) const {
+template <typename Solver>
+inline bool BlockSymmetric<Solver>::
+operator==(const BlockSymmetric &rhs) const {
   return (A == rhs.A && Ai_B == rhs.Ai_B && S == rhs.S);
 }
 
+template <typename Solver>
 template <typename Archive>
-inline void BlockSymmetric::serialize(Archive &archive, const std::uint32_t) {
+inline void BlockSymmetric<Solver>::serialize(Archive &archive,
+                                              const std::uint32_t) {
   archive(cereal::make_nvp("A", A), cereal::make_nvp("Ai_B", Ai_B),
           cereal::make_nvp("S", S));
 }
 
-inline Eigen::Index BlockSymmetric::rows() const { return A.rows() + S.rows(); }
+template <typename Solver>
+inline Eigen::Index BlockSymmetric<Solver>::rows() const {
+  return A.rows() + S.rows();
+}
 
-inline Eigen::Index BlockSymmetric::cols() const { return A.cols() + S.cols(); }
+template <typename Solver>
+inline Eigen::Index BlockSymmetric<Solver>::cols() const {
+  return A.cols() + S.cols();
+}
+
+template <typename Solver>
+BlockSymmetric<Solver> build_block_symmetric(const Solver &A,
+                                             const Eigen::MatrixXd &B,
+                                             const Eigen::SerializableLDLT &S) {
+  return BlockSymmetric<Solver>(A, B, S);
+}
+
+template <typename Solver>
+BlockSymmetric<Solver> build_block_symmetric(const Solver &A,
+                                             const Eigen::MatrixXd &B,
+                                             const Eigen::MatrixXd &C) {
+  return BlockSymmetric<Solver>(A, B, C);
+}
 
 } // namespace albatross
 

--- a/tests/test_block_utils.cc
+++ b/tests/test_block_utils.cc
@@ -121,13 +121,13 @@ TEST(test_block_utils, test_block_symmetric) {
   const Eigen::MatrixXd C = X.bottomRightCorner(2, 2);
 
   // Test when constructing from the actual blocks.
-  const auto block = BlockSymmetric(A.ldlt(), B, C);
+  const auto block = build_block_symmetric(A.ldlt(), B, C);
   const Eigen::MatrixXd actual = block.solve(rhs);
   EXPECT_TRUE(actual.isApprox(expected));
 
   // And again using a pre computed S
   const Eigen::MatrixXd S = C - B.transpose() * A.ldlt().solve(B);
-  const auto block_direct = BlockSymmetric(A.ldlt(), B, S.ldlt());
+  const auto block_direct = build_block_symmetric(A.ldlt(), B, S.ldlt());
   const Eigen::MatrixXd actual_direct = block_direct.solve(rhs);
   EXPECT_TRUE(actual_direct.isApprox(expected));
 }

--- a/tests/test_gp.cc
+++ b/tests/test_gp.cc
@@ -165,11 +165,9 @@ TEST(test_gp, test_update_model_trait) {
   using UpdatedFitType = typename updated_fit_type<FitModelType, int>::type;
   using ExpectedType =
       FitModel<decltype(model),
-               Fit<GPFit<BlockSymmetric, variant<double, int>>>>;
+               Fit<GPFit<BlockSymmetric<Eigen::SerializableLDLT>,
+                         variant<double, int>>>>;
 
-  std::cout << typeid(ExpectedType).name() << std::endl;
-  std::cout << "=====" << std::endl;
-  std::cout << typeid(UpdatedFitType).name() << std::endl;
   EXPECT_TRUE(bool(std::is_same<UpdatedFitType, ExpectedType>::value));
 }
 

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -237,7 +237,8 @@ struct VariantAsDouble : public SerializableType<variant<int, double>> {
   }
 };
 
-struct BlockSymmetricMatrix : public SerializableType<BlockSymmetric> {
+struct BlockSymmetricMatrix
+    : public SerializableType<BlockSymmetric<Eigen::SerializableLDLT>> {
 
   RepresentationType create() const override {
 
@@ -248,7 +249,7 @@ struct BlockSymmetricMatrix : public SerializableType<BlockSymmetric> {
     const Eigen::MatrixXd C = X.bottomRightCorner(2, 2);
 
     // Test when constructing from the actual blocks.
-    return BlockSymmetric(A.ldlt(), B, C);
+    return BlockSymmetric<Eigen::SerializableLDLT>(A.ldlt(), B, C);
   }
 };
 


### PR DESCRIPTION
Currently `BlockSymmetric` only works with an `Eigen::SerializableLDLT` type, but this templates the class to allow for anything with a `.solve()` method.