### PR TITLE
Improve SparseGaussianProcess

### DIFF
--- a/include/albatross/src/covariance_functions/representations.hpp
+++ b/include/albatross/src/covariance_functions/representations.hpp
@@ -88,8 +88,40 @@ struct ExplainedCovariance {
             cereal::make_nvp("inner", inner));
   }
 
+  Eigen::Index rows() const { return inner.rows(); }
+
+  Eigen::Index cols() const { return inner.cols(); }
+
   Eigen::SerializableLDLT outer_ldlt;
   Eigen::MatrixXd inner;
+};
+
+/*
+ * Simply stores a pre-computed inverse.
+ */
+struct DirectInverse {
+  DirectInverse(){};
+
+  DirectInverse(const Eigen::MatrixXd &inverse) : inverse_(inverse){};
+
+  Eigen::MatrixXd solve(const Eigen::MatrixXd &rhs) const {
+    return inverse_ * rhs;
+  }
+
+  bool operator==(const DirectInverse &rhs) const {
+    return (inverse_ == rhs.inverse_);
+  }
+
+  template <typename Archive>
+  void serialize(Archive &archive, const std::uint32_t) {
+    archive(cereal::make_nvp("inverse", inverse_));
+  }
+
+  Eigen::Index rows() const { return inverse_.rows(); }
+
+  Eigen::Index cols() const { return inverse_.cols(); }
+
+  Eigen::MatrixXd inverse_;
 };
 
 } // namespace albatross

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -234,7 +234,8 @@ public:
   std::string pretty_string() const {
     std::ostringstream ss;
     ss << "model_name: " << get_name() << std::endl;
-    ss << "covariance_name: " << covariance_function_.pretty_string();
+    ss << "covariance_name: " << covariance_function_.get_name() << std::endl;
+    ss << "params: " << pretty_params(impl().get_params());
     return ss.str();
   }
 

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -231,7 +231,7 @@ public:
     const auto A_llt = A.llt();
     Eigen::MatrixXd Pt = P.transpose();
     const auto A_sqrt = A_llt.matrixL();
-    Eigen::MatrixXd RtR = A_sqrt.llt().solve(Pt);
+    Eigen::MatrixXd RtR = A_sqrt.solve(Pt);
     RtR = RtR.transpose() * RtR;
     const Eigen::MatrixXd B = Eigen::MatrixXd::Identity(m, m) + RtR;
 

--- a/tests/test_block_utils.cc
+++ b/tests/test_block_utils.cc
@@ -97,7 +97,7 @@ TEST(test_block_utils, test_matrix_l) {
 
   Eigen::MatrixXd rhs = Eigen::MatrixXd::Random(dense.cols(), 3);
   const auto block_llt = block_diag.llt();
-  BlockDiagonal block_l_val = block_llt.matrixL();
+  const auto block_l_val = block_llt.matrixL();
   const auto block_result = block_l_val * rhs;
   Eigen::MatrixXd block_l = block_l_val.toDense();
 
@@ -107,6 +107,10 @@ TEST(test_block_utils, test_matrix_l) {
 
   EXPECT_LE((block_l - dense_l).norm(), 1e-6);
   EXPECT_LE((block_result - dense_result).norm(), 1e-6);
+
+  EXPECT_LE((block_l_val.solve(rhs) - dense_l.colPivHouseholderQr().solve(rhs))
+                .norm(),
+            1e-6);
 }
 
 TEST(test_block_utils, test_block_symmetric) {

--- a/tests/test_scaling_function.cc
+++ b/tests/test_scaling_function.cc
@@ -148,7 +148,7 @@ TEST(test_scaling_functions, test_inference) {
   EXPECT_LE(fabs(state_estimate.mean()[0] - attenuation), 1e-2);
 }
 
-class DummyCovariance : public CovarianceFunction<DummyCovariance> {
+class ZeroCovariance : public CovarianceFunction<ZeroCovariance> {
 public:
   template <typename X, typename Y>
   double _call_impl(const X &x, const Y &y) const {
@@ -170,9 +170,9 @@ TEST(test_scaling_functions, test_operations) {
   using DoubleNoise = IndependentNoise<double>;
   DoubleNoise double_noise(sigma);
 
-  DummyCovariance dummy;
+  ZeroCovariance zero;
 
-  auto rhs_cov_func = double_noise * scaling + dummy;
+  auto rhs_cov_func = double_noise * scaling + zero;
 
   double a = 0.;
   double b = 1.;
@@ -183,12 +183,12 @@ TEST(test_scaling_functions, test_operations) {
   X x;
   Y y;
 
-  EXPECT_EQ(rhs_cov_func(x, y), 0.);
-  EXPECT_EQ(rhs_cov_func(x, x), 0.);
-  EXPECT_EQ(rhs_cov_func(x, y), 0.);
-  EXPECT_EQ(rhs_cov_func(a, y), 0.);
-  EXPECT_EQ(rhs_cov_func(a, x), 0.);
-  EXPECT_EQ(rhs_cov_func(a, b), 0.);
+  EXPECT_DOUBLE_EQ(rhs_cov_func(x, y), 0.);
+  EXPECT_DOUBLE_EQ(rhs_cov_func(x, x), 0.);
+  EXPECT_DOUBLE_EQ(rhs_cov_func(x, y), 0.);
+  EXPECT_DOUBLE_EQ(rhs_cov_func(a, y), 0.);
+  EXPECT_DOUBLE_EQ(rhs_cov_func(a, x), 0.);
+  EXPECT_DOUBLE_EQ(rhs_cov_func(a, b), 0.);
   EXPECT_GT(rhs_cov_func(a, a), 0.);
 
   /*
@@ -196,14 +196,14 @@ TEST(test_scaling_functions, test_operations) {
    * for left hand side (LHS) and right hand side (RHS)
    * products, so we test both.
    */
-  auto lhs_cov_func = scaling * double_noise + dummy;
+  auto lhs_cov_func = scaling * double_noise + zero;
 
-  EXPECT_EQ(lhs_cov_func(x, y), 0.);
-  EXPECT_EQ(lhs_cov_func(x, x), 0.);
-  EXPECT_EQ(lhs_cov_func(x, y), 0.);
-  EXPECT_EQ(lhs_cov_func(a, y), 0.);
-  EXPECT_EQ(lhs_cov_func(a, x), 0.);
-  EXPECT_EQ(lhs_cov_func(a, b), 0.);
+  EXPECT_DOUBLE_EQ(lhs_cov_func(x, y), 0.);
+  EXPECT_DOUBLE_EQ(lhs_cov_func(x, x), 0.);
+  EXPECT_DOUBLE_EQ(lhs_cov_func(x, y), 0.);
+  EXPECT_DOUBLE_EQ(lhs_cov_func(a, y), 0.);
+  EXPECT_DOUBLE_EQ(lhs_cov_func(a, x), 0.);
+  EXPECT_DOUBLE_EQ(lhs_cov_func(a, b), 0.);
   EXPECT_GT(lhs_cov_func(a, a), 0.);
 }
 


### PR DESCRIPTION
Fixes a bug in SparseGaussianProcess in which the inverse square root of a
block diagonal matrix was required, but was done by taking:
```
  A.llt().matrixL().ldlt().solve()
```
which isn't a valid operation since the LDLT of a lower triangular matrix isn't well defined.  This is fixed by adding a `solve()` method for block triangular matrices.

It also improves the numerical stability by preferring the inverse of `I + R.T R` instead of `R.T R`, which is done by introducing a `DirectSolver`.

And also adds two new parameters to the sparse GP, a nugget for the measurement and for the inducing points.  The measurement nugget is required for situations where the observations are fully (or nearly so) defined by the inducing points.  In this situation the `A` matrix will be zero, the nugget ensures a positive diagonal.  Similarly the inducing point nugget ensures that the prior for the inducing points `K_uu` is positive definite by adding to its diagonal.