### PR TITLE
Null Model

### DIFF
--- a/include/albatross/NullModel
+++ b/include/albatross/NullModel
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_NULL_MODEL_H
+#define ALBATROSS_NULL_MODEL_H
+
+#include "Core"
+
+#include <albatross/src/models/null_model.hpp>
+
+#endif

--- a/include/albatross/src/models/null_model.hpp
+++ b/include/albatross/src/models/null_model.hpp
@@ -64,9 +64,9 @@ public:
   _predict_impl(const std::vector<FeatureType> &features,
                 const Fit<NullModel> &fit,
                 PredictTypeIdentity<JointDistribution> &&) const {
-    const Eigen::Index en = static_cast<Eigen::Index>(features.size());
-    const Eigen::VectorXd mean = Eigen::VectorXd::Zero(en);
-    const Eigen::MatrixXd cov = 1.e4 * Eigen::MatrixXd::Identity(en, en);
+    const Eigen::Index n = static_cast<Eigen::Index>(features.size());
+    const Eigen::VectorXd mean = Eigen::VectorXd::Zero(n);
+    const Eigen::MatrixXd cov = 1.e4 * Eigen::MatrixXd::Identity(n, n);
     return JointDistribution(mean, cov);
   }
 

--- a/include/albatross/src/models/null_model.hpp
+++ b/include/albatross/src/models/null_model.hpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_SRC_MODELS_NULL_MODEL_HPP_
+#define ALBATROSS_SRC_MODELS_NULL_MODEL_HPP_
+
+namespace albatross {
+
+class NullModel;
+
+template <> struct Fit<NullModel> {
+  template <typename Archive>
+  void serialize(Archive &archive, const std::uint32_t){};
+
+  bool operator==(const Fit<NullModel> &other) const { return true; }
+};
+
+class NullModel : public ModelBase<NullModel> {
+
+public:
+  NullModel(){};
+  NullModel(const ParameterStore &param_store) : params_(param_store){};
+
+  std::string get_name() const { return "null_model"; };
+
+  /*
+   * The Gaussian Process Regression model derives its parameters from
+   * the covariance functions.
+   */
+  ParameterStore get_params() const override { return params_; }
+
+  void unchecked_set_param(const std::string &name,
+                           const Parameter &param) override {
+    params_[name] = param;
+  }
+
+  // If the implementing class doesn't have a fit method for this
+  // FeatureType but the CovarianceFunction does.
+  template <typename FeatureType>
+  Fit<NullModel> _fit_impl(const std::vector<FeatureType> &features,
+                           const MarginalDistribution &targets) const {
+    return {};
+  }
+
+  template <typename FeatureType>
+  auto fit_from_prediction(const std::vector<FeatureType> &features,
+                           const JointDistribution &prediction) const {
+    const NullModel m(*this);
+    FitModel<NullModel, Fit<NullModel>> fit_model(m, Fit<NullModel>());
+    return fit_model;
+  }
+
+  template <typename FeatureType>
+  JointDistribution
+  _predict_impl(const std::vector<FeatureType> &features,
+                const Fit<NullModel> &fit,
+                PredictTypeIdentity<JointDistribution> &&) const {
+    const Eigen::Index en = static_cast<Eigen::Index>(features.size());
+    const Eigen::VectorXd mean = Eigen::VectorXd::Zero(en);
+    const Eigen::MatrixXd cov = 1.e4 * Eigen::MatrixXd::Identity(en, en);
+    return JointDistribution(mean, cov);
+  }
+
+  template <typename FeatureType>
+  MarginalDistribution
+  _predict_impl(const std::vector<FeatureType> &features,
+                const Fit<NullModel> &fit,
+                PredictTypeIdentity<MarginalDistribution> &&) const {
+    const Eigen::Index en = static_cast<Eigen::Index>(features.size());
+    const Eigen::VectorXd mean = Eigen::VectorXd::Zero(en);
+    const Eigen::VectorXd diag = 1.e4 * Eigen::VectorXd::Ones(en);
+    return MarginalDistribution(mean, diag.asDiagonal());
+  }
+
+private:
+  ParameterStore params_;
+};
+
+} // namespace albatross
+
+#endif /* THIRD_PARTY_ALBATROSS_INCLUDE_ALBATROSS_SRC_MODELS_NULL_MODEL_HPP_   \
+        */

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -42,7 +42,7 @@ TEST(test_cross_validation, test_fold_creation) {
 
 bool is_monotonic_increasing(const Eigen::VectorXd &x) {
   for (Eigen::Index i = 0; i < x.size() - 1; i++) {
-    if (x[i + 1] - x[i] <= 0.) {
+    if (x[i + 1] - x[i] < 0.) {
       return false;
     }
   }
@@ -110,7 +110,9 @@ TYPED_TEST_P(RegressionModelTester, test_score_variants) {
   // Here we make sure the cross validated mean absolute error is reasonable.
   // Note that because we are running leave one out cross validation, the
   // RMSE for each fold is just the absolute value of the error.
-  EXPECT_LE(cv_scores.mean(), 0.1);
+  if (!std::is_same<decltype(model), NullModel>::value) {
+    EXPECT_LE(cv_scores.mean(), 0.1);
+  }
 }
 
 REGISTER_TYPED_TEST_CASE_P(RegressionModelTester, test_loo_predict_variants,

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -18,6 +18,10 @@ TYPED_TEST_P(RegressionModelTester, test_performs_reasonably_on_linear_data) {
   auto dataset = this->test_case.get_dataset();
   auto model = this->test_case.get_model();
 
+  if (std::is_same<decltype(model), NullModel>::value) {
+    return;
+  }
+
   const auto fit_model = model.fit(dataset.features, dataset.targets);
   const auto pred = fit_model.predict(dataset.features);
   const auto pred_mean = pred.mean();

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -12,6 +12,7 @@
 
 #include <albatross/GP>
 #include <albatross/LeastSquares>
+#include <albatross/NullModel>
 #include <albatross/Ransac>
 #include <gtest/gtest.h>
 
@@ -171,6 +172,15 @@ public:
   }
 };
 
+class MakeNullModel {
+public:
+  NullModel get_model() const { return NullModel(); }
+
+  RegressionDataset<double> get_dataset() const {
+    return make_toy_linear_data();
+  }
+};
+
 template <typename ModelTestCase>
 class RegressionModelTester : public ::testing::Test {
 public:
@@ -179,7 +189,7 @@ public:
 
 typedef ::testing::Types<MakeLinearRegression, MakeGaussianProcess,
                          MakeAdaptedGaussianProcess, MakeRansacGaussianProcess,
-                         MakeRansacAdaptedGaussianProcess>
+                         MakeRansacAdaptedGaussianProcess, MakeNullModel>
     ExampleModels;
 
 TYPED_TEST_CASE_P(RegressionModelTester);


### PR DESCRIPTION
This change adds a `NullModel` which is a lot like it sounds.  You can treat it like any other model, ie `fit`, `predict` etc ... but it will always just return zero predictions which can be helpful as a benchmark model to make sure another model is actually doing something useful.