### PR TITLE
Eigen Value Debug Utils

### DIFF
--- a/include/albatross/src/utils/linalg_utils.hpp
+++ b/include/albatross/src/utils/linalg_utils.hpp
@@ -17,10 +17,13 @@ namespace albatross {
 
 namespace details {
 
+constexpr double DEFAULT_EIGEN_VALUE_PRINT_THRESHOLD = 1e-3;
+
 template <typename FeatureType, typename Comparator>
 inline void _print_eigen_directions(const Eigen::MatrixXd &matrix,
                                     const std::vector<FeatureType> &features,
                                     std::size_t count, Comparator comp,
+                                    double print_if_above,
                                     std::ostream *stream) {
   Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> ev(matrix);
   const Eigen::VectorXd values = ev.eigenvalues().real();
@@ -47,7 +50,7 @@ inline void _print_eigen_directions(const Eigen::MatrixXd &matrix,
     (*stream) << "eigen value: " << value << std::endl;
     for (Eigen::Index j = 0; j < vector.size(); ++j) {
       double coef = vector[j];
-      if (fabs(coef) > 1e-3) {
+      if (fabs(coef) > print_if_above) {
         (*stream) << "    " << std::setw(12) << coef << "   " << features[j]
                   << std::endl;
       }
@@ -60,23 +63,29 @@ inline void _print_eigen_directions(const Eigen::MatrixXd &matrix,
 template <typename FeatureType>
 inline void print_small_eigen_directions(
     const Eigen::MatrixXd &matrix, const std::vector<FeatureType> &features,
-    std::size_t count, std::ostream *stream = &std::cout) {
+    std::size_t count,
+    double print_if_above = details::DEFAULT_EIGEN_VALUE_PRINT_THRESHOLD,
+    std::ostream *stream = &std::cout) {
   const auto ascending = [&](const double &a, const double &b) -> bool {
     return a < b;
   };
 
-  details::_print_eigen_directions(matrix, features, count, ascending, stream);
+  details::_print_eigen_directions(matrix, features, count, ascending,
+                                   print_if_above, stream);
 }
 
 template <typename FeatureType>
 inline void print_large_eigen_directions(
     const Eigen::MatrixXd &matrix, const std::vector<FeatureType> &features,
-    std::size_t count, std::ostream *stream = &std::cout) {
+    std::size_t count,
+    double print_if_above = details::DEFAULT_EIGEN_VALUE_PRINT_THRESHOLD,
+    std::ostream *stream = &std::cout) {
   const auto decending = [&](const double &a, const double &b) -> bool {
     return a > b;
   };
 
-  details::_print_eigen_directions(matrix, features, count, decending, stream);
+  details::_print_eigen_directions(matrix, features, count, decending,
+                                   print_if_above, stream);
 }
 
 } // namespace albatross

--- a/include/albatross/src/utils/linalg_utils.hpp
+++ b/include/albatross/src/utils/linalg_utils.hpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_UTILS_LINALG_UTILS_HPP_
+#define ALBATROSS_UTILS_LINALG_UTILS_HPP_
+
+namespace albatross {
+
+namespace details {
+
+template <typename FeatureType, typename Comparator>
+inline void _print_eigen_directions(const Eigen::MatrixXd &matrix,
+                                    const std::vector<FeatureType> &features,
+                                    std::size_t count, Comparator comp,
+                                    std::ostream *stream) {
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> ev(matrix);
+  const Eigen::VectorXd values = ev.eigenvalues().real();
+  const Eigen::MatrixXd vectors = ev.eigenvectors();
+
+  using ValueAndVector = std::tuple<double, Eigen::VectorXd>;
+  std::vector<ValueAndVector> values_and_vectors;
+
+  for (Eigen::Index i = 0; i < values.size(); ++i) {
+    values_and_vectors.emplace_back(values[i], vectors.col(i));
+  }
+
+  std::sort(values_and_vectors.begin(), values_and_vectors.end(),
+            [&](const ValueAndVector &a, const ValueAndVector &b) -> bool {
+              return comp(std::get<0>(a), std::get<0>(b));
+            });
+
+  (*stream) << "MIN: " << values.minCoeff() << std::endl;
+  (*stream) << "MAX: " << values.maxCoeff() << std::endl;
+
+  for (std::size_t i = 0; i < count; ++i) {
+    const double value = std::get<0>(values_and_vectors[i]);
+    const auto vector = std::get<1>(values_and_vectors[i]);
+    (*stream) << "eigen value: " << value << std::endl;
+    for (Eigen::Index j = 0; j < vector.size(); ++j) {
+      double coef = vector[j];
+      if (fabs(coef) > 1e-3) {
+        (*stream) << "    " << std::setw(12) << coef << "   " << features[j]
+                  << std::endl;
+      }
+    }
+  }
+}
+
+} // namespace details
+
+template <typename FeatureType>
+inline void print_small_eigen_directions(
+    const Eigen::MatrixXd &matrix, const std::vector<FeatureType> &features,
+    std::size_t count, std::ostream *stream = &std::cout) {
+  const auto ascending = [&](const double &a, const double &b) -> bool {
+    return a < b;
+  };
+
+  details::_print_eigen_directions(matrix, features, count, ascending, stream);
+}
+
+template <typename FeatureType>
+inline void print_large_eigen_directions(
+    const Eigen::MatrixXd &matrix, const std::vector<FeatureType> &features,
+    std::size_t count, std::ostream *stream = &std::cout) {
+  const auto decending = [&](const double &a, const double &b) -> bool {
+    return a > b;
+  };
+
+  details::_print_eigen_directions(matrix, features, count, decending, stream);
+}
+
+} // namespace albatross
+
+#endif /* ALBATROSS_UTILS_LINALG_UTILS_HPP_ */

--- a/include/albatross/utils/LinalgUtils
+++ b/include/albatross/utils/LinalgUtils
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_UTILS_LINALG_UTILS_H
+#define ALBATROSS_UTILS_LINALG_UTILS_H
+
+#include "../src/utils/linalg_utils.hpp"
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(albatross_unit_tests
   test_evaluate.cc
   test_gp.cc
   test_indexing.cc
+  test_linalg_utils.cc
   test_map_utils.cc
   test_model_adapter.cc
   test_model_metrics.cc  

--- a/tests/test_linalg_utils.cc
+++ b/tests/test_linalg_utils.cc
@@ -27,10 +27,14 @@ TEST(test_linalg_utils, test_print_eigen_values) {
     features.push_back(i);
   }
 
+  // Simple sanity check;
   std::ostringstream oss;
-  print_small_eigen_directions(random, features, k - 4, &oss);
-
-  print_large_eigen_directions(random, features, k - 4, &oss);
+  print_small_eigen_directions(random, features, k - 4,
+                               details::DEFAULT_EIGEN_VALUE_PRINT_THRESHOLD,
+                               &oss);
+  print_large_eigen_directions(random, features, k - 4,
+                               details::DEFAULT_EIGEN_VALUE_PRINT_THRESHOLD,
+                               &oss);
 }
 
 } // namespace albatross

--- a/tests/test_linalg_utils.cc
+++ b/tests/test_linalg_utils.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/Core>
+#include <albatross/utils/LinalgUtils>
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+TEST(test_linalg_utils, test_print_eigen_values) {
+
+  Eigen::Index k = 10;
+  Eigen::MatrixXd random = Eigen::MatrixXd::Random(k, k);
+  random = random * random.transpose();
+
+  std::vector<int> features;
+  for (Eigen::Index i = 0; i < k; ++i) {
+    features.push_back(i);
+  }
+
+  std::ostringstream oss;
+  print_small_eigen_directions(random, features, k - 4, &oss);
+
+  print_large_eigen_directions(random, features, k - 4, &oss);
+}
+
+} // namespace albatross


### PR DESCRIPTION
Added `linalg_utils.cc` which includes a couple methods which make it easy to print small / large eigen values along with the features that correspond.  This has proven useful when debugging situations that are either unobservable or overly constrained.

To illustrate how this can be useful here's an example in which we build a covariance matrix which represents an ill conditioned problem. Staring with two independent variables of different scales:
```
u ~ N(0, 10)
v ~ N(0, 0.01)
```
We can then build a new system which will contain two very highly correlated variables
```
x = u + v
y = u - v
```
This sets up that situation:
```
Eigen::Index k = 2;
// This represents the variance of u and v 
Eigen::VectorXd diag(k);
diag << 100., 1e-4;
// permute translates from u, v to x, y
Eigen::MatrixXd permute(k, k);
permute.row(0) << 1., 1.;
permute.row(1) << 1., -1.;
// Build the new system
Eigen::MatrixXd covariance = permute * diag.asDiagonal();
covariance = covariance * permute.transpose();
// Use some simple features
std::vector<int> features;
for (Eigen::Index i = 0; i < k; ++i) {
  features.push_back(i);
}
```
After which a call to: `print_small_eigen_directions(covariance, features, k)` would result in:
```
MIN: 0.0002
MAX: 200
eigen value: 0.0002
       -0.707107   0
        0.707107   1
eigen value: 200
        0.707107   0
        0.707107   1
```
From which we can see `x - y` is very observable (variance of `0.0002`) while `x + y` is extremely noisy (variance of `200`).