### PR TITLE
Consensus Metric for GPs

### DIFF
--- a/include/albatross/src/cereal/ransac.hpp
+++ b/include/albatross/src/cereal/ransac.hpp
@@ -42,11 +42,13 @@ inline void serialize(Archive &archive,
   archive(cereal::make_nvp("indexing_function", strategy.indexing_function_));
 }
 
-template <typename Archive, typename InlierMetric, typename IndexingFunction>
-inline void serialize(
-    Archive &archive,
-    GaussianProcessRansacStrategy<InlierMetric, IndexingFunction> &strategy,
-    const std::uint32_t) {
+template <typename Archive, typename InlierMetric, typename ConsensusMetric,
+          typename IndexingFunction>
+inline void
+serialize(Archive &archive,
+          GaussianProcessRansacStrategy<InlierMetric, ConsensusMetric,
+                                        IndexingFunction> &strategy,
+          const std::uint32_t) {
   archive(cereal::make_nvp("inlier_metric", strategy.inlier_metric_));
   archive(cereal::make_nvp("indexing_function", strategy.indexing_function_));
 }

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -112,7 +112,8 @@ template <typename InlierMetric, typename ConsensusMetric,
           typename IndexingFunction>
 struct GenericRansacStrategy;
 
-template <typename InlierMetric, typename IndexingFunction>
+template <typename InlierMetric, typename ConsensusMetric,
+          typename IndexingFunction>
 struct GaussianProcessRansacStrategy;
 
 } // namespace albatross

--- a/include/albatross/src/stats/incomplete_gamma.hpp
+++ b/include/albatross/src/stats/incomplete_gamma.hpp
@@ -126,8 +126,14 @@ inline double incomplete_gamma_continuous_fraction(double a, double z,
 }
 
 inline double incomplete_gamma_continuous_fraction(double a, double z) {
-  return (exp(a * log(z) - z) / tgamma(a) /
-          incomplete_gamma_continuous_fraction(a, z, 1));
+  double numerator = exp(a * log(z) - z) / tgamma(a);
+  // the denominator can't be any smaller than the numerator since this
+  // quantity is bounded by 0 and 1.  With numerical round off when evaluating
+  // this function for really large a the continuous fraction sometimes dips
+  // below the numerator (and sometimes even below zero).
+  double denominator =
+      std::max(numerator, incomplete_gamma_continuous_fraction(a, z, 1));
+  return numerator / denominator;
 }
 
 } // namespace details

--- a/include/albatross/src/stats/incomplete_gamma.hpp
+++ b/include/albatross/src/stats/incomplete_gamma.hpp
@@ -133,6 +133,13 @@ inline double incomplete_gamma_continuous_fraction(double a, double z) {
   // below the numerator (and sometimes even below zero).
   double denominator =
       std::max(numerator, incomplete_gamma_continuous_fraction(a, z, 1));
+  // When `a` get's really really large the numerator (and in turn the
+  // denominator) can hit zero which would turn into a NAN but we want
+  // to treat it as evaluating at infinity which should yield 1.
+  if (std::numeric_limits<double>::epsilon() > numerator &&
+      std::numeric_limits<double>::epsilon() > denominator) {
+    return 1.;
+  }
   return numerator / denominator;
 }
 

--- a/tests/test_stats.cc
+++ b/tests/test_stats.cc
@@ -71,8 +71,8 @@ TEST(test_stats, test_uniform_ks) {
   EXPECT_LT(uniform_ks_test(samples), 0.05);
 }
 
-JointDistribution random_sample(Eigen::Index k,
-                                std::default_random_engine &gen) {
+Eigen::MatrixXd random_covariance(Eigen::Index k,
+                                  std::default_random_engine &gen) {
 
   // Create diagonal with a wide range of scales.
   Eigen::VectorXd diag(k);
@@ -80,21 +80,23 @@ JointDistribution random_sample(Eigen::Index k,
     diag[i] = pow(2, 3 - i);
   }
 
-  // Generate a random covariance with the perscribed eigen values.
+  // Generate a random covariance with the prescribed eigen values.
   Eigen::MatrixXd matrix(k, k);
   gaussian_fill(matrix, gen);
   const Eigen::MatrixXd random_rotation =
       matrix.colPivHouseholderQr().matrixQ();
   Eigen::MatrixXd random_covariance = random_rotation * diag.asDiagonal();
   random_covariance = random_covariance * random_rotation.transpose();
+  return random_covariance;
+}
 
-  // Sample from the distribution
-  Eigen::VectorXd sample(k);
+Eigen::VectorXd random_sample(const Eigen::MatrixXd &covariance,
+                              std::default_random_engine &gen) {
+  // Sample from a mnv distribution with given covariance
+  Eigen::VectorXd sample(covariance.rows());
   gaussian_fill(sample, gen);
-  sample = diag.array().sqrt().cwiseProduct(sample.array());
-  sample = random_rotation * sample;
-
-  return JointDistribution(sample, random_covariance);
+  sample = covariance.llt().matrixL() * sample;
+  return sample;
 }
 
 TEST(test_stats, test_chi_squared_cdf) {
@@ -104,9 +106,10 @@ TEST(test_stats, test_chi_squared_cdf) {
   std::size_t iterations = 1000;
   std::vector<double> cdfs(iterations);
   for (std::size_t i = 0; i < iterations; ++i) {
-    const auto sample = random_sample(k, gen);
+    const auto covariance = random_covariance(k, gen);
+    const auto sample = random_sample(covariance, gen);
     // Collect all the cdfs
-    cdfs[i] = chi_squared_cdf(sample.mean, sample.covariance);
+    cdfs[i] = chi_squared_cdf(sample, covariance);
   }
 
   EXPECT_LT(*std::min_element(cdfs.begin(), cdfs.end()), 0.1);
@@ -119,16 +122,18 @@ TEST(test_stats, test_chi_squared_cdf_monotonic) {
   Eigen::Index k = 5;
 
   std::default_random_engine gen(2012);
-  const auto sample = random_sample(k, gen);
+
+  const auto covariance = random_covariance(k, gen);
+  const auto sample = random_sample(covariance, gen);
 
   std::size_t iterations = 50;
-  ASSERT_LT(chi_squared_cdf(sample.mean, sample.covariance), 1.);
+  ASSERT_LT(chi_squared_cdf(sample, covariance), 1.);
   double previous = -std::numeric_limits<double>::epsilon();
   // Evaluate the cdf while scaling the sampled vector by increasingly
   // large amounts, the cdf should also continue increasing.
   for (std::size_t i = 0; i < iterations; ++i) {
     double scale = i / 5.;
-    double cdf = chi_squared_cdf(scale * sample.mean, sample.covariance);
+    double cdf = chi_squared_cdf(scale * sample, covariance);
     EXPECT_LT(previous, cdf);
   }
 }

--- a/tests/test_stats.cc
+++ b/tests/test_stats.cc
@@ -11,6 +11,7 @@
  */
 
 #include <albatross/Common>
+#include <albatross/Distribution>
 #include <albatross/Stats>
 #include <albatross/src/utils/eigen_utils.hpp>
 #include <gtest/gtest.h>
@@ -70,40 +71,66 @@ TEST(test_stats, test_uniform_ks) {
   EXPECT_LT(uniform_ks_test(samples), 0.05);
 }
 
-TEST(test_stats, test_chi_squared_cdf) {
+JointDistribution random_sample(Eigen::Index k,
+                                std::default_random_engine &gen) {
 
-  Eigen::Index k = 5;
+  // Create diagonal with a wide range of scales.
   Eigen::VectorXd diag(k);
   for (Eigen::Index i = 0; i < diag.size(); ++i) {
     diag[i] = pow(2, 3 - i);
   }
 
+  // Generate a random covariance with the perscribed eigen values.
+  Eigen::MatrixXd matrix(k, k);
+  gaussian_fill(matrix, gen);
+  const Eigen::MatrixXd random_rotation =
+      matrix.colPivHouseholderQr().matrixQ();
+  Eigen::MatrixXd random_covariance = random_rotation * diag.asDiagonal();
+  random_covariance = random_covariance * random_rotation.transpose();
+
+  // Sample from the distribution
+  Eigen::VectorXd sample(k);
+  gaussian_fill(sample, gen);
+  sample = diag.array().sqrt().cwiseProduct(sample.array());
+  sample = random_rotation * sample;
+
+  return JointDistribution(sample, random_covariance);
+}
+
+TEST(test_stats, test_chi_squared_cdf) {
+
+  Eigen::Index k = 5;
   std::default_random_engine gen(2012);
   std::size_t iterations = 1000;
   std::vector<double> cdfs(iterations);
   for (std::size_t i = 0; i < iterations; ++i) {
-
-    // Create a random covariance matrix with perscribed eigen values (from
-    // diag).
-    Eigen::MatrixXd matrix(k, k);
-    gaussian_fill(matrix, gen);
-    const Eigen::MatrixXd random_rotation =
-        matrix.colPivHouseholderQr().matrixQ();
-    Eigen::MatrixXd random_covariance = random_rotation * diag.asDiagonal();
-    random_covariance = random_covariance * random_rotation.transpose();
-
-    // Sample from the distribution
-    Eigen::VectorXd sample(k);
-    gaussian_fill(sample, gen);
-    sample = diag.array().sqrt().cwiseProduct(sample.array());
-    sample = random_rotation * sample;
-
+    const auto sample = random_sample(k, gen);
     // Collect all the cdfs
-    cdfs[i] = chi_squared_cdf(sample, random_covariance);
+    cdfs[i] = chi_squared_cdf(sample.mean, sample.covariance);
   }
 
+  EXPECT_LT(*std::min_element(cdfs.begin(), cdfs.end()), 0.1);
+  EXPECT_GT(*std::max_element(cdfs.begin(), cdfs.end()), 0.9);
   double ks = uniform_ks_test(cdfs);
   EXPECT_LT(ks, 0.05);
+}
+
+TEST(test_stats, test_chi_squared_cdf_monotonic) {
+  Eigen::Index k = 5;
+
+  std::default_random_engine gen(2012);
+  const auto sample = random_sample(k, gen);
+
+  std::size_t iterations = 50;
+  ASSERT_LT(chi_squared_cdf(sample.mean, sample.covariance), 1.);
+  double previous = -std::numeric_limits<double>::epsilon();
+  // Evaluate the cdf while scaling the sampled vector by increasingly
+  // large amounts, the cdf should also continue increasing.
+  for (std::size_t i = 0; i < iterations; ++i) {
+    double scale = i / 5.;
+    double cdf = chi_squared_cdf(scale * sample.mean, sample.covariance);
+    EXPECT_LT(previous, cdf);
+  }
 }
 
 } // namespace albatross


### PR DESCRIPTION
This adds a configurable `ConsensusMetric` to RANSAC for Gaussian processes and provides three options: feature count, differential entropy and the chi squared cdf.