### PR TITLE
Macro and Call Trace improvements.

### DIFF
--- a/include/albatross/src/core/traits.hpp
+++ b/include/albatross/src/core/traits.hpp
@@ -61,7 +61,7 @@ public:
   static constexpr bool value = decltype(test<T>(0))::value;
 };
 
-HAS_METHOD(_fit_impl);
+DEFINE_CLASS_METHOD_TRAITS(_fit_impl);
 
 template <typename T, typename FeatureType>
 class has_possible_fit : public has__fit_impl<T, std::vector<FeatureType> &,
@@ -139,9 +139,7 @@ public:
   typedef decltype(test<T>(0)) type;
 };
 
-MAKE_HAS_ANY_TRAIT(_predict_impl);
-
-HAS_METHOD_WITH_RETURN_TYPE(_predict_impl);
+DEFINE_CLASS_METHOD_TRAITS(_predict_impl);
 
 template <typename T, typename FeatureType, typename FitType,
           typename PredictType>
@@ -163,7 +161,7 @@ template <typename T, typename FeatureType, typename FitType>
 using has_valid_predict_joint =
     has_valid_predict<T, FeatureType, FitType, JointDistribution>;
 
-HAS_METHOD(_mean);
+DEFINE_CLASS_METHOD_TRAITS(_mean);
 
 template <typename T, typename ModelType, typename FeatureType,
           typename FitType>
@@ -172,7 +170,7 @@ struct can_predict_mean
                        typename const_ref<FitType>::type,
                        typename const_ref<std::vector<FeatureType>>::type> {};
 
-HAS_METHOD(_marginal);
+DEFINE_CLASS_METHOD_TRAITS(_marginal);
 
 template <typename T, typename ModelType, typename FeatureType,
           typename FitType>
@@ -182,7 +180,7 @@ struct can_predict_marginal
                            typename const_ref<std::vector<FeatureType>>::type> {
 };
 
-HAS_METHOD(_joint);
+DEFINE_CLASS_METHOD_TRAITS(_joint);
 
 template <typename T, typename ModelType, typename FeatureType,
           typename FitType>

--- a/include/albatross/src/covariance_functions/call_trace.hpp
+++ b/include/albatross/src/covariance_functions/call_trace.hpp
@@ -103,26 +103,15 @@ public:
   CallTrace(const CovFunc &cov_func) : cov_func_(cov_func){};
 
   template <typename X, typename Y,
+            typename std::enable_if<has_call_operator<CovFunc, X &, Y &>::value,
+                                    int>::type = 0>
+  std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
+    return {{cov_func_.get_name(), std::to_string(cov_func_(x, y))}};
+  }
+
+  template <typename X, typename Y,
             typename std::enable_if<
-                has_valid_call_impl<CovFunc, X &, Y &>::value, int>::type = 0>
-  std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
-    return {{cov_func_.get_name(), std::to_string(cov_func_(x, y))}};
-  }
-
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(has_valid_call_impl<CovFunc, Y &, X &>::value &&
-                               !has_valid_call_impl<CovFunc, X &, Y &>::value),
-                              int>::type = 0>
-  std::vector<CallAndValue> get_trace(const X &x, const Y &y) const {
-    return {{cov_func_.get_name(), std::to_string(cov_func_(x, y))}};
-  }
-
-  template <
-      typename X, typename Y,
-      typename std::enable_if<(!has_valid_call_impl<CovFunc, Y &, X &>::value &&
-                               !has_valid_call_impl<CovFunc, X &, Y &>::value),
-                              int>::type = 0>
+                !has_call_operator<CovFunc, X &, Y &>::value, int>::type = 0>
   std::vector<CallAndValue> get_trace(const X &, const Y &) const {
     return {{cov_func_.get_name(), "UNDEFINED"}};
   }
@@ -139,8 +128,8 @@ public:
 
   template <typename X, typename Y,
             typename std::enable_if<
-                has_valid_call_impl<SumOfCovarianceFunctions<LHS, RHS>, X &,
-                                    Y &>::value,
+                has_call_operator<SumOfCovarianceFunctions<LHS, RHS>, X &,
+                                  Y &>::value,
                 int>::type = 0>
   std::string eval(const X &x, const Y &y) const {
     std::ostringstream oss;
@@ -150,8 +139,8 @@ public:
 
   template <typename X, typename Y,
             typename std::enable_if<
-                !has_valid_call_impl<SumOfCovarianceFunctions<LHS, RHS>, X &,
-                                     Y &>::value,
+                !has_call_operator<SumOfCovarianceFunctions<LHS, RHS>, X &,
+                                   Y &>::value,
                 int>::type = 0>
   std::string eval(const X &, const Y &) const {
     return "UNDEFINED";
@@ -185,8 +174,8 @@ public:
 
   template <typename X, typename Y,
             typename std::enable_if<
-                has_valid_call_impl<ProductOfCovarianceFunctions<LHS, RHS>, X &,
-                                    Y &>::value,
+                has_call_operator<ProductOfCovarianceFunctions<LHS, RHS>, X &,
+                                  Y &>::value,
                 int>::type = 0>
   std::string eval(const X &x, const Y &y) const {
     std::ostringstream oss;
@@ -196,8 +185,8 @@ public:
 
   template <typename X, typename Y,
             typename std::enable_if<
-                !has_valid_call_impl<ProductOfCovarianceFunctions<LHS, RHS>,
-                                     X &, Y &>::value,
+                !has_call_operator<ProductOfCovarianceFunctions<LHS, RHS>, X &,
+                                   Y &>::value,
                 int>::type = 0>
   std::string eval(const X &, const Y &) const {
     return "UNDEFINED";

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -20,14 +20,12 @@ MAKE_HAS_ANY_TRAIT(_call_impl);
 // A helper rename to avoid duplicate underscores.
 template <typename U> class has_any_call_impl : public has_any__call_impl<U> {};
 
-HAS_METHOD_WITH_RETURN_TYPE(_call_impl);
+DEFINE_CLASS_METHOD_TRAITS(_call_impl);
 
 template <typename U, typename... Args>
-class has_valid_call_impl : public has__call_impl_with_return_type<
-                                U, double, typename const_ref<Args>::type...> {
-};
-
-HAS_METHOD(_call_impl);
+class has_valid_call_impl
+    : public has__call_impl_with_return_type<
+          const U, double, typename const_ref<Args>::type...> {};
 
 template <typename U, typename... Args>
 class has_possible_call_impl : public has__call_impl<U, Args &...> {};
@@ -35,7 +33,8 @@ class has_possible_call_impl : public has__call_impl<U, Args &...> {};
 /*
  * has_valid_cov_caller
  */
-HAS_METHOD_WITH_RETURN_TYPE(call);
+
+DEFINE_CLASS_METHOD_TRAITS(call);
 
 template <typename CovFunc, typename Caller, typename... Args>
 class has_valid_cov_caller
@@ -77,7 +76,7 @@ public:
                                  !has_valid_call_impl<T, Args...>::value);
 };
 
-HAS_METHOD(solve);
+DEFINE_CLASS_METHOD_TRAITS(solve);
 
 /*
  * Has valid caller for all variants

--- a/include/albatross/src/details/has_any_macros.hpp
+++ b/include/albatross/src/details/has_any_macros.hpp
@@ -22,7 +22,7 @@ template <typename First, typename Second> struct TypePair {
 
 /*
  * Defines a couple of traits which help inspect whether a type has a method
- * which is callable whne provided with specific arguments.
+ * which is callable when provided with specific arguments.
  *
  *   template <typename T, typename ... Args>
  *   struct class_method_FNAME_traits {

--- a/include/albatross/src/details/has_any_macros.hpp
+++ b/include/albatross/src/details/has_any_macros.hpp
@@ -15,29 +15,70 @@
 
 namespace albatross {
 
-#define HAS_METHOD(fname)                                                      \
-  template <typename T, typename... Args> class has_##fname {                  \
-    template <typename C, typename = decltype(std::declval<C>().fname(         \
-                              std::declval<Args>()...))>                       \
-    static std::true_type test(C *);                                           \
-    template <typename> static std::false_type test(...);                      \
-                                                                               \
-  public:                                                                      \
-    static constexpr bool value = decltype(test<T>(0))::value;                 \
-  };
+template <typename First, typename Second> struct TypePair {
+  using first_type = First;
+  using second_type = Second;
+};
 
-#define HAS_METHOD_WITH_RETURN_TYPE(fname)                                     \
-  template <typename T, typename ReturnType, typename... Args>                 \
-  class has_##fname##_with_return_type {                                       \
+/*
+ * Defines a couple of traits which help inspect whether a type has a method
+ * which is callable whne provided with specific arguments.
+ *
+ *   template <typename T, typename ... Args>
+ *   struct class_method_FNAME_traits {
+ *     static constexpr bool is_defined;
+ *     typename return_type;
+ *   }
+ *
+ * So for example:
+ *
+ *   class_method_foo_traits<Bar, int, double>::is_defined;
+ *
+ * would be a static bool which would tell you if you can call:
+ *
+ *   Bar.foo(int(1), double(3.14159));
+ *
+ * similarly:
+ *
+ *   class_method_foo_traits<Bar, int, double>::return_type
+ *
+ * would tell you the return type.  Note that if the method is not
+ * defined `return_type` will be void, be sure to check `is_defined`
+ * if you want to make sure the call is feasible, or use the
+ * helper class:
+ *
+ *   has_foo_with_return_type<Bar, ExpectedReturnType, int, double>::value
+ *
+ * Similarly there is a helper class if you want to check if the
+ * method exists in a (slightly) more concise way:
+ *
+ *   has_foo<Bar, int, double>::value
+ */
+#define DEFINE_CLASS_METHOD_TRAITS(fname)                                      \
+  template <typename T, typename... Args>                                      \
+  class class_method_##fname##_traits {                                        \
     template <typename C,                                                      \
-              typename ActualReturnType = decltype(                            \
-                  std::declval<const C>().fname(std::declval<Args>()...))>     \
-    static typename std::is_same<ActualReturnType, ReturnType>::type           \
-    test(C *);                                                                 \
-    template <typename> static std::false_type test(...);                      \
+              typename ReturnType =                                            \
+                  decltype(std::declval<C>().fname(std::declval<Args>()...))>  \
+    static TypePair<std::true_type, ReturnType> test(C *);                     \
+    template <typename> static TypePair<std::false_type, void> test(...);      \
                                                                                \
   public:                                                                      \
-    static constexpr bool value = decltype(test<T>(0))::value;                 \
+    static constexpr bool is_defined =                                         \
+        decltype(test<T>(0))::first_type::value;                               \
+    using return_type = typename decltype(test<T>(0))::second_type;            \
+  };                                                                           \
+                                                                               \
+  template <typename T, typename... Args> struct has_##fname {                 \
+    static constexpr bool value =                                              \
+        class_method_##fname##_traits<T, Args...>::is_defined;                 \
+  };                                                                           \
+  template <typename T, typename ReturnType, typename... Args>                 \
+  struct has_##fname##_with_return_type {                                      \
+    using MethodTraits = class_method_##fname##_traits<T, Args...>;            \
+    static constexpr bool value =                                              \
+        MethodTraits::is_defined &&                                            \
+        std::is_same<ReturnType, typename MethodTraits::return_type>::value;   \
   };
 
 /*


### PR DESCRIPTION
These changes started from an attempt to fix https://github.com/swift-nav/albatross/issues/166 by inspecting covariance functions for specialized implementations specific to `Measurement` types, but that attempt failed.

In the process however I ended up with these two commits which I think are worth getting in.
- The first is a change to the macros which define the `has_any_*` and `has_any_*_with_return_type` traits which consolidated the trickiest part of the logic into one place.
- The second fixes a bug in the `CallTrace` method in which it was possible for the call trace that got generated to differ from the actual covariance evaluation.