### PR TITLE
GroupBy: Split Apply Combine

### DIFF
--- a/include/albatross/Common
+++ b/include/albatross/Common
@@ -25,7 +25,6 @@
 #include <iomanip>
 #include <set>
 #include <iostream>
-#include <unordered_map>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -35,7 +34,7 @@
 #include "ForwardDeclarations"
 
 #include <albatross/src/details/traits.hpp>
-#include <albatross/src/details/has_any_macros.hpp>
+#include <albatross/src/details/method_inspection_macros.hpp>
 #include <albatross/src/details/error_handling.hpp>
 
 #include <albatross/src/utils/map_utils.hpp>

--- a/include/albatross/Distribution
+++ b/include/albatross/Distribution
@@ -15,8 +15,6 @@
 
 #include "Common"
 
-#include <albatross/src/core/declarations.hpp>
-#include <albatross/src/core/indexing.hpp>
 #include <albatross/src/core/distribution.hpp>
 
 #endif

--- a/include/albatross/Evaluation
+++ b/include/albatross/Evaluation
@@ -15,6 +15,7 @@
 
 #include "Core"
 #include "Stats"
+#include "Indexing"
 
 #include <albatross/src/evaluation/likelihood.hpp>
 #include <albatross/src/evaluation/differential_entropy.hpp>

--- a/include/albatross/ForwardDeclarations
+++ b/include/albatross/ForwardDeclarations
@@ -19,5 +19,6 @@
 #include <Eigen/src/Core/util/ForwardDeclarations.h>
 
 #include <albatross/src/core/declarations.hpp>
+#include <albatross/src/indexing/declarations.hpp>
 
 #endif

--- a/include/albatross/Indexing
+++ b/include/albatross/Indexing
@@ -10,19 +10,14 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifndef ALBATROSS_CORE_H
-#define ALBATROSS_CORE_H
+#ifndef ALBATROSS_INDEXING_H
+#define ALBATROSS_INDEXING_H
 
 #include "Dataset"
 
-#include <type_traits>
-
-#include <albatross/src/core/traits.hpp>
-#include <albatross/src/core/priors.hpp>
-#include <albatross/src/core/parameter_handling_mixin.hpp>
-#include <albatross/src/core/parameter_macros.hpp>
-#include <albatross/src/core/fit_model.hpp>
-#include <albatross/src/core/prediction.hpp>
-#include <albatross/src/core/model.hpp>
+#include <albatross/src/indexing/traits.hpp>
+#include <albatross/src/indexing/subset.hpp>
+#include <albatross/src/indexing/group_by.hpp>
+#include <albatross/src/indexing/apply.hpp>
 
 #endif

--- a/include/albatross/src/core/concatenate.hpp
+++ b/include/albatross/src/core/concatenate.hpp
@@ -69,6 +69,15 @@ inline auto concatenate(const std::vector<X> &xs, const std::vector<X> &ys) {
   return features;
 }
 
+template <typename X>
+inline auto concatenate(const std::vector<std::vector<X>> &all_xs) {
+  std::vector<X> features;
+  for (const auto &one : all_xs) {
+    features.insert(features.end(), one.begin(), one.end());
+  }
+  return features;
+}
+
 /*
  * concatenate with two different non-variant types
  */

--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -50,6 +50,10 @@ template <typename FeatureType> struct RegressionDataset {
   }
 
   std::size_t size() const { return features.size(); }
+
+  template <typename GrouperFunc>
+  GroupBy<RegressionDataset<FeatureType>, GrouperFunc>
+  group_by(GrouperFunc grouper) const;
 };
 
 /*
@@ -67,9 +71,23 @@ template <typename X>
 inline auto concatenate_datasets(const RegressionDataset<X> &x,
                                  const RegressionDataset<X> &y) {
   const auto targets = concatenate_marginals(x.targets, y.targets);
-  std::vector<X> features(x.features);
-  features.insert(features.end(), y.features.begin(), y.features.end());
+  std::vector<X> features = concatenate(x.features, y.features);
   return RegressionDataset<X>(features, targets);
+}
+
+template <typename X>
+inline auto
+concatenate_datasets(const std::vector<RegressionDataset<X>> &datasets) {
+  std::vector<std::vector<X>> features;
+  std::vector<MarginalDistribution> targets;
+
+  for (const auto &dataset : datasets) {
+    features.emplace_back(dataset.features);
+    targets.emplace_back(dataset.targets);
+  }
+
+  return RegressionDataset<X>(concatenate(features),
+                              concatenate_marginals(targets));
 }
 
 template <typename X, typename Y>

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -40,6 +40,22 @@ template <typename ModelType, typename FitType> class FitModel;
 template <typename Derived> class Fit {};
 
 template <typename X> struct Measurement;
+
+/*
+ * Group By
+ */
+
+using GroupIndices = std::vector<std::size_t>;
+
+template <typename GroupKey, typename ValueType> class Grouped;
+
+template <typename GroupKey>
+using GroupIndexer = Grouped<GroupKey, GroupIndices>;
+
+struct LeaveOneOut;
+
+template <typename ValueType, typename GrouperFunction> class GroupBy;
+
 /*
  * Parameter Handling
  */
@@ -115,6 +131,15 @@ struct GenericRansacStrategy;
 template <typename InlierMetric, typename ConsensusMetric,
           typename IndexingFunction>
 struct GaussianProcessRansacStrategy;
+
+/*
+ * Traits
+ */
+
+template <typename First, typename Second> struct TypePair {
+  using first_type = First;
+  using second_type = Second;
+};
 
 } // namespace albatross
 

--- a/include/albatross/src/core/distribution.hpp
+++ b/include/albatross/src/core/distribution.hpp
@@ -148,7 +148,7 @@ concatenate_marginals(const std::vector<MarginalDistribution> &dists) {
   Eigen::VectorXd mean(static_cast<Eigen::Index>(size));
   Eigen::Index i = 0;
   for (const auto &dist : dists) {
-    mean.block(i, 0, dist.mean.size(), 1) = dist.mean;
+    mean.middleRows(i, dist.mean.size()) = dist.mean;
     i += dist.mean.size();
   }
 

--- a/include/albatross/src/details/method_inspection_macros.hpp
+++ b/include/albatross/src/details/method_inspection_macros.hpp
@@ -10,15 +10,10 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifndef INCLUDE_ALBATROSS_SRC_DETAILS_HAS_ANY_MACROS_HPP_
-#define INCLUDE_ALBATROSS_SRC_DETAILS_HAS_ANY_MACROS_HPP_
+#ifndef ALBATROSS_DETAILS_METHOD_INSPECTION_MACROS_HPP_
+#define ALBATROSS_DETAILS_METHOD_INSPECTION_MACROS_HPP_
 
 namespace albatross {
-
-template <typename First, typename Second> struct TypePair {
-  using first_type = First;
-  using second_type = Second;
-};
 
 /*
  * Defines a couple of traits which help inspect whether a type has a method
@@ -161,4 +156,4 @@ struct DummyType {};
 
 } // namespace albatross
 
-#endif /* INCLUDE_ALBATROSS_SRC_DETAILS_HAS_ANY_MACROS_HPP_ */
+#endif /* ALBATROSS_DETAILS_METHOD_INSPECTION_MACROS_HPP_ */

--- a/include/albatross/src/indexing/apply.hpp
+++ b/include/albatross/src/indexing/apply.hpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_INDEXING_APPLY_HPP_
+#define ALBATROSS_INDEXING_APPLY_HPP_
+
+namespace albatross {
+
+template <typename ToKeepFunction, typename ValueType,
+          typename std::enable_if<details::is_valid_value_only_filter_function<
+                                      ToKeepFunction, ValueType>::value,
+                                  int>::type = 0>
+inline auto filter(const std::vector<ValueType> &values,
+                   const ToKeepFunction &to_keep) {
+  std::vector<ValueType> output;
+  for (const auto &v : values) {
+    if (to_keep(v)) {
+      output.emplace_back(v);
+    }
+  }
+  return output;
+}
+
+} // namespace albatross
+
+#endif /* ALBATROSS_INDEXING_APPLY_HPP_ */

--- a/include/albatross/src/indexing/declarations.hpp
+++ b/include/albatross/src/indexing/declarations.hpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_INDEXING_DECLARATIONS_HPP_
+#define ALBATROSS_INDEXING_DECLARATIONS_HPP_
+
+namespace albatross {
+
+template <typename SizeType>
+Eigen::MatrixXd symmetric_subset(const Eigen::MatrixXd &v,
+                                 const std::vector<SizeType> &indices);
+
+template <typename SizeType, typename Scalar, int Size>
+Eigen::DiagonalMatrix<Scalar, Size>
+symmetric_subset(const Eigen::DiagonalMatrix<Scalar, Size> &v,
+                 const std::vector<SizeType> &indices);
+
+template <typename SizeType>
+Eigen::VectorXd subset(const Eigen::VectorXd &v,
+                       const std::vector<SizeType> &indices);
+
+template <typename SizeType, typename X>
+std::vector<X> subset(const std::vector<X> &v,
+                      const std::vector<SizeType> &indices);
+
+template <typename SizeType>
+Eigen::MatrixXd subset_cols(const Eigen::MatrixXd &v,
+                            const std::vector<SizeType> &col_indices);
+
+} // namespace albatross
+
+#endif /* ALBATROSS_INDEXING_DECLARATIONS_HPP_ */

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -1,0 +1,443 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_INDEXING_GROUPBY_HPP_
+#define ALBATROSS_INDEXING_GROUPBY_HPP_
+
+/*
+ * Group By
+ *
+ * This collection of classes facilitates the manipulation of data through
+ * the use of split-apply-combine approach.
+ */
+
+namespace albatross {
+
+/*
+ * The Grouped class is the output of a call to method such as
+ *
+ *   dataset.groupby(grouper).groups()
+ *
+ * which is basically just a map with additional functionality
+ * that facilitates applying a function to all values, filtering etc ...
+ */
+
+template <typename KeyType, typename ValueType>
+class GroupedBase : public std::map<KeyType, ValueType> {
+
+public:
+  /*
+   * Filtering a Grouped object consists of deciding which of the
+   * groups you would like to keep.  This is done by providing a function which
+   * returns bool when provided with a group (or group key and group)
+   */
+  template <
+      typename FilterFunction,
+      typename std::enable_if<details::is_valid_value_only_filter_function<
+                                  FilterFunction, ValueType>::value,
+                              int>::type = 0>
+  auto filter(const FilterFunction &f) const {
+    Grouped<KeyType, ValueType> output;
+    for (const auto &pair : *this) {
+      if (f(pair.second)) {
+        output.emplace(pair.first, pair.second);
+      }
+    }
+    return output;
+  }
+
+  template <
+      typename FilterFunction,
+      typename std::enable_if<details::is_valid_key_value_filter_function<
+                                  FilterFunction, KeyType, ValueType>::value,
+                              int>::type = 0>
+  auto filter(const FilterFunction &f) const {
+    Grouped<KeyType, ValueType> output;
+    for (const auto &pair : *this) {
+      if (f(pair.first, pair.second)) {
+        output.emplace(pair.first, pair.second);
+      }
+    }
+    return output;
+  }
+
+  /*
+   * Using Apply with Grouped objects consists of performing some operation
+   * to each group.  This is done by provided a function which takes a group
+   * (or group key and group).  If the function returns something other than
+   * void the results will be aggregated into a new Grouped object.
+   */
+  template <
+      typename ApplyFunction,
+      typename ApplyType = typename details::key_value_apply_return_type<
+          ApplyFunction, KeyType, ValueType>::type,
+      typename std::enable_if<details::is_valid_key_value_apply_function<
+                                  ApplyFunction, KeyType, ValueType>::value &&
+                                  std::is_same<void, ApplyType>::value,
+                              int>::type = 0>
+  void apply(const ApplyFunction &f) const {
+    for (const auto &pair : *this) {
+      f(pair.first, pair.second);
+    }
+  }
+
+  template <
+      typename ApplyFunction,
+      typename ApplyType = typename details::key_value_apply_return_type<
+          ApplyFunction, KeyType, ValueType>::type,
+      typename std::enable_if<details::is_valid_key_value_apply_function<
+                                  ApplyFunction, KeyType, ValueType>::value &&
+                                  !std::is_same<void, ApplyType>::value,
+                              int>::type = 0>
+  auto apply(const ApplyFunction &f) const {
+    Grouped<KeyType, ApplyType> output;
+    for (const auto &pair : *this) {
+      output.emplace(pair.first, f(pair.first, pair.second));
+    }
+    return output;
+  }
+
+  template <typename ApplyFunction,
+            typename ApplyType = typename details::value_only_apply_return_type<
+                ApplyFunction, ValueType>::type,
+            typename std::enable_if<details::is_valid_value_only_apply_function<
+                                        ApplyFunction, ValueType>::value &&
+                                        !std::is_same<void, ApplyType>::value,
+                                    int>::type = 0>
+  auto apply(const ApplyFunction &f) const {
+    Grouped<KeyType, ApplyType> output;
+    for (const auto &pair : *this) {
+      output.emplace(pair.first, f(pair.second));
+    }
+    return output;
+  }
+
+  template <typename ApplyFunction,
+            typename ApplyType = typename details::value_only_apply_return_type<
+                ApplyFunction, ValueType>::type,
+            typename std::enable_if<details::is_valid_value_only_apply_function<
+                                        ApplyFunction, ValueType>::value &&
+                                        std::is_same<void, ApplyType>::value,
+                                    int>::type = 0>
+  auto apply(const ApplyFunction &f) const {
+    for (const auto &pair : *this) {
+      f(pair.second);
+    }
+  }
+};
+
+template <typename KeyType, typename ValueType>
+class Grouped : public GroupedBase<KeyType, ValueType> {};
+
+template <typename KeyType>
+class Grouped<KeyType, GroupIndices>
+    : public GroupedBase<KeyType, GroupIndices> {
+public:
+  template <typename ApplyFunction,
+            typename ApplyType = typename details::key_value_apply_return_type<
+                ApplyFunction, KeyType, GroupIndices>::type,
+            typename std::enable_if<
+                details::is_valid_index_apply_function<ApplyFunction, KeyType,
+                                                       GroupIndices>::value &&
+                    !std::is_same<void, ApplyType>::value,
+                int>::type = 0>
+  auto index_apply(const ApplyFunction &f) const {
+    Grouped<KeyType, ApplyType> output;
+    for (const auto &pair : *this) {
+      output.emplace(pair.first, f(pair.first, pair.second));
+    }
+    return output;
+  }
+};
+
+/*
+ * combine
+ *
+ * Like concatenate, but works on map values.
+ */
+template <typename KeyType, typename FeatureType>
+RegressionDataset<FeatureType>
+combine(const std::map<KeyType, RegressionDataset<FeatureType>> &groups) {
+  return concatenate_datasets(map_values(groups));
+}
+
+template <typename KeyType, typename FeatureType>
+std::vector<FeatureType>
+combine(const std::map<KeyType, std::vector<FeatureType>> &groups) {
+  return concatenate(map_values(groups));
+}
+
+template <typename KeyType>
+Eigen::VectorXd combine(const std::map<KeyType, double> &groups) {
+  Eigen::VectorXd output(static_cast<Eigen::Index>(groups.size()));
+  Eigen::Index i = 0;
+  for (const auto &x : map_values(groups)) {
+    output[i] = x;
+    ++i;
+  }
+  assert(i == output.size());
+  return output;
+}
+
+/*
+ * Combinable grouped objects support operations in which you can
+ * collapse a `map<Key, Value>` into a single `Value`
+ */
+template <typename KeyType, typename ValueType>
+class CombinableBase : public GroupedBase<KeyType, ValueType> {
+public:
+  ValueType combine() const { return albatross::combine(*this); }
+};
+
+template <typename KeyType, typename FeatureType>
+class Grouped<KeyType, RegressionDataset<FeatureType>>
+    : public CombinableBase<KeyType, RegressionDataset<FeatureType>> {};
+
+template <typename KeyType, typename FeatureType>
+class Grouped<KeyType, std::vector<FeatureType>>
+    : public CombinableBase<KeyType, std::vector<FeatureType>> {};
+
+/*
+ * Not all GrouperFunctions actually take Values as input, the leave one
+ * out approach (for example) requires knowledge of the total number of
+ * indices not the actual values.  This `IndexBuilder` class is responsible
+ * for distinguishing between these different approaches.
+ */
+template <typename GrouperFunction> struct IndexerBuilder {
+
+  template <
+      typename Iterable,
+      typename IterableValue = typename const_ref<typename std::iterator_traits<
+          typename Iterable::iterator>::value_type>::type,
+      typename std::enable_if<
+          details::is_valid_grouper<GrouperFunction, IterableValue>::value,
+          int>::type = 0>
+  static auto build(const GrouperFunction &grouper_function,
+                    const Iterable &iterable) {
+    using GroupKey = typename details::grouper_return_type<GrouperFunction,
+                                                           IterableValue>::type;
+    GroupIndexer<GroupKey> output;
+    std::size_t i = 0;
+    for (const auto &value : iterable) {
+      const GroupKey group_key = grouper_function(value);
+      // Get the existing indices if we've already encountered this group_name
+      // otherwise initialize a new one.
+      GroupIndices indices;
+      if (output.find(group_key) == output.end()) {
+        output[group_key] = GroupIndices();
+      }
+      // Add the current index.
+      output[group_key].push_back(i);
+      ++i;
+    }
+    return output;
+  }
+};
+
+struct LeaveOneOutGrouper {
+  template <typename Arg> std::size_t operator()(const Arg &) const {
+    static_assert(
+        delay_static_assert<Arg>::value,
+        "You shouldn't be calling LeaveOneOutGrouper directly, pass it into "
+        "group_by as a GrouperFunction");
+    return 0;
+  };
+};
+
+template <> struct IndexerBuilder<LeaveOneOutGrouper> {
+
+  template <typename Iterable>
+  static auto build(const LeaveOneOutGrouper &grouper_function,
+                    const Iterable &iterable) {
+    GroupIndexer<std::size_t> output;
+    std::size_t i = 0;
+    auto it = iterable.begin();
+    while (it != iterable.end()) {
+      // Add the current index.
+      output[i] = {i};
+      ++i;
+      ++it;
+    }
+    return output;
+  }
+};
+
+template <
+    typename GrouperFunction, typename Iterable,
+    typename IterableValue = typename const_ref<typename std::iterator_traits<
+        typename Iterable::iterator>::value_type>::type,
+    typename std::enable_if<
+        details::is_valid_grouper<GrouperFunction, IterableValue>::value,
+        int>::type = 0>
+inline auto build_indexer(const GrouperFunction &grouper_function,
+                          const Iterable &iterable) {
+  return IndexerBuilder<GrouperFunction>::build(grouper_function, iterable);
+}
+
+/*
+ * GroupByBase
+ *
+ * This is the base class holding common operations for classes which can
+ * be grouped.
+ */
+template <typename Derived> class GroupByBase {
+
+public:
+  using KeyType = typename details::traits<Derived>::KeyType;
+  using ValueType = typename details::traits<Derived>::ValueType;
+  using GrouperType = typename details::traits<Derived>::GrouperType;
+  using IndexerType = GroupIndexer<KeyType>;
+
+  GroupByBase(const ValueType &parent, const GrouperType &grouper)
+      : parent_(parent), grouper_(grouper) {
+    indexers_ = build_indexers();
+  };
+
+  IndexerType indexers() const { return indexers_; }
+
+  Grouped<KeyType, ValueType> groups() const {
+    Grouped<KeyType, ValueType> output;
+    for (const auto &key_indexer_pair : indexers()) {
+      output.emplace(key_indexer_pair.first,
+                     albatross::subset(parent_, key_indexer_pair.second));
+    }
+    return output;
+  }
+
+  std::vector<KeyType> keys() const { return map_keys(indexers()); }
+
+  std::size_t size() const { return indexers().size(); }
+
+  template <typename ApplyFunction> auto apply(const ApplyFunction &f) const {
+    return groups().apply(f);
+  }
+
+  template <typename ApplyFunction,
+            typename ApplyType = typename details::key_value_apply_return_type<
+                ApplyFunction, KeyType, GroupIndices>::type,
+            typename std::enable_if<
+                details::is_valid_index_apply_function<ApplyFunction, KeyType,
+                                                       GroupIndices>::value &&
+                    !std::is_same<void, ApplyType>::value,
+                int>::type = 0>
+  auto index_apply(const ApplyFunction &f) const {
+    Grouped<KeyType, ApplyType> output;
+    for (const auto &pair : indexers()) {
+      output.emplace(pair.first, f(pair.first, pair.second));
+    }
+    return output;
+  }
+
+  template <typename ApplyFunction,
+            typename ApplyType = typename details::key_value_apply_return_type<
+                ApplyFunction, KeyType, GroupIndices>::type,
+            typename std::enable_if<
+                details::is_valid_index_apply_function<ApplyFunction, KeyType,
+                                                       GroupIndices>::value &&
+                    std::is_same<void, ApplyType>::value,
+                int>::type = 0>
+  auto index_apply(const ApplyFunction &f) const {
+    for (const auto &pair : indexers()) {
+      f(pair.first, pair.second);
+    }
+  }
+
+  template <typename FilterFunction> auto filter(FilterFunction f) const {
+    return groups().filter(f);
+  }
+
+  std::map<KeyType, std::size_t> counts() const {
+    std::map<KeyType, std::size_t> output;
+    for (const auto &key_indexer_pair : indexers()) {
+      output.emplace(key_indexer_pair.first, key_indexer_pair.second.size());
+    }
+    return output;
+  }
+
+protected:
+  ValueType parent_;
+  GrouperType grouper_;
+  IndexerType indexers_;
+
+private:
+  IndexerType build_indexers() const {
+    return albatross::build_indexer(grouper_, derived()._get_iterable());
+  }
+
+  /*
+   * CRTP Helpers
+   */
+  Derived &derived() { return *static_cast<Derived *>(this); }
+  const Derived &derived() const { return *static_cast<const Derived *>(this); }
+};
+
+/*
+ * GroupBy for RegressionDataset
+ */
+template <typename FeatureType, typename GrouperFunction>
+class GroupBy<RegressionDataset<FeatureType>, GrouperFunction>
+    : public GroupByBase<
+          GroupBy<RegressionDataset<FeatureType>, GrouperFunction>> {
+
+public:
+  using Base =
+      GroupByBase<GroupBy<RegressionDataset<FeatureType>, GrouperFunction>>;
+  using Base::Base;
+
+  auto &_get_iterable() const { return this->parent_.features; }
+};
+
+/*
+ * GroupBy for std::vector
+ */
+template <typename FeatureType, typename GrouperFunction>
+class GroupBy<std::vector<FeatureType>, GrouperFunction>
+    : public GroupByBase<GroupBy<std::vector<FeatureType>, GrouperFunction>> {
+
+public:
+  using Base = GroupByBase<GroupBy<std::vector<FeatureType>, GrouperFunction>>;
+  using Base::Base;
+
+  auto &_get_iterable() const { return this->parent_; }
+};
+
+/*
+ * Define the (already declared) group_by method for datasets.
+ */
+template <typename FeatureType>
+template <typename GrouperFunc>
+GroupBy<RegressionDataset<FeatureType>, GrouperFunc>
+RegressionDataset<FeatureType>::group_by(GrouperFunc grouper) const {
+  return GroupBy<RegressionDataset<FeatureType>, GrouperFunc>(
+      *this, std::move(grouper));
+}
+
+/*
+ * Free functions which create a common way of performing group_by on
+ * datasets and vectors.  This is useful because we can't add a .group_by()
+ * method to standard library vectors.
+ */
+template <typename FeatureType, typename GrouperFunc>
+auto group_by(const RegressionDataset<FeatureType> &dataset,
+              GrouperFunc grouper) {
+  return dataset.group_by(std::move(grouper));
+}
+
+template <typename FeatureType, typename GrouperFunc>
+auto group_by(const std::vector<FeatureType> &vector, GrouperFunc grouper) {
+  return GroupBy<std::vector<FeatureType>, GrouperFunc>(vector,
+                                                        std::move(grouper));
+}
+
+} // namespace albatross
+
+#endif /* ALBATROSS_INDEXING_GROUPBY_HPP_ */

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -321,9 +321,9 @@ inline auto build_indexer(const GrouperFunction &grouper_function,
 template <typename Derived> class GroupByBase {
 
 public:
-  using KeyType = typename details::traits<Derived>::KeyType;
-  using ValueType = typename details::traits<Derived>::ValueType;
-  using GrouperType = typename details::traits<Derived>::GrouperType;
+  using KeyType = typename details::group_by_traits<Derived>::KeyType;
+  using ValueType = typename details::group_by_traits<Derived>::ValueType;
+  using GrouperType = typename details::group_by_traits<Derived>::GrouperType;
   using IndexerType = GroupIndexer<KeyType>;
 
   GroupByBase(const ValueType &parent, const GrouperType &grouper)
@@ -374,7 +374,7 @@ public:
                                                        GroupIndices>::value &&
                     std::is_same<void, ApplyType>::value,
                 int>::type = 0>
-  auto index_apply(const ApplyFunction &f) const {
+  void index_apply(const ApplyFunction &f) const {
     for (const auto &pair : indexers()) {
       f(pair.first, pair.second);
     }

--- a/include/albatross/src/indexing/subset.hpp
+++ b/include/albatross/src/indexing/subset.hpp
@@ -10,8 +10,8 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifndef ALBATROSS_CORE_INDEXING_H
-#define ALBATROSS_CORE_INDEXING_H
+#ifndef ALBATROSS_INDEXING_SUBSET_H
+#define ALBATROSS_INDEXING_SUBSET_H
 
 namespace albatross {
 
@@ -149,12 +149,19 @@ inline void set_subset(const Eigen::DiagonalMatrix<Scalar, Size> &from,
 }
 
 template <typename X>
-inline std::vector<X> vector_set_difference(const std::vector<X> &x,
-                                            const std::vector<X> &y) {
-  std::vector<X> diff;
+inline std::set<X> set_difference(const std::set<X> &x, const std::set<X> &y) {
+  std::set<X> diff;
   std::set_difference(x.begin(), x.end(), y.begin(), y.end(),
                       std::inserter(diff, diff.begin()));
   return diff;
+}
+
+template <typename X>
+inline std::set<X> vector_set_difference(const std::vector<X> &x,
+                                         const std::vector<X> &y) {
+  std::set<X> sorted_x(x.begin(), x.end());
+  std::set<X> sorted_y(y.begin(), y.end());
+  return set_difference(sorted_x, sorted_y);
 }
 
 /*
@@ -169,7 +176,8 @@ indices_complement(const std::vector<std::size_t> &indices,
                    const std::size_t n) {
   std::vector<std::size_t> all_indices(n);
   std::iota(all_indices.begin(), all_indices.end(), 0);
-  return vector_set_difference(all_indices, indices);
+  const auto complement = vector_set_difference(all_indices, indices);
+  return std::vector<std::size_t>(complement.begin(), complement.end());
 }
 
 inline FoldIndices indices_from_names(const FoldIndexer &indexer,

--- a/include/albatross/src/indexing/traits.hpp
+++ b/include/albatross/src/indexing/traits.hpp
@@ -168,10 +168,11 @@ struct is_valid_value_only_filter_function {
  *
  * GrouperFunction is a callable type which should take
  */
-template <typename T> struct traits {};
+template <typename T> struct group_by_traits {};
 
 template <typename FeatureType, typename GrouperFunction>
-struct traits<GroupBy<RegressionDataset<FeatureType>, GrouperFunction>> {
+struct group_by_traits<
+    GroupBy<RegressionDataset<FeatureType>, GrouperFunction>> {
   using ValueType = RegressionDataset<FeatureType>;
   using IterableType = FeatureType;
   using KeyType =
@@ -180,7 +181,7 @@ struct traits<GroupBy<RegressionDataset<FeatureType>, GrouperFunction>> {
 };
 
 template <typename FeatureType, typename GrouperFunction>
-struct traits<GroupBy<std::vector<FeatureType>, GrouperFunction>> {
+struct group_by_traits<GroupBy<std::vector<FeatureType>, GrouperFunction>> {
   using ValueType = std::vector<FeatureType>;
   using IterableType = FeatureType;
   using KeyType =

--- a/include/albatross/src/indexing/traits.hpp
+++ b/include/albatross/src/indexing/traits.hpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_INDEXING_TRAITS_HPP_
+#define ALBATROSS_INDEXING_TRAITS_HPP_
+
+namespace albatross {
+
+namespace details {
+
+template <typename T> class has_less_than_operator {
+  template <typename C,
+            typename std::enable_if<
+                std::is_same<bool, decltype(std::declval<C>() <
+                                            std::declval<C>())>::value,
+                int>::type = 0>
+  static std::true_type test(C *);
+  template <typename> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+template <typename T> class is_valid_map_key {
+  template <typename C,
+            typename std::enable_if<std::is_default_constructible<C>::value &&
+                                        std::is_copy_assignable<C>::value &&
+                                        has_less_than_operator<C>::value,
+                                    int>::type = 0>
+  static std::true_type test(C *);
+  template <typename> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+template <> class is_valid_map_key<void> {
+public:
+  static constexpr bool value = false;
+};
+
+/*
+ * This checks that a given type can be called with the following
+ * argument types.
+ *
+ * Only works for non-overloaded methods, but does work with
+ * lambda functions and function pointers.
+ */
+template <typename T, typename... Args> class callable_traits {
+  template <typename C, typename ReturnType = decltype(
+                            std::declval<C>()(std::declval<Args>()...))>
+  static TypePair<std::true_type, ReturnType> test(C *);
+  template <typename> static TypePair<std::false_type, void> test(...);
+
+public:
+  static constexpr bool is_defined = decltype(test<T>(0))::first_type::value;
+  using return_type = typename decltype(test<T>(0))::second_type;
+};
+
+/*
+ * Here we only care about the `is_defined` trait.
+ */
+template <typename T, typename... Args> struct can_be_called_with {
+  static constexpr bool value = callable_traits<T, Args...>::is_defined;
+};
+
+template <typename T, typename... Args>
+class can_be_called_with_const_ref
+    : public can_be_called_with<const T, typename const_ref<Args>::type...> {};
+
+/*
+ * Stores the return type resulting from calling T with Args, if the
+ * call isn't valid the resulting type will be void.
+ */
+template <typename T, typename... Args> struct return_type_when_called_with {
+  using type = typename callable_traits<T, Args...>::return_type;
+};
+
+/*
+ * A GrouperFunction is a function which takes a single const ref argument
+ * and returns a non-void type which will end up being the key used in group by.
+ */
+template <typename GrouperFunction, typename ValueType>
+struct grouper_return_type
+    : public return_type_when_called_with<GrouperFunction,
+                                          typename const_ref<ValueType>::type> {
+};
+
+template <typename GrouperFunction, typename ValueType>
+struct group_key_is_valid {
+  static constexpr bool value = is_valid_map_key<
+      typename grouper_return_type<GrouperFunction, ValueType>::type>::value;
+};
+
+template <typename GrouperFunction, typename ValueType>
+struct is_valid_grouper {
+
+  static constexpr bool value =
+      can_be_called_with_const_ref<GrouperFunction, ValueType>::value &&
+      group_key_is_valid<GrouperFunction, ValueType>::value;
+};
+
+/*
+ * An ApplyFunction is a function which takes a key value pair and
+ * returns a new type, they key type needs to remain unchanged but
+ * the value can be modified.
+ */
+template <typename ApplyFunction, typename KeyType, typename ArgType>
+struct key_value_apply_return_type
+    : public return_type_when_called_with<
+          ApplyFunction, typename const_ref<KeyType>::type, ArgType> {};
+
+template <typename ApplyFunction, typename ArgType>
+struct value_only_apply_return_type
+    : public return_type_when_called_with<ApplyFunction, ArgType> {};
+
+template <typename ApplyFunction, typename KeyType, typename ArgType>
+struct is_valid_key_value_apply_function
+    : public can_be_called_with_const_ref<
+          ApplyFunction, typename const_ref<KeyType>::type, ArgType> {};
+
+template <typename ApplyFunction, typename ArgType>
+struct is_valid_value_only_apply_function
+    : public can_be_called_with_const_ref<ApplyFunction, ArgType> {};
+
+template <typename ApplyFunction, typename KeyType, typename ArgType>
+struct is_valid_index_apply_function
+    : public can_be_called_with_const_ref<
+          ApplyFunction, typename const_ref<KeyType>::type,
+          typename const_ref<GroupIndices>::type> {};
+
+template <typename FilterFunction, typename... Args>
+struct returns_bool_when_called_with {
+  static constexpr bool value = std::is_same<
+      typename return_type_when_called_with<FilterFunction, Args...>::type,
+      bool>::value;
+};
+
+template <typename FilterFunction, typename KeyType, typename ArgType>
+struct is_valid_key_value_filter_function {
+  static constexpr bool value =
+      can_be_called_with_const_ref<FilterFunction, KeyType, ArgType>::value &&
+      returns_bool_when_called_with<FilterFunction, KeyType, ArgType>::value;
+};
+
+template <typename FilterFunction, typename ArgType>
+struct is_valid_value_only_filter_function {
+  static constexpr bool value =
+      can_be_called_with_const_ref<FilterFunction, ArgType>::value &&
+      returns_bool_when_called_with<FilterFunction, ArgType>::value;
+};
+
+/*
+ * The following traits are required in order to allow inspection of
+ * the only partially defined Derived types inside of GroupByBase.
+ *
+ * To get GroupByBase to work with other types you need to add a new
+ * trait struct for the type.
+ *
+ * GrouperFunction is a callable type which should take
+ */
+template <typename T> struct traits {};
+
+template <typename FeatureType, typename GrouperFunction>
+struct traits<GroupBy<RegressionDataset<FeatureType>, GrouperFunction>> {
+  using ValueType = RegressionDataset<FeatureType>;
+  using IterableType = FeatureType;
+  using KeyType =
+      typename grouper_return_type<GrouperFunction, IterableType>::type;
+  using GrouperType = GrouperFunction;
+};
+
+template <typename FeatureType, typename GrouperFunction>
+struct traits<GroupBy<std::vector<FeatureType>, GrouperFunction>> {
+  using ValueType = std::vector<FeatureType>;
+  using IterableType = FeatureType;
+  using KeyType =
+      typename grouper_return_type<GrouperFunction, IterableType>::type;
+  using GrouperType = GrouperFunction;
+};
+
+} // namespace details
+
+} // namespace albatross
+
+#endif /* ALBATROSS_INDEXING_TRAITS_HPP_ */

--- a/include/albatross/src/utils/map_utils.hpp
+++ b/include/albatross/src/utils/map_utils.hpp
@@ -19,13 +19,8 @@ namespace albatross {
  * Convenience function instead of using the find == end
  * method of determining if a key exists in a map.
  */
-template <typename K, typename V>
-bool map_contains(const std::map<K, V> &m, const K &k) {
-  return m.find(k) != m.end();
-}
-
-template <typename K, typename V>
-bool map_contains(const std::unordered_map<K, V> &m, const K &k) {
+template <template <typename...> class Map, typename K, typename V>
+bool map_contains(const Map<K, V> &m, const K &k) {
   return m.find(k) != m.end();
 }
 
@@ -36,8 +31,8 @@ bool map_contains(const std::unordered_map<K, V> &m, const K &k) {
  * If the key doesn't exist a new object of the value type
  * is inserted into the map, then returned.
  */
-template <typename K, typename V>
-V map_get_or_construct(const std::map<K, V> &m, const K &k) {
+template <template <typename...> class Map, typename K, typename V>
+V map_get_or_construct(const Map<K, V> &m, const K &k) {
   if (!map_contains(m, k)) {
     V default_value = V();
     return default_value;
@@ -48,8 +43,8 @@ V map_get_or_construct(const std::map<K, V> &m, const K &k) {
 /*
  * Returns a vector consisting of all the keys in a map.
  */
-template <typename K, typename V>
-std::vector<K> map_keys(const std::map<K, V> m) {
+template <template <typename...> class Map, typename K, typename V>
+std::vector<K> map_keys(const Map<K, V> &m) {
   std::vector<K> keys;
   for (const auto &pair : m) {
     keys.push_back(pair.first);
@@ -60,8 +55,8 @@ std::vector<K> map_keys(const std::map<K, V> m) {
 /*
  * Returns a vector consisting of all the values in a map.
  */
-template <typename K, typename V>
-std::vector<V> map_values(const std::map<K, V> m) {
+template <template <typename...> class Map, typename K, typename V>
+std::vector<V> map_values(const Map<K, V> &m) {
   std::vector<V> values;
   for (const auto &pair : m) {
     values.push_back(pair.second);
@@ -69,9 +64,9 @@ std::vector<V> map_values(const std::map<K, V> m) {
   return values;
 }
 
-template <typename K, typename V>
-std::map<K, V> map_join(const std::map<K, V> m, const std::map<K, V> other) {
-  std::map<K, V> join(other);
+template <template <typename...> class Map, typename K, typename V>
+Map<K, V> map_join(const Map<K, V> &m, const Map<K, V> &other) {
+  Map<K, V> join(other);
   // Note the order here is reversed since insert will not insert if a key
   // already exists, in this case we want the result to contain all elements of
   // m overwritten by any elements in other.
@@ -79,10 +74,9 @@ std::map<K, V> map_join(const std::map<K, V> m, const std::map<K, V> other) {
   return join;
 }
 
-template <typename K, typename V>
-std::map<K, V> map_join_strict(const std::map<K, V> m,
-                               const std::map<K, V> other) {
-  std::map<K, V> join(other);
+template <template <typename...> class Map, typename K, typename V>
+Map<K, V> map_join_strict(const Map<K, V> &m, const Map<K, V> &other) {
+  Map<K, V> join(other);
   // Note the order here is reversed since insert will not insert if a key
   // already exists, in this case we want the result to contain all elements of
   // m overwritten by any elements in other.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(albatross_unit_tests
   test_eigen_utils.cc
   test_evaluate.cc
   test_gp.cc
+  test_group_by.cc
   test_indexing.cc
   test_linalg_utils.cc
   test_map_utils.cc
@@ -35,6 +36,7 @@ add_executable(albatross_unit_tests
   test_traits_details.cc
   test_traits_covariance_functions.cc
   test_traits_evaluation.cc
+  test_traits_indexing.cc
   test_tune.cc
   )
 target_include_directories(albatross_unit_tests SYSTEM PRIVATE

--- a/tests/test_core_dataset.cc
+++ b/tests/test_core_dataset.cc
@@ -11,6 +11,7 @@
  */
 
 #include <albatross/Dataset>
+#include <albatross/Indexing>
 #include <gtest/gtest.h>
 
 namespace albatross {

--- a/tests/test_core_distribution.cc
+++ b/tests/test_core_distribution.cc
@@ -11,6 +11,7 @@
  */
 
 #include <albatross/Distribution>
+#include <albatross/Indexing>
 #include <gtest/gtest.h>
 
 #include "test_core_distribution.h"

--- a/tests/test_eigen_utils.cc
+++ b/tests/test_eigen_utils.cc
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <albatross/Core>
+#include <albatross/Indexing>
 
 #include <albatross/src/utils/eigen_utils.hpp>
 

--- a/tests/test_group_by.cc
+++ b/tests/test_group_by.cc
@@ -1,0 +1,404 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/Indexing>
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+bool above_three(const int &x) { return x > 3; }
+
+struct AboveThree {
+  bool operator()(const int &x) const { return above_three(x); }
+};
+
+int mod_three(const int &x) { return x % 3; }
+
+struct IntMod3 {
+  int operator()(const int &x) const { return mod_three(x); }
+};
+
+struct StringMod3 {
+  std::string operator()(const int &x) const {
+    return std::to_string(IntMod3()(x));
+  }
+};
+
+struct CustomGroupKey {
+
+  bool operator<(const CustomGroupKey &other) const {
+    return value < other.value;
+  }
+
+  bool operator==(const CustomGroupKey &other) const {
+    return value == other.value;
+  }
+
+  double value;
+};
+
+CustomGroupKey custom_nearest_even_number(const int &x) {
+  CustomGroupKey key;
+  key.value = x - (x % 2);
+  return key;
+}
+
+struct CustomNearestEvenNumber {
+  CustomGroupKey operator()(const int &x) const {
+    return custom_nearest_even_number(x);
+  }
+};
+
+RegressionDataset<int> test_integer_dataset() {
+  std::vector<int> features = {3, 7, 1, 2, 5, 8};
+  Eigen::VectorXd targets = Eigen::VectorXd::Random(6);
+  return RegressionDataset<int>(features, targets);
+}
+
+/*
+ * Here we define all the test cases.
+ */
+
+struct BoolClassMethodGrouper {
+
+  auto get_parent() const { return test_integer_dataset(); }
+
+  auto get_grouper() const { return AboveThree(); }
+};
+
+struct BoolFunctionPointerGrouper {
+
+  auto get_parent() const { return test_integer_dataset(); }
+
+  auto get_grouper() const { return &above_three; }
+};
+
+struct BoolClassMethodVectorGrouper {
+
+  auto get_parent() const { return test_integer_dataset().features; }
+
+  auto get_grouper() const { return AboveThree(); }
+};
+
+struct BoolLambdaGrouper {
+
+  auto get_parent() const { return test_integer_dataset(); }
+
+  auto get_grouper() const {
+    const auto get_group = [](const int &x) { return AboveThree()(x); };
+    return get_group;
+  }
+};
+
+struct IntClassMethodGrouper {
+
+  auto get_parent() const { return test_integer_dataset(); }
+
+  auto get_grouper() const { return IntMod3(); }
+};
+
+struct StringClassMethodGrouper {
+
+  auto get_parent() const { return test_integer_dataset(); }
+
+  auto get_grouper() const { return IntMod3(); }
+};
+
+struct LeaveOneOutTest {
+  auto get_parent() const { return test_integer_dataset(); }
+
+  auto get_grouper() const { return LeaveOneOutGrouper(); }
+};
+
+struct CustomClassMethodGrouper {
+  auto get_parent() const { return test_integer_dataset(); }
+
+  auto get_grouper() const { return CustomNearestEvenNumber(); }
+};
+
+struct CustomFunctionPointerGrouper {
+  auto get_parent() const { return test_integer_dataset(); }
+
+  auto get_grouper() const { return &custom_nearest_even_number; }
+};
+
+template <typename CaseType> class GroupByTester : public ::testing::Test {
+public:
+  CaseType test_case;
+};
+
+typedef ::testing::Types<BoolClassMethodGrouper, BoolLambdaGrouper,
+                         BoolFunctionPointerGrouper, IntClassMethodGrouper,
+                         StringClassMethodGrouper, BoolClassMethodVectorGrouper,
+                         LeaveOneOutTest, CustomClassMethodGrouper,
+                         CustomFunctionPointerGrouper>
+    GrouperTestCases;
+
+TYPED_TEST_CASE_P(GroupByTester);
+
+template <typename GrouperFunction, typename ValueType,
+          typename GroupKey = typename details::grouper_return_type<
+              GrouperFunction, ValueType>::type,
+          typename std::enable_if<
+              !std::is_same<GrouperFunction, LeaveOneOutGrouper>::value,
+              int>::type = 0>
+void expect_group_key_matches_expected(const GrouperFunction &grouper,
+                                       const ValueType &value,
+                                       const GroupKey &expected) {
+  EXPECT_EQ(grouper(value), expected);
+}
+
+template <typename GrouperFunction, typename ValueType,
+          typename GroupKey = typename details::grouper_return_type<
+              GrouperFunction, ValueType>::type,
+          typename std::enable_if<
+              std::is_same<GrouperFunction, LeaveOneOutGrouper>::value,
+              int>::type = 0>
+void expect_group_key_matches_expected(const GrouperFunction &grouper,
+                                       const ValueType &value,
+                                       const GroupKey &expected) {}
+
+TYPED_TEST_P(GroupByTester, test_groupby_groups) {
+  auto parent = this->test_case.get_parent();
+  const auto grouped = group_by(parent, this->test_case.get_grouper());
+
+  // Can split into groups, and those groups align with the grouper
+  for (const auto &pair : grouped.groups()) {
+    // we only need this to get at the underlying iterable
+    const auto value_grouped =
+        group_by(pair.second, this->test_case.get_grouper());
+    for (const auto &f : value_grouped._get_iterable()) {
+      expect_group_key_matches_expected(this->test_case.get_grouper(), f,
+                                        pair.first);
+    }
+  }
+};
+
+template <typename FeatureType>
+void expect_same_but_maybe_out_of_order(
+    const RegressionDataset<FeatureType> &x,
+    const RegressionDataset<FeatureType> &y) {
+  EXPECT_EQ(vector_set_difference(x.features, y.features).size(), 0);
+  EXPECT_LT(fabs(x.targets.mean.sum() - y.targets.mean.sum()), 1e-10);
+}
+
+template <typename FeatureType>
+void expect_same_but_maybe_out_of_order(const std::vector<FeatureType> &x,
+                                        const std::vector<FeatureType> &y) {
+  EXPECT_EQ(vector_set_difference(x, y).size(), 0);
+}
+
+TYPED_TEST_P(GroupByTester, test_groupby_combine) {
+  auto parent = this->test_case.get_parent();
+  const auto grouped = group_by(parent, this->test_case.get_grouper());
+
+  const auto combined = grouped.groups().combine();
+
+  EXPECT_EQ(combined.size(), parent.size());
+
+  expect_same_but_maybe_out_of_order(combined, parent);
+}
+
+TYPED_TEST_P(GroupByTester, test_groupby_counts) {
+  auto parent = this->test_case.get_parent();
+  const auto grouped = group_by(parent, this->test_case.get_grouper());
+
+  const auto counts = grouped.counts();
+
+  for (const auto &pair : grouped.indexers()) {
+    EXPECT_EQ(counts.at(pair.first), pair.second.size());
+  }
+}
+
+TYPED_TEST_P(GroupByTester, test_groupby_modify_combine) {
+  auto parent = this->test_case.get_parent();
+  const auto grouped = group_by(parent, this->test_case.get_grouper());
+  auto groups = grouped.groups();
+
+  const auto first_key = map_keys(groups)[0];
+  const auto first_group = groups[first_key];
+
+  const std::size_t num_removed = first_group.size();
+  std::vector<std::size_t> single_ind = {};
+  groups[first_key] = albatross::subset(first_group, single_ind);
+
+  const auto combined = groups.combine();
+
+  EXPECT_EQ(combined.size(), parent.size() - num_removed);
+  EXPECT_EQ(combine(groups).size(), combined.size());
+}
+
+TYPED_TEST_P(GroupByTester, test_groupby_apply_combine) {
+  auto parent = this->test_case.get_parent();
+  const auto grouped = group_by(parent, this->test_case.get_grouper());
+
+  const auto only_keep_one = [](const auto &, const auto &one_group) {
+    std::vector<std::size_t> single_ind = {0};
+    return subset(one_group, single_ind);
+  };
+
+  const auto combined = grouped.apply(only_keep_one).combine();
+
+  // Same number of final combined elements as there are groups.
+  EXPECT_EQ(grouped.size(), combined.size());
+}
+
+TYPED_TEST_P(GroupByTester, test_groupby_apply_void) {
+  auto parent = this->test_case.get_parent();
+  const auto grouped = group_by(parent, this->test_case.get_grouper());
+
+  std::size_t count = 0;
+
+  const auto increment_count = [&](const auto &, const auto &) { ++count; };
+
+  grouped.apply(increment_count);
+
+  EXPECT_EQ(grouped.size(), count);
+}
+
+TYPED_TEST_P(GroupByTester, test_groupby_apply_value_only) {
+  auto parent = this->test_case.get_parent();
+  const auto grouped = group_by(parent, this->test_case.get_grouper());
+
+  std::size_t count = 0;
+
+  const auto increment_count = [&](const auto &) { ++count; };
+
+  grouped.apply(increment_count);
+
+  EXPECT_EQ(grouped.size(), count);
+}
+
+TYPED_TEST_P(GroupByTester, test_groupby_index_apply) {
+  auto parent = this->test_case.get_parent();
+  const auto grouped = group_by(parent, this->test_case.get_grouper());
+
+  std::size_t count = 0;
+
+  const auto increment_count = [&](const auto &, const GroupIndices &) {
+    ++count;
+  };
+
+  grouped.index_apply(increment_count);
+
+  EXPECT_EQ(grouped.size(), count);
+}
+
+TYPED_TEST_P(GroupByTester, test_groupby_filter) {
+  auto parent = this->test_case.get_parent();
+  const auto grouped = group_by(parent, this->test_case.get_grouper());
+
+  const auto keys = grouped.keys();
+  assert(keys.size() > 1);
+
+  const auto remove_first = [&keys](const auto &key, const auto &) {
+    return !(key == keys[0]);
+  };
+
+  const auto filtered = grouped.filter(remove_first);
+
+  EXPECT_EQ(filtered.size(), grouped.size() - 1);
+
+  // Combine, then regroup and make sure the combined object no longer
+  // contains the removed group.
+  EXPECT_EQ(group_by(filtered.combine(), this->test_case.get_grouper()).size(),
+            filtered.size());
+}
+
+REGISTER_TYPED_TEST_CASE_P(GroupByTester, test_groupby_groups,
+                           test_groupby_counts, test_groupby_combine,
+                           test_groupby_modify_combine,
+                           test_groupby_apply_combine, test_groupby_apply_void,
+                           test_groupby_filter, test_groupby_apply_value_only,
+                           test_groupby_index_apply);
+
+INSTANTIATE_TYPED_TEST_CASE_P(test_groupby, GroupByTester, GrouperTestCases);
+
+/*
+ * Test Filtering
+ */
+
+std::vector<double> fibonacci(std::size_t n) {
+  assert(n > 2);
+  std::vector<double> fib = {1., 2.};
+  for (std::size_t i = 2; i < n; ++i) {
+    fib.emplace_back(fib[i - 1] + fib[i - 2]);
+  }
+  return fib;
+}
+
+double mean(const std::vector<double> &xs) {
+  double mean = 0;
+  for (const auto &x : xs) {
+    mean += x;
+  }
+  return mean / xs.size();
+}
+
+long int number_of_digits(double x) { return lround(floor(log10(x))); }
+
+std::vector<double>
+direct_remove_less_than_mean(const std::vector<double> &xs) {
+
+  std::map<long, std::vector<double>> grouped;
+  for (const auto &x : xs) {
+    long digits = number_of_digits(x);
+    if (grouped.find(digits) == grouped.end()) {
+      grouped[digits] = {x};
+    } else {
+      grouped[digits].emplace_back(x);
+    }
+  }
+
+  std::vector<double> output;
+  for (const auto group_pair : grouped) {
+    const double group_mean = mean(group_pair.second);
+    for (const auto &v : group_pair.second) {
+      if (v > group_mean) {
+        output.emplace_back(v);
+      }
+    }
+  }
+
+  return output;
+}
+
+std::vector<double>
+split_apply_combine_less_than_mean(const std::vector<double> &xs) {
+
+  const auto remove_less_than_mean = [](const std::vector<double> &group) {
+    const double group_mean = mean(group);
+    const auto is_greater_than_mean = [&group_mean](const double &x) {
+      return x > group_mean;
+    };
+    return filter(group, is_greater_than_mean);
+  };
+
+  return group_by(xs, number_of_digits).apply(remove_less_than_mean).combine();
+}
+
+TEST(test_groupby, test_group_by_nested_filter) {
+
+  const auto fib = fibonacci(20);
+
+  const auto filtered = split_apply_combine_less_than_mean(fib);
+
+  const auto direct = direct_remove_less_than_mean(fib);
+
+  EXPECT_EQ(direct.size(), filtered.size());
+
+  for (std::size_t i = 0; i < direct.size(); ++i) {
+    EXPECT_EQ(direct[i], filtered[i]);
+  }
+}
+
+} // namespace albatross

--- a/tests/test_indexing.cc
+++ b/tests/test_indexing.cc
@@ -11,6 +11,7 @@
  */
 
 #include <albatross/Core>
+#include <albatross/Indexing>
 
 #include <gtest/gtest.h>
 

--- a/tests/test_random_utils.cc
+++ b/tests/test_random_utils.cc
@@ -12,7 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <albatross/Core>
-
+#include <albatross/Indexing>
 #include <albatross/src/utils/random_utils.hpp>
 
 namespace albatross {

--- a/tests/test_traits_indexing.cc
+++ b/tests/test_traits_indexing.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Na vigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include "../include/albatross/Indexing"
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+struct X {
+  int something;
+  std::string other;
+};
+
+TEST(test_traits_indexing, test_is_valid_map_key) {
+  EXPECT_TRUE(bool(details::is_valid_map_key<int>::value));
+  EXPECT_FALSE(bool(details::is_valid_map_key<X>::value));
+  EXPECT_FALSE(bool(details::is_valid_map_key<void>::value));
+}
+
+std::string free_string_const_ref_int(const int &x) { return "int"; }
+
+std::string free_string_ref_int(int &x) { return free_string_const_ref_int(x); }
+
+std::string free_string_int(int x) { return free_string_const_ref_int(x); }
+
+std::string free_string_X(const X &x) { return "x"; }
+
+const auto lambda_string_const_ref_int = [](const int &x) {
+  return free_string_const_ref_int(x);
+};
+
+struct CallOperatorStringConstRefInt {
+  std::string operator()(const int &x) const {
+    return free_string_const_ref_int(x);
+  }
+};
+
+CallOperatorStringConstRefInt call_operator_string_const_ref_int;
+
+template <typename T> class TestCanBeCalledWithInt : public ::testing::Test {};
+
+template <typename _FunctionType, typename _ReturnType> struct WithReturnType {
+  using FunctionType = _FunctionType;
+  using ReturnType = _ReturnType;
+};
+
+typedef ::testing::Types<
+    WithReturnType<decltype(free_string_const_ref_int), std::string>,
+    //    decltype(free_string_ref_int),  WHY DOESN'T THIS ONE WORK??
+    WithReturnType<decltype(free_string_int), std::string>,
+    WithReturnType<decltype(lambda_string_const_ref_int), std::string>,
+    WithReturnType<decltype(call_operator_string_const_ref_int), std::string>,
+    WithReturnType<CallOperatorStringConstRefInt, std::string>>
+    TestFunctions;
+
+TYPED_TEST_CASE(TestCanBeCalledWithInt, TestFunctions);
+
+TYPED_TEST(TestCanBeCalledWithInt, test_callable_traits) {
+  using Expected = typename TypeParam::ReturnType;
+
+  using FunctionType = typename TypeParam::FunctionType;
+  EXPECT_TRUE(bool(details::callable_traits<FunctionType, int>::is_defined));
+  EXPECT_TRUE(
+      bool(std::is_same<Expected, typename details::callable_traits<
+                                      FunctionType, int>::return_type>::value));
+  // HOW SHOULD IT BEHAVE IF YOU CAN CONVERT AN ARGUMENT AND CALL???
+  // EXPECT_TRUE(bool(details::can_be_called_with<ToTest, double>::value));
+  EXPECT_FALSE(bool(details::callable_traits<FunctionType, X>::is_defined));
+}
+
+TYPED_TEST(TestCanBeCalledWithInt, test_can_be_called_with) {
+  using FunctionType = typename TypeParam::FunctionType;
+  EXPECT_TRUE(bool(details::can_be_called_with<FunctionType, int>::value));
+}
+
+TYPED_TEST(TestCanBeCalledWithInt, test_can_be_called_with_return_type) {
+  using Expected = typename TypeParam::ReturnType;
+  using FunctionType = typename TypeParam::FunctionType;
+  EXPECT_TRUE(bool(
+      std::is_same<Expected, typename details::return_type_when_called_with<
+                                 FunctionType, int>::type>::value));
+}
+
+TYPED_TEST(TestCanBeCalledWithInt, test_is_valid_grouper) {
+  using FunctionType = typename TypeParam::FunctionType;
+  EXPECT_TRUE(bool(details::is_valid_grouper<FunctionType, int>::value));
+  EXPECT_FALSE(bool(details::is_valid_grouper<FunctionType, X>::value));
+}
+
+template <typename... Args> struct Tester {
+  template <typename FunctionType> bool test(const FunctionType &) const {
+    return details::can_be_called_with<FunctionType, Args...>::value;
+  }
+};
+
+// Here we make sure can_be_called_with works when the type of the
+// functions is deduced by the compiler.
+TEST(test_traits_indexing, test_can_be_called_with_deduction) {
+  const Tester<int> int_tester;
+  const Tester<X> x_tester;
+
+  EXPECT_TRUE(int_tester.test(free_string_const_ref_int));
+  //  EXPECT_TRUE(int_tester.test(free_string_ref_int));
+  EXPECT_TRUE(int_tester.test(free_string_int));
+  EXPECT_TRUE(int_tester.test(lambda_string_const_ref_int));
+  EXPECT_TRUE(int_tester.test(call_operator_string_const_ref_int));
+  EXPECT_TRUE(int_tester.test(CallOperatorStringConstRefInt()));
+  EXPECT_TRUE(int_tester.test(
+      [](const int &x) { return free_string_const_ref_int(x); }));
+  EXPECT_TRUE(int_tester.test(
+      [](const auto &x) { return free_string_const_ref_int(x); }));
+
+  EXPECT_FALSE(x_tester.test(free_string_const_ref_int));
+  EXPECT_FALSE(x_tester.test(free_string_ref_int));
+  EXPECT_FALSE(x_tester.test(free_string_int));
+  EXPECT_FALSE(x_tester.test(lambda_string_const_ref_int));
+  EXPECT_FALSE(x_tester.test(call_operator_string_const_ref_int));
+  EXPECT_FALSE(x_tester.test(CallOperatorStringConstRefInt()));
+  EXPECT_FALSE(
+      x_tester.test([](const int &x) { return free_string_const_ref_int(x); }));
+}
+
+/*
+ * Test Filter Function Traits
+ */
+bool free_bool_const_ref_int(const int &x) { return true; }
+
+bool free_bool_ref_int(int &x) { return free_bool_const_ref_int(x); }
+
+bool free_bool_int(int x) { return free_bool_const_ref_int(x); }
+
+bool free_bool_X(const X &x) { return true; }
+
+const auto lambda_bool_const_ref_int = [](const int &x) {
+  return free_bool_const_ref_int(x);
+};
+
+const bool need_this_or_clang_complains_about_unused_variables =
+    lambda_bool_const_ref_int(0);
+
+struct CallOperatorBoolConstRefInt {
+  bool operator()(const int &x) const { return free_bool_const_ref_int(x); }
+};
+
+CallOperatorBoolConstRefInt call_operator_bool_const_ref_int;
+
+template <typename T>
+class TestIsValueFilterFunction : public ::testing::Test {};
+
+typedef ::testing::Types<
+    decltype(free_bool_const_ref_int), decltype(free_bool_int),
+    decltype(lambda_bool_const_ref_int), CallOperatorBoolConstRefInt>
+    ValueFilterFunctionTestCases;
+
+TYPED_TEST_CASE(TestIsValueFilterFunction, ValueFilterFunctionTestCases);
+
+TYPED_TEST(TestIsValueFilterFunction, test_is_value_filter_function) {
+  EXPECT_TRUE(bool(
+      details::is_valid_value_only_filter_function<TypeParam, int>::value));
+}
+
+} // namespace albatross


### PR DESCRIPTION
A pretty common pattern that has emerged when using `albatross` is the desire to split a dataset into groups, and inspect or modify on a per group basis, then occasionally recombine the results into a new dataset.  This PR adds a `group_by` method to dataset which facilitates these sorts of operations.

For example, what used to look like this:
```
const LeaveOneGroupOut<FeatureType> get_groups(get_group_name);
const auto by_group = by_groups(dataset.features);
for (const auto &pair : by_group) {
  const std::string group_name = pair.first;
  const std::vector<std::size_t> group_indexer = pair.second;
  const auto group_dataset = albatross::subset(dataset, group_indexer);
  do_something(group_dataset);
}
```
Can now be done like this:
```
dataset.group_by(get_group_name).apply(do_something);
```
Similarly you do sort-of-kind-of pandas style split-apply-combine operations:
```
const auto remove_bad_things = [](const auto &group_name, const auto &dataset) {
  return remove(dataset);
}
const auto clean_dataset = dataset.group_by(&get_group_name).apply(remove_bad_things).combine();
```
I stopped short of completely flushing out all desired functionality in the interest of getting some feedback (and keeping an already large PR from growing larger).  A lot of the trait logic (for example) is going to get an overhaul.  And for the moment this PR doesn't actually use the group by logic anywhere (but I have a follow up PR which does).

Currently supported operations:
```
auto groups = dataset.group_by(get_group).groups();
auto same_dataset = groups.combine();
auto modified_groups = dataset.group_by(get_group).apply(do_something_to_each_group);
// same for vectors
auto groups = group_by(vector, get_group).groups();
etc ...
// some simple operations over the groups
auto map_containing_size_of_each_group = dataset.group_by(get_group).counts();
// ability to remove groups (using filter).
auto dataset_without_outliers = dataset.group_by(get_group).filter(is_ok).combine();
```