### PR TITLE
Log Transformation of Priors While Tuning

### DIFF
--- a/include/albatross/src/core/parameter_handling_mixin.hpp
+++ b/include/albatross/src/core/parameter_handling_mixin.hpp
@@ -15,6 +15,10 @@
 
 namespace albatross {
 
+constexpr double PARAMETER_EPSILON =
+    std::numeric_limits<ParameterValue>::epsilon();
+constexpr double PARAMETER_MAX = std::numeric_limits<ParameterValue>::max();
+
 struct TunableParameters {
   std::vector<double> values;
   std::vector<double> lower_bounds;

--- a/include/albatross/src/core/priors.hpp
+++ b/include/albatross/src/core/priors.hpp
@@ -32,6 +32,7 @@ public:
   virtual std::string get_name() const = 0;
   virtual double lower_bound() const { return -LARGE_VAL; }
   virtual double upper_bound() const { return LARGE_VAL; }
+  virtual bool is_log_scale() const { return false; };
   virtual bool is_fixed() const { return false; }
   virtual bool operator==(const Prior &other) const {
     return typeid(*this) == typeid(other);
@@ -115,9 +116,31 @@ public:
             cereal::make_nvp("upper", upper_));
   }
 
-private:
+protected:
   double lower_;
   double upper_;
+};
+
+class LogScaleUniformPrior : public UniformPrior {
+public:
+  LogScaleUniformPrior(double lower = 1e-12, double upper = 1.e12)
+      : UniformPrior(lower, upper) {
+    assert(upper_ > 0.);
+    assert(lower_ > 0.);
+  };
+
+  std::string get_name() const override {
+    std::ostringstream oss;
+    oss << "log_scale_uniform[" << lower_ << "," << upper_ << "]";
+    return oss.str();
+  };
+
+  template <typename Archive>
+  void serialize(Archive &archive, const std::uint32_t) {
+    archive(cereal::base_class<UniformPrior>(this));
+  }
+
+  bool is_log_scale() const override { return true; };
 };
 
 class GaussianPrior : public Prior {
@@ -201,6 +224,7 @@ CEREAL_REGISTER_TYPE(albatross::PositivePrior);
 CEREAL_REGISTER_TYPE(albatross::NonNegativePrior);
 CEREAL_REGISTER_TYPE(albatross::FixedPrior);
 CEREAL_REGISTER_TYPE(albatross::UniformPrior);
+CEREAL_REGISTER_TYPE(albatross::LogScaleUniformPrior);
 CEREAL_REGISTER_TYPE(albatross::GaussianPrior);
 CEREAL_REGISTER_TYPE(albatross::LogNormalPrior);
 

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -137,9 +137,11 @@ public:
 
   void initialize_params() {
     measurement_nugget_ = {details::DEFAULT_NUGGET,
-                           std::make_shared<NonNegativePrior>()};
+                           std::make_shared<LogScaleUniformPrior>(
+                               PARAMETER_EPSILON, PARAMETER_MAX)};
     inducing_nugget_ = {details::DEFAULT_NUGGET,
-                        std::make_shared<NonNegativePrior>()};
+                        std::make_shared<LogScaleUniformPrior>(
+                            PARAMETER_EPSILON, PARAMETER_MAX)};
   }
 
   ParameterStore get_params() const override {

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -17,8 +17,8 @@ namespace albatross {
 
 namespace details {
 constexpr double DEFAULT_NUGGET = 1e-12;
-const std::string log_measurement_nugget_name = "log_measurement_nugget";
-const std::string log_inducing_nugget_name = "log_inducing_nugget";
+const std::string measurement_nugget_name = "measurement_nugget";
+const std::string inducing_nugget_name = "inducing_nugget";
 } // namespace details
 
 template <typename CovFunc, typename InducingPointStrategy,
@@ -136,16 +136,16 @@ public:
   };
 
   void initialize_params() {
-    log_measurement_nugget_ = {log10(details::DEFAULT_NUGGET),
-                               std::make_shared<UninformativePrior>()};
-    log_inducing_nugget_ = {log10(details::DEFAULT_NUGGET),
-                            std::make_shared<UninformativePrior>()};
+    measurement_nugget_ = {details::DEFAULT_NUGGET,
+                           std::make_shared<NonNegativePrior>()};
+    inducing_nugget_ = {details::DEFAULT_NUGGET,
+                        std::make_shared<NonNegativePrior>()};
   }
 
   ParameterStore get_params() const override {
     auto params = this->covariance_function_.get_params();
-    params[details::log_measurement_nugget_name] = log_measurement_nugget_;
-    params[details::log_inducing_nugget_name] = log_inducing_nugget_;
+    params[details::measurement_nugget_name] = measurement_nugget_;
+    params[details::inducing_nugget_name] = inducing_nugget_;
     return params;
   }
 
@@ -153,10 +153,10 @@ public:
                            const Parameter &param) override {
     if (map_contains(this->covariance_function_.get_params(), name)) {
       this->covariance_function_.set_param(name, param);
-    } else if (name == details::log_measurement_nugget_name) {
-      log_measurement_nugget_ = param;
-    } else if (name == details::log_inducing_nugget_name) {
-      log_inducing_nugget_ = param;
+    } else if (name == details::measurement_nugget_name) {
+      measurement_nugget_ = param;
+    } else if (name == details::inducing_nugget_name) {
+      inducing_nugget_ = param;
     } else {
       std::cerr << "Unknown param: " << name << std::endl;
       assert(false);
@@ -202,8 +202,8 @@ public:
     const Eigen::MatrixXd K_fu = this->covariance_function_(features, u);
     Eigen::MatrixXd K_uu = this->covariance_function_(u);
 
-    double inducing_nugget = pow(10., log_inducing_nugget_.value);
-    K_uu.diagonal() += inducing_nugget * Eigen::VectorXd::Ones(K_uu.rows());
+    K_uu.diagonal() +=
+        inducing_nugget_.value * Eigen::VectorXd::Ones(K_uu.rows());
 
     const auto K_uu_llt = K_uu.llt();
     // P is such that:
@@ -227,8 +227,8 @@ public:
     // some of the data, in which case we need to add a bit of extra
     // noise to make sure lambda is invertible.
     for (auto &b : A.blocks) {
-      double meas_nugget = pow(10., log_measurement_nugget_.value);
-      b.diagonal() += meas_nugget * Eigen::VectorXd::Ones(b.rows());
+      b.diagonal() +=
+          measurement_nugget_.value * Eigen::VectorXd::Ones(b.rows());
     }
 
     /*
@@ -291,8 +291,8 @@ public:
     return Fit<GPFit<DirectInverse, InducingPointFeatureType>>(u, solver, v);
   }
 
-  Parameter log_measurement_nugget_;
-  Parameter log_inducing_nugget_;
+  Parameter measurement_nugget_;
+  Parameter inducing_nugget_;
   InducingPointStrategy inducing_point_strategy;
   IndexingFunction independent_group_indexing_function;
 };

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -49,14 +49,14 @@ void expect_sparse_gp_performance(const CovFunc &covariance,
   UniformlySpacedInducingPoints strategy(8);
   auto sparse =
       sparse_gp_from_covariance(covariance, strategy, indexer, "sparse");
-  sparse.set_param(details::log_inducing_nugget_name, -3.);
-  sparse.set_param(details::log_measurement_nugget_name, -12.);
+  sparse.set_param(details::inducing_nugget_name, 1e-3);
+  sparse.set_param(details::measurement_nugget_name, 1e-12);
 
   UniformlySpacedInducingPoints bad_strategy(3);
   auto really_sparse = sparse_gp_from_covariance(covariance, bad_strategy,
                                                  indexer, "really_sparse");
-  really_sparse.set_param(details::log_inducing_nugget_name, -3.);
-  really_sparse.set_param(details::log_measurement_nugget_name, -12.);
+  really_sparse.set_param(details::inducing_nugget_name, 1e-3);
+  really_sparse.set_param(details::measurement_nugget_name, 1e-12);
 
   auto direct_fit = direct.fit(dataset);
   auto sparse_fit = sparse.fit(dataset);


### PR DESCRIPTION
This adds a `LogUniformPrior` which lets you specify the bounds of a uniform prior which is subsequently explored in log space while tuning.

The nugget parameters in the sparse gaussian process were then reverted to non-log scale with the expectation that if a log scale is required (for tuning) the user can manually set the prior.