### PR TITLE
Compiler Hints

### DIFF
--- a/include/albatross/src/evaluation/folds.hpp
+++ b/include/albatross/src/evaluation/folds.hpp
@@ -70,10 +70,10 @@ struct LeaveOneOut {
  * Leave One Group Out
  */
 
-template <typename FeatureType>
+template <typename FeatureType, typename GetFolds>
 static inline FoldIndexer
 leave_one_group_out_indexer(const std::vector<FeatureType> &features,
-                            GroupFunction<FeatureType> get_group_name) {
+                            const GetFolds &get_group_name) {
   FoldIndexer groups;
   for (std::size_t i = 0; i < features.size(); i++) {
     const std::string k = get_group_name(features[i]);

--- a/include/albatross/src/evaluation/folds.hpp
+++ b/include/albatross/src/evaluation/folds.hpp
@@ -70,10 +70,10 @@ struct LeaveOneOut {
  * Leave One Group Out
  */
 
-template <typename FeatureType, typename GetFolds>
+template <typename FeatureType, typename GetGroupName>
 static inline FoldIndexer
 leave_one_group_out_indexer(const std::vector<FeatureType> &features,
-                            const GetFolds &get_group_name) {
+                            const GetGroupName &get_group_name) {
   FoldIndexer groups;
   for (std::size_t i = 0; i < features.size(); i++) {
     const std::string k = get_group_name(features[i]);

--- a/include/albatross/src/utils/block_utils.hpp
+++ b/include/albatross/src/utils/block_utils.hpp
@@ -247,8 +247,8 @@ inline Eigen::Matrix<_Scalar, _Rows, _Cols> BlockSymmetric<Solver>::solve(
   Eigen::Index n = A.rows() + S.rows();
   assert(rhs.rows() == n);
 
-  const auto rhs_a = rhs.topRows(A.rows());
-  const auto rhs_b = rhs.bottomRows(S.rows());
+  const Eigen::MatrixXd rhs_a = rhs.topRows(A.rows());
+  const Eigen::MatrixXd rhs_b = rhs.bottomRows(S.rows());
 
   const auto Bt_Ai_rhs = Ai_B.transpose() * rhs_a;
 


### PR DESCRIPTION
This fixes two situations where the compiler erroneously resolves types.

In the first situation a lambda function can't be passed in as `GrouperFunction<>` since lambdas with captures aren't convertible to function pointers.  This is fixed by using a template parameter to catch anything that is callable.

In the second situation an `Eigen::Block<...>` type is passed around, but we want it to be an `Eigen::MatrixXd` in order to be compatible with the `.solve()` methods of our covariance respresentations.  A full fix would involve allowing the `.solve` methods to work with blocks, for now we simply enforce the variable in question stays a matrix.