### PR TITLE
Stop Using Measurement Wrapper

### DIFF
--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -242,8 +242,10 @@ public:
   CholeskyFit<FeatureType>
   _fit_impl(const std::vector<FeatureType> &features,
             const MarginalDistribution &targets) const {
-    const auto measurement_features = as_measurements(features);
-    Eigen::MatrixXd cov = covariance_function_(measurement_features);
+    Eigen::MatrixXd cov = covariance_function_(features);
+    if (targets.has_covariance()) {
+      cov += targets.covariance;
+    }
     return CholeskyFit<FeatureType>(features, cov, targets);
   }
 


### PR DESCRIPTION
The `Measurement` wrapper type is only used in one place and was causing an issue in which a covariance function with templated arguments looks like it is defined for `Measurement<T>` types which results in unexpected behavior.  For example the following covariance function
```
class OneIfDouble : public CovarianceFunction<OneIfDouble> {
 public:

  double _call_impl(const double &x, const double &y) const {
    return 1.;
  }
  template <typename X, typename Y>
  double _call_impl(const X &x, const Y &y) const {
    return 0.;
  }
};
```
Would fail the following test.
```
OneIfDouble cov;
EXPECT_EQ(cov(Measurement<double>, Measurement<double>), 1.);
```
