### PR TITLE
Remove const strings.

### DIFF
--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -16,9 +16,13 @@
 namespace albatross {
 
 namespace details {
+
 constexpr double DEFAULT_NUGGET = 1e-12;
-const std::string measurement_nugget_name = "measurement_nugget";
-const std::string inducing_nugget_name = "inducing_nugget";
+
+inline std::string measurement_nugget_name() { return "measurement_nugget"; }
+
+inline std::string inducing_nugget_name() { return "inducing_nugget"; }
+
 } // namespace details
 
 template <typename CovFunc, typename InducingPointStrategy,
@@ -145,8 +149,8 @@ public:
 
   ParameterStore get_params() const override {
     auto params = this->covariance_function_.get_params();
-    params[details::measurement_nugget_name] = measurement_nugget_;
-    params[details::inducing_nugget_name] = inducing_nugget_;
+    params[details::measurement_nugget_name()] = measurement_nugget_;
+    params[details::inducing_nugget_name()] = inducing_nugget_;
     return params;
   }
 
@@ -154,9 +158,9 @@ public:
                            const Parameter &param) override {
     if (map_contains(this->covariance_function_.get_params(), name)) {
       this->covariance_function_.set_param(name, param);
-    } else if (name == details::measurement_nugget_name) {
+    } else if (name == details::measurement_nugget_name()) {
       measurement_nugget_ = param;
-    } else if (name == details::inducing_nugget_name) {
+    } else if (name == details::inducing_nugget_name()) {
       inducing_nugget_ = param;
     } else {
       std::cerr << "Unknown param: " << name << std::endl;

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -49,14 +49,14 @@ void expect_sparse_gp_performance(const CovFunc &covariance,
   UniformlySpacedInducingPoints strategy(8);
   auto sparse =
       sparse_gp_from_covariance(covariance, strategy, indexer, "sparse");
-  sparse.set_param(details::inducing_nugget_name, 1e-3);
-  sparse.set_param(details::measurement_nugget_name, 1e-12);
+  sparse.set_param(details::inducing_nugget_name(), 1e-3);
+  sparse.set_param(details::measurement_nugget_name(), 1e-12);
 
   UniformlySpacedInducingPoints bad_strategy(3);
   auto really_sparse = sparse_gp_from_covariance(covariance, bad_strategy,
                                                  indexer, "really_sparse");
-  really_sparse.set_param(details::inducing_nugget_name, 1e-3);
-  really_sparse.set_param(details::measurement_nugget_name, 1e-12);
+  really_sparse.set_param(details::inducing_nugget_name(), 1e-3);
+  really_sparse.set_param(details::measurement_nugget_name(), 1e-12);
 
   auto direct_fit = direct.fit(dataset);
   auto sparse_fit = sparse.fit(dataset);


### PR DESCRIPTION
These `const std::string` lines caused multiple declaration errors, switched to functions since the more standard `extern` pattern doesn't work well for header only libraries.