### PR TITLE
Scaling Function Fix

### DIFF
--- a/tests/test_scaling_function.cc
+++ b/tests/test_scaling_function.cc
@@ -147,4 +147,39 @@ TEST(test_scaling_functions, test_inference) {
   // that we made scaled observations of it.
   EXPECT_LE(fabs(state_estimate.mean()[0] - attenuation), 1e-2);
 }
+
+/*
+ * This test make sure (and illustrates how) we can perform inference
+ * on the unknown attenuation constant of the material in the test
+ * case described above.
+ */
+TEST(test_scaling_functions, test_operations) {
+  using Feature = double;
+
+  double attenuation = 3.14159;
+  double sigma = 0.01;
+
+  Constant constant(2 * attenuation);
+  Noise noise(sigma);
+
+  using TestScalingTerm = ScalingTerm<ObliquityScaling>;
+  TestScalingTerm scaling;
+
+  using IntNoise = IndependentNoise<int>;
+  IntNoise int_noise;
+  auto covariance_function = constant * scaling + int_noise;
+
+  double x = 0.;
+  double y = 1.;
+  int ix = 0;
+  int iy = 1;
+
+  std::cout << covariance_function(x, y) << std::endl;
+  std::cout << covariance_function(x, x) << std::endl;
+  std::cout << covariance_function(ix, iy) << std::endl;
+  std::cout << covariance_function(ix, ix) << std::endl;
+
+}
+
+
 } // namespace albatross

--- a/tests/test_scaling_function.cc
+++ b/tests/test_scaling_function.cc
@@ -148,38 +148,63 @@ TEST(test_scaling_functions, test_inference) {
   EXPECT_LE(fabs(state_estimate.mean()[0] - attenuation), 1e-2);
 }
 
+class DummyCovariance : public CovarianceFunction<DummyCovariance> {
+public:
+  template <typename X, typename Y>
+  double _call_impl(const X &x, const Y &y) const {
+    return 0.;
+  }
+};
+
 /*
  * This test make sure (and illustrates how) we can perform inference
  * on the unknown attenuation constant of the material in the test
  * case described above.
  */
 TEST(test_scaling_functions, test_operations) {
-  using Feature = double;
-
-  double attenuation = 3.14159;
   double sigma = 0.01;
-
-  Constant constant(2 * attenuation);
-  Noise noise(sigma);
 
   using TestScalingTerm = ScalingTerm<ObliquityScaling>;
   TestScalingTerm scaling;
 
-  using IntNoise = IndependentNoise<int>;
-  IntNoise int_noise;
-  auto covariance_function = constant * scaling + int_noise;
+  using DoubleNoise = IndependentNoise<double>;
+  DoubleNoise double_noise(sigma);
 
-  double x = 0.;
-  double y = 1.;
-  int ix = 0;
-  int iy = 1;
+  DummyCovariance dummy;
 
-  std::cout << covariance_function(x, y) << std::endl;
-  std::cout << covariance_function(x, x) << std::endl;
-  std::cout << covariance_function(ix, iy) << std::endl;
-  std::cout << covariance_function(ix, ix) << std::endl;
+  auto rhs_cov_func = double_noise * scaling + dummy;
 
+  double a = 0.;
+  double b = 1.;
+
+  struct X {};
+  struct Y {};
+
+  X x;
+  Y y;
+
+  EXPECT_EQ(rhs_cov_func(x, y), 0.);
+  EXPECT_EQ(rhs_cov_func(x, x), 0.);
+  EXPECT_EQ(rhs_cov_func(x, y), 0.);
+  EXPECT_EQ(rhs_cov_func(a, y), 0.);
+  EXPECT_EQ(rhs_cov_func(a, x), 0.);
+  EXPECT_EQ(rhs_cov_func(a, b), 0.);
+  EXPECT_GT(rhs_cov_func(a, a), 0.);
+
+  /*
+   * The scaling functions need to be defined differently
+   * for left hand side (LHS) and right hand side (RHS)
+   * products, so we test both.
+   */
+  auto lhs_cov_func = scaling * double_noise + dummy;
+
+  EXPECT_EQ(lhs_cov_func(x, y), 0.);
+  EXPECT_EQ(lhs_cov_func(x, x), 0.);
+  EXPECT_EQ(lhs_cov_func(x, y), 0.);
+  EXPECT_EQ(lhs_cov_func(a, y), 0.);
+  EXPECT_EQ(lhs_cov_func(a, x), 0.);
+  EXPECT_EQ(lhs_cov_func(a, b), 0.);
+  EXPECT_GT(lhs_cov_func(a, a), 0.);
 }
-
 
 } // namespace albatross


### PR DESCRIPTION
The `ScalingFunction` is a helper to optionally scale the covariance depending on the types involved.  For example, you may have some latent variable, then make observations of it which are in different units, or some other linear transformation.  This might end up looking like:

```
LatentCovariance latent;
ScalingTerm<Scaling> scaler;

auto prod = scaler * latent;
```

With most covariance operations a product results in the following logic.  If two covariance functions, `x` and `y` are defined then their product, `cov = x * y`, evaluated for types `A` and `B` will be:

```
if x(a, b) and y(a, b) are defined:
  cov(a, b) = x(a, b) * y(a, b)
if only x(a, b) is defined:
  cov(a, b) = x(a, b)
if only y(a, b) is defined:
  cov(a, b) = y(a, b)
if neither x(a, b) or y(a, b) are defined:
  cov(a, b) = undefined
```
When a scaling function is involved, we want slightly different logic.  Namely we want the resulting covariance to only be defined if the term it's scaling is defined.  Consider for example if `latent` is not defined for some types, but `scaler` is.  We don't want the result of evaluating `prod` to be equal to the scale factor.  As a result we had to add two specialization of the covariance products.  One in which a scaling term is applied on the left and another when it's applied on the right.

