### PR TITLE
VariantCaller can use variants of differing types.

### DIFF
--- a/include/albatross/src/covariance_functions/callers.hpp
+++ b/include/albatross/src/covariance_functions/callers.hpp
@@ -217,14 +217,14 @@ template <typename SubCaller> struct VariantForwarder {
     return apply_visitor(visitor, x);
   }
 
-  // Deals with two identical variants.
-  template <typename CovFunc, typename... Ts,
+  // Deals with two variants.
+  template <typename CovFunc, typename... Xs, typename... Ys,
             typename std::enable_if<
-                has_valid_cov_caller<CovFunc, SubCaller, variant<Ts...>,
-                                     variant<Ts...>>::value,
+                has_valid_cov_caller<CovFunc, SubCaller, variant<Xs...>,
+                                     variant<Ys...>>::value,
                 int>::type = 0>
-  static double call(const CovFunc &cov_func, const variant<Ts...> &x,
-                     const variant<Ts...> &y) {
+  static double call(const CovFunc &cov_func, const variant<Xs...> &x,
+                     const variant<Ys...> &y) {
     return x.match(
         [&y, &cov_func](const auto &xx) { return call(cov_func, xx, y); });
   }

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -101,10 +101,14 @@ struct has_valid_caller_for_all_variants<U, Caller, variant<A, Ts...>> {
  * A specialization of has_valid_cov_caller for variants in which
  * the call is valid if all the types involved are valid.
  */
-template <typename CovFunc, typename Caller, typename... Ts>
-struct has_valid_cov_caller<CovFunc, Caller, variant<Ts...>, variant<Ts...>>
-    : public has_valid_caller_for_all_variants<CovFunc, Caller,
-                                               variant<Ts...>> {};
+template <typename CovFunc, typename Caller, typename... Ts, typename... Ys>
+struct has_valid_cov_caller<CovFunc, Caller, variant<Ts...>, variant<Ys...>> {
+  static constexpr bool value =
+      (has_valid_caller_for_all_variants<CovFunc, Caller,
+                                         variant<Ts...>>::value &&
+       has_valid_caller_for_all_variants<CovFunc, Caller,
+                                         variant<Ys...>>::value);
+};
 
 /*
  * A specialization of has_valid_cross_cov_caller in which all variant

--- a/tests/test_callers.cc
+++ b/tests/test_callers.cc
@@ -144,6 +144,17 @@ TEST(test_callers, test_variant_caller_XYW) {
   expect_symmetric_calls_true<VariantCaller, VariantXYW, VariantXYW>();
 }
 
+/*
+ * This Makes sure you can call with variants of different types.
+ */
+TEST(test_callers, test_variant_caller_XYW_XY) {
+  using VariantCaller = internal::VariantForwarder<
+      internal::SymmetricCaller<internal::DirectCaller>>;
+
+  expect_symmetric_calls_true<VariantCaller, VariantXYW, VariantXY>();
+  expect_symmetric_calls_true<VariantCaller, VariantXY, VariantXYW>();
+}
+
 template <typename T>
 using VariantWithMeasurement =
     typename VariantOrRaw<T, variant<Measurement<X>, Y>>::type;


### PR DESCRIPTION
This changes the behavior of the `VariantCaller` to allow for two pairs of variants which have differing types.  This is allowed only when all types involved have a valid covariance method, but they need not have cross covariance.

For example, for a covriance function with the following mtehods:
```
Example : public CovarianceFunction<Example> {
  double _call_impl(const X&, const X&) const;
  double _call_impl(const X&, const Y&) const;
  double _call_impl(const Y&, const Y&) const;
  double _call_impl(const W&, const W&) const;
}
```
The following pairs of argument types would be acceptable:
```
X, X
X, Y
Y, Y
W, W
variant<X, Y>, variant<X, Y>
variant<X, Y>, variant<Y, X>
variant<X, Y>, variant<X, Y, W>
variant<X>, variant<X, Y, W>
variant<X, W, Y>, variant<W, X, Y>
...
```
The key point being that even though the `W` and `Y` cross covariance isn't defined variants containing those pairs will be, but will evaluate to `0`.