### PR TITLE
Revert the measurement change which wasn't actually tested.

### DIFF
--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -242,10 +242,8 @@ public:
   CholeskyFit<FeatureType>
   _fit_impl(const std::vector<FeatureType> &features,
             const MarginalDistribution &targets) const {
-    Eigen::MatrixXd cov = covariance_function_(features);
-    if (targets.has_covariance()) {
-      cov += targets.covariance;
-    }
+    const auto measurement_features = as_measurements(features);
+    Eigen::MatrixXd cov = covariance_function_(measurement_features);
     return CholeskyFit<FeatureType>(features, cov, targets);
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,39 @@
 add_executable(albatross_unit_tests 
+  test_block_utils.cc
+  test_call_trace.cc
+  test_callers.cc
+  test_concatenate.cc
+  test_core_dataset.cc
+  test_core_distribution.cc
+  test_core_model.cc
+  test_covariance_function.cc
+  test_covariance_functions.cc
+  test_cross_validation.cc
   test_csv_utils.cc
+  test_distance_metrics.cc
+  test_eigen_utils.cc
+  test_evaluate.cc
+  test_gp.cc
+  test_indexing.cc
+  test_map_utils.cc
+  test_model_adapter.cc
+  test_model_metrics.cc  
+  test_models.cc
+  test_parameter_handling_mixin.cc
+  test_prediction.cc
+  test_radial.cc
+  test_random_utils.cc
+  test_ransac.cc
+  test_scaling_function.cc
+  test_serializable_ldlt.cc
+  test_serialize.cc
+  test_sparse_gp.cc
+  test_traits_cereal.cc
+  test_traits_core.cc
+  test_traits_details.cc
+  test_traits_covariance_functions.cc
+  test_traits_evaluation.cc
+  test_tune.cc
   )
 target_include_directories(albatross_unit_tests SYSTEM PRIVATE
   "${gtest_SOURCE_DIR}"


### PR DESCRIPTION
Turns out the `Measurement<T>` flags are used in the `SparseGaussianProcess` and are actually quite important there.  Basically, the `SparseGaussianProcess` may be using the same feature type for both the input features and the inducing points.  This is the case in some of the tests where the data points are all `double` and the inducing points are also a uniform grid of `double`.  In this situation we want the covariance function to evaluate the covariance between inputs as being measurements, but do not want the measurement noise when evaluating the covariance between inducing points.

As a result I've put the `as_measurement` step back into `_fit_impl`.  Also, I (re)discovered that the target variance *is* being added inside the `Fit` constructor.

This was all caught after realizing PR #161 actually reduced the tests to only the csv tests :grimacing: .  Overall, not a good streak in the last two PRs!  Ooops!