### PR TITLE
Avoid an assert and add a ForwardDeclarations include

### DIFF
--- a/include/albatross/Common
+++ b/include/albatross/Common
@@ -23,9 +23,7 @@
 
 #include <math.h>
 #include <iomanip>
-#include <map>
 #include <set>
-#include <string>
 #include <iostream>
 #include <unordered_map>
 #include <functional>
@@ -34,7 +32,7 @@
 #include <numeric>
 #include <random>
 
-#include <albatross/src/core/declarations.hpp>
+#include "ForwardDeclarations"
 
 #include <albatross/src/details/traits.hpp>
 #include <albatross/src/details/has_any_macros.hpp>

--- a/include/albatross/ForwardDeclarations
+++ b/include/albatross/ForwardDeclarations
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_FORWARD_DECLARATIONS_H
+#define ALBATROSS_FORWARD_DECLARATIONS_H
+
+#include <map>
+#include <string>
+
+#include <Eigen/src/Core/util/ForwardDeclarations.h>
+
+#include <albatross/src/core/declarations.hpp>
+
+#endif

--- a/include/albatross/src/core/parameter_handling_mixin.hpp
+++ b/include/albatross/src/core/parameter_handling_mixin.hpp
@@ -142,10 +142,29 @@ public:
     }
   }
 
+  void set_params_if_exists(const ParameterStore &params) {
+    const ParameterStore current_params = get_params();
+    for (const auto &pair : params) {
+      if (map_contains(current_params, pair.first)) {
+        unchecked_set_param(pair.first, pair.second);
+      }
+    }
+  }
+
   void set_param_values(const std::map<ParameterKey, ParameterValue> &values) {
     for (const auto &pair : values) {
       check_param_key(pair.first);
       unchecked_set_param(pair.first, pair.second);
+    }
+  }
+
+  void set_param_values_if_exists(
+      const std::map<ParameterKey, ParameterValue> &values) {
+    const ParameterStore current_params = get_params();
+    for (const auto &pair : values) {
+      if (map_contains(current_params, pair.first)) {
+        unchecked_set_param(pair.first, pair.second);
+      }
     }
   }
 
@@ -247,14 +266,13 @@ public:
         }
 
         const double lb = pair.second.prior.lower_bound();
-        const double ub = pair.second.prior.upper_bound();
-
-        // this silly diversion is to make lint think lb and ub get used;
         if (v < lb) {
-          assert(false);
+          v = lb;
         };
+
+        const double ub = pair.second.prior.upper_bound();
         if (v > ub) {
-          assert(false);
+          v = ub;
         };
 
         unchecked_set_param(pair.first, v);


### PR DESCRIPTION
A few minor changes which:
- Avoid hard failures during tuning by removing an assert.  If an assert is still desired that *could* be manually enforced by first getting the tuning parameters, then hard enforcing the bounds externally.
- Allow setting a set of parameters which don't neccesarily overlap.  Putting this inside the `ParameterHandlingMixin` instead of in user code makes it a bit more efficient since there's access to `unchecked_set_param`.
- Add an include target for `ForwardDeclarations`, `CsvUtils` and `MapUtils`