### PR TITLE
Ransac: Output and is_valid_candidate.

### DIFF
--- a/include/albatross/src/cereal/ransac.hpp
+++ b/include/albatross/src/cereal/ransac.hpp
@@ -18,17 +18,26 @@ using albatross::GaussianProcessRansacStrategy;
 using albatross::GenericRansacStrategy;
 using albatross::Ransac;
 using albatross::RansacFit;
+using albatross::RansacOutput;
 
 namespace cereal {
+
+template <typename Archive>
+inline void serialize(Archive &archive, RansacOutput &ransac_output,
+                      const std::uint32_t) {
+  archive(cereal::make_nvp("return_code", ransac_output.return_code));
+  archive(cereal::make_nvp("inliers", ransac_output.inliers));
+  archive(cereal::make_nvp("outliers", ransac_output.outliers));
+  archive(cereal::make_nvp("consensus_metric", ransac_output.consensus_metric));
+}
 
 template <typename Archive, typename ModelType, typename StrategyType,
           typename FeatureType>
 inline void serialize(Archive &archive,
                       Fit<RansacFit<ModelType, StrategyType, FeatureType>> &fit,
                       const std::uint32_t) {
-  archive(cereal::make_nvp("fit_model", fit.fit_model));
-  archive(cereal::make_nvp("inliers", fit.inliers));
-  archive(cereal::make_nvp("outliers", fit.outliers));
+  archive(cereal::make_nvp("maybe_empty_fit_model", fit.maybe_empty_fit_model));
+  archive(cereal::make_nvp("ransac_output", fit.ransac_output));
 }
 
 template <typename Archive, typename InlierMetric, typename ConsensusMetric,
@@ -50,6 +59,7 @@ serialize(Archive &archive,
                                         IndexingFunction> &strategy,
           const std::uint32_t) {
   archive(cereal::make_nvp("inlier_metric", strategy.inlier_metric_));
+  archive(cereal::make_nvp("consensus_metric", strategy.consensus_metric_));
   archive(cereal::make_nvp("indexing_function", strategy.indexing_function_));
 }
 

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -103,6 +103,9 @@ template <typename RequiredPredictType> struct PredictionMetric;
 /*
  * RANSAC
  */
+
+struct RansacOutput;
+
 template <typename ModelType, typename StrategyType> class Ransac;
 
 template <typename ModelType, typename StrategyType, typename FeatureType>

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -106,6 +106,8 @@ template <typename RequiredPredictType> struct PredictionMetric;
 
 struct RansacOutput;
 
+struct RansacConfig;
+
 template <typename ModelType, typename StrategyType> class Ransac;
 
 template <typename ModelType, typename StrategyType, typename FeatureType>

--- a/include/albatross/src/core/model.hpp
+++ b/include/albatross/src/core/model.hpp
@@ -139,6 +139,10 @@ public:
          std::size_t random_sample_size, std::size_t min_consensus_size,
          std::size_t max_iteration) const;
 
+  template <typename Strategy>
+  Ransac<ModelType, Strategy> ransac(const Strategy &strategy,
+                                     const RansacConfig &) const;
+
   Insights insights;
 };
 } // namespace albatross

--- a/include/albatross/src/models/ransac.hpp
+++ b/include/albatross/src/models/ransac.hpp
@@ -44,6 +44,29 @@ inline bool contains_group(const std::vector<FoldName> &vect,
   return std::find(vect.begin(), vect.end(), group) != vect.end();
 }
 
+typedef enum ransac_return_code_e {
+  RANSAC_RETURN_CODE_INVALID = -1,
+  RANSAC_RETURN_CODE_SUCCESS,
+  RANSAC_RETURN_CODE_EXCEEDED_MAX_FAILED_CANDIDATES,
+  RANSAC_RETURN_CODE_FAILURE
+} ransac_return_code_t;
+
+inline bool ransac_success(const ransac_return_code_t &rc) {
+  return rc == RANSAC_RETURN_CODE_SUCCESS;
+}
+
+struct RansacOutput {
+
+  RansacOutput()
+      : return_code(RANSAC_RETURN_CODE_FAILURE), inliers(), outliers(),
+        consensus_metric(HUGE_VAL){};
+
+  ransac_return_code_t return_code;
+  std::vector<FoldName> inliers;
+  std::vector<FoldName> outliers;
+  double consensus_metric;
+};
+
 /*
  * This RANdom SAmple Consensus (RANSAC) algorithm works as follows.
  *
@@ -63,18 +86,19 @@ inline bool contains_group(const std::vector<FoldName> &vect,
  * metrics.
  */
 template <typename FitType>
-std::vector<FoldName>
-ransac(const RansacFunctions<FitType> &ransac_functions,
-       const std::vector<FoldName> &groups, double inlier_threshold,
-       std::size_t random_sample_size, std::size_t min_consensus_size,
-       std::size_t max_iterations) {
+RansacOutput ransac(const RansacFunctions<FitType> &ransac_functions,
+                    const std::vector<FoldName> &groups,
+                    double inlier_threshold, std::size_t random_sample_size,
+                    std::size_t min_consensus_size,
+                    std::size_t max_iterations) {
 
   std::default_random_engine gen;
 
-  double best_consensus_metric = HUGE_VAL;
-  std::vector<FoldName> best_consensus;
+  RansacOutput output;
 
-  for (std::size_t i = 0; i < max_iterations; i++) {
+  std::size_t i = 0;
+  std::size_t failed_candidates = 0;
+  while (i < max_iterations) {
     // Sample a random subset of the data and fit a model.
     auto candidate_groups =
         random_without_replacement(groups, random_sample_size, gen);
@@ -82,6 +106,7 @@ ransac(const RansacFunctions<FitType> &ransac_functions,
 
     // Any group that's part of the candidate set is automatically an inlier.
     std::vector<FoldName> candidate_consensus = candidate_groups;
+    std::vector<FoldName> outliers;
 
     // Find which of the other groups agree with the reference model
     // which gives us a consensus (set of inliers).
@@ -91,6 +116,8 @@ ransac(const RansacFunctions<FitType> &ransac_functions,
             ransac_functions.inlier_metric(possible_inlier, fit);
         if (metric_value < inlier_threshold) {
           candidate_consensus.emplace_back(possible_inlier);
+        } else {
+          outliers.emplace_back(possible_inlier);
         }
       }
     }
@@ -100,21 +127,26 @@ ransac(const RansacFunctions<FitType> &ransac_functions,
     if (candidate_consensus.size() >= min_consensus_size) {
       double consensus_metric_value =
           ransac_functions.consensus_metric(candidate_consensus);
-      if (consensus_metric_value < best_consensus_metric) {
-        best_consensus = candidate_consensus;
-        best_consensus_metric = consensus_metric_value;
+      if (consensus_metric_value < output.consensus_metric) {
+        output.inliers = candidate_consensus;
+        output.consensus_metric = consensus_metric_value;
+        output.outliers = outliers;
       }
     }
+
+    ++i;
   }
-  return best_consensus;
+
+  output.return_code = RANSAC_RETURN_CODE_SUCCESS;
+
+  return output;
 }
 
 template <typename FitType>
-std::vector<FoldName>
-ransac(const RansacFunctions<FitType> &ransac_functions,
-       const FoldIndexer &indexer, double inlier_threshold,
-       std::size_t random_sample_size, std::size_t min_consensus_size,
-       std::size_t max_iterations) {
+auto ransac(const RansacFunctions<FitType> &ransac_functions,
+            const FoldIndexer &indexer, double inlier_threshold,
+            std::size_t random_sample_size, std::size_t min_consensus_size,
+            std::size_t max_iterations) {
   return ransac(ransac_functions, map_keys(indexer), inlier_threshold,
                 random_sample_size, min_consensus_size, max_iterations);
 }
@@ -231,19 +263,56 @@ struct Fit<RansacFit<ModelType, StrategyType, FeatureType>> {
 
   using FitModelType = typename fit_model_type<ModelType, FeatureType>::type;
 
-  Fit(){};
+  struct EmptyFit {
+    bool operator==(const EmptyFit &other) const { return true; };
 
-  Fit(const FitModelType &fit_model_, const std::vector<FoldName> &inliers_,
-      const std::vector<FoldName> &outliers_)
-      : fit_model(fit_model_), inliers(inliers_), outliers(outliers_){};
+    template <typename Archive>
+    void serialize(Archive &archive, const std::uint32_t){};
+  };
+
+  Fit() : maybe_empty_fit_model(EmptyFit()){};
+
+  Fit(const FitModelType &fit_model_, const RansacOutput &ransac_output_)
+      : maybe_empty_fit_model(fit_model_), ransac_output(ransac_output_){};
+
+  Fit(const RansacOutput &ransac_output_)
+      : maybe_empty_fit_model(EmptyFit()), ransac_output(ransac_output_){};
 
   bool operator==(const Fit &other) const {
-    return fit_model == other.fit_model;
+    return maybe_empty_fit_model == other.maybe_empty_fit_model;
   }
 
-  FitModelType fit_model;
-  std::vector<FoldName> inliers;
-  std::vector<FoldName> outliers;
+  bool has_fit_model() const {
+    return maybe_empty_fit_model.template is<FitModelType>();
+  }
+
+  const FitModelType &get_fit_model_or_assert() const {
+    assert(maybe_empty_fit_model.template is<FitModelType>());
+    return maybe_empty_fit_model.template get<FitModelType>();
+  }
+
+  variant<EmptyFit, FitModelType> maybe_empty_fit_model;
+  RansacOutput ransac_output;
+};
+
+struct RansacConfig {
+
+  RansacConfig(){};
+
+  RansacConfig(double inlier_threshold_, std::size_t random_sample_size_,
+               std::size_t min_consensus_size_, std::size_t max_iterations_,
+               std::size_t max_failed_candidates_)
+      : inlier_threshold(inlier_threshold_),
+        random_sample_size(random_sample_size_),
+        min_consensus_size(min_consensus_size_),
+        max_iterations(max_iterations_),
+        max_failed_candidates(max_failed_candidates_){};
+
+  double inlier_threshold;
+  std::size_t random_sample_size;
+  std::size_t min_consensus_size;
+  std::size_t max_iterations;
+  std::size_t max_failed_candidates;
 };
 
 /*
@@ -255,13 +324,24 @@ public:
   Ransac(){};
 
   Ransac(const ModelType &sub_model, const StrategyType &strategy,
+         const RansacConfig &config)
+      : sub_model_(sub_model), strategy_(strategy), config_(config){};
+
+  Ransac(const ModelType &sub_model, const StrategyType &strategy,
          double inlier_threshold, std::size_t random_sample_size,
          std::size_t min_consensus_size, std::size_t max_iterations)
-      : sub_model_(sub_model), strategy_(strategy),
-        inlier_threshold_(inlier_threshold),
-        random_sample_size_(random_sample_size),
-        min_consensus_size_(min_consensus_size),
-        max_iterations_(max_iterations){};
+      : Ransac(sub_model, strategy,
+               RansacConfig(inlier_threshold, random_sample_size,
+                            min_consensus_size, max_iterations, 0)){};
+
+  Ransac(const ModelType &sub_model, const StrategyType &strategy,
+         double inlier_threshold, std::size_t random_sample_size,
+         std::size_t min_consensus_size, std::size_t max_iterations,
+         std::size_t max_failed_candidates)
+      : Ransac(sub_model, strategy,
+               RansacConfig(inlier_threshold, random_sample_size,
+                            min_consensus_size, max_iterations,
+                            max_failed_candidates)){};
 
   std::string get_name() const {
     return "ransac[" + sub_model_.get_name() + "]";
@@ -289,38 +369,37 @@ public:
     auto indexer = strategy_.get_indexer(dataset);
     auto ransac_functions = strategy_(sub_model_, dataset);
 
-    std::vector<FoldName> inliers =
-        ransac(ransac_functions, map_keys(indexer), inlier_threshold_,
-               random_sample_size_, min_consensus_size_, max_iterations_);
+    const auto ransac_output =
+        ransac(ransac_functions, map_keys(indexer), config_.inlier_threshold,
+               config_.random_sample_size, config_.min_consensus_size,
+               config_.max_iterations);
 
-    const auto good_inds = indices_from_names(indexer, inliers);
-    const auto consensus_set = subset(dataset, good_inds);
-
-    std::vector<FoldName> outliers;
-    for (const auto &pair : indexer) {
-      if (!contains_group(inliers, pair.first)) {
-        outliers.emplace_back(pair.first);
-      }
+    if (ransac_success(ransac_output.return_code)) {
+      const auto good_inds = indices_from_names(indexer, ransac_output.inliers);
+      const auto consensus_set = subset(dataset, good_inds);
+      return Fit<RansacFit<ModelType, StrategyType, FeatureType>>(
+          sub_model_.fit(consensus_set), ransac_output);
+    } else {
+      return Fit<RansacFit<ModelType, StrategyType, FeatureType>>(
+          ransac_output);
     }
-
-    // Then generate a fit.
-    return Fit<RansacFit<ModelType, StrategyType, FeatureType>>(
-        sub_model_.fit(consensus_set), inliers, outliers);
   }
 
   template <typename PredictFeatureType, typename FitType, typename PredictType>
   PredictType _predict_impl(const std::vector<PredictFeatureType> &features,
                             const FitType &ransac_fit_,
                             PredictTypeIdentity<PredictType> &&) const {
-    return ransac_fit_.fit_model.predict(features).template get<PredictType>();
+    // If RANSAC failed it's up to the user to determine that from the output of
+    // fit and deal with it appropriately.
+    assert(ransac_fit_.has_fit_model());
+    return ransac_fit_.get_fit_model_or_assert()
+        .predict(features)
+        .template get<PredictType>();
   }
 
   ModelType sub_model_;
   StrategyType strategy_;
-  double inlier_threshold_;
-  std::size_t random_sample_size_;
-  std::size_t min_consensus_size_;
-  std::size_t max_iterations_;
+  RansacConfig config_;
 };
 
 template <typename ModelType>

--- a/include/albatross/src/models/ransac.hpp
+++ b/include/albatross/src/models/ransac.hpp
@@ -425,7 +425,6 @@ public:
       return Fit<RansacFit<ModelType, StrategyType, FeatureType>>(
           sub_model_.fit(consensus_set), ransac_output);
     } else {
-      std::cout << ransac_output.return_code << std::endl;
       return Fit<RansacFit<ModelType, StrategyType, FeatureType>>(
           ransac_output);
     }

--- a/include/albatross/src/models/ransac_gp.hpp
+++ b/include/albatross/src/models/ransac_gp.hpp
@@ -54,9 +54,12 @@ get_gp_ransac_is_valid_candidate(const RegressionDataset<FeatureType> &dataset,
 
     const JointDistribution prior(Eigen::VectorXd::Zero(train_cov.rows()),
                                   train_cov);
-    const double chi2 = chi_squared_cdf(prior, train_dataset.targets);
-    const double skip_every_1000_candidates = 0.999;
-    return (chi2 < skip_every_1000_candidates);
+    // These thresholds are under the assumption of a perfectly
+    // representative prior.
+    const double probability_prior_exceeded =
+        chi_squared_cdf(prior, train_dataset.targets);
+    const double skip_every_1000th_candidate = 0.999;
+    return (probability_prior_exceeded < skip_every_1000th_candidate);
   };
 }
 

--- a/include/albatross/src/models/ransac_gp.hpp
+++ b/include/albatross/src/models/ransac_gp.hpp
@@ -36,8 +36,27 @@ inline
     using GPFitType = typename FitAndIndices<ModelType, FeatureType>::FitType;
     const GPFitType fit(train_dataset.features, train_cov,
                         train_dataset.targets);
-    FitAndIndices<ModelType, FeatureType> fit_and_indices = {fit, inds};
+    const FitAndIndices<ModelType, FeatureType> fit_and_indices = {fit, inds};
     return fit_and_indices;
+  };
+}
+
+template <typename ModelType, typename FeatureType>
+inline typename RansacFunctions<
+    FitAndIndices<ModelType, FeatureType>>::IsValidCandidate
+get_gp_ransac_is_valid_candidate(const RegressionDataset<FeatureType> &dataset,
+                                 const FoldIndexer &indexer,
+                                 const Eigen::MatrixXd &cov) {
+  return [&, indexer, cov, dataset](const std::vector<FoldName> &groups) {
+    auto inds = indices_from_names(indexer, groups);
+    const auto train_dataset = subset(dataset, inds);
+    const auto train_cov = symmetric_subset(cov, inds);
+
+    const JointDistribution prior(Eigen::VectorXd::Zero(train_cov.rows()),
+                                  train_cov);
+    const double chi2 = chi_squared_cdf(prior, train_dataset.targets);
+    const double skip_every_1000_candidates = 0.999;
+    return (chi2 < skip_every_1000_candidates);
   };
 }
 
@@ -52,13 +71,12 @@ get_gp_ransac_inlier_metric(const RegressionDataset<FeatureType> &dataset,
   return [&, indexer, cov, model, dataset](
              const FoldName &group,
              const FitAndIndices<ModelType, FeatureType> &fit_and_indices) {
-    auto inds = indexer.at(group);
+    const auto inds = indexer.at(group);
     const auto test_dataset = subset(dataset, inds);
 
     const auto pred =
         get_prediction(model, fit_and_indices.fit, test_dataset.features);
-    double metric_value = metric(pred, test_dataset.targets);
-    return metric_value;
+    return metric(pred, test_dataset.targets);
   };
 }
 
@@ -72,8 +90,8 @@ public:
       : indexer_(indexer), cov_(cov){};
 
   double operator()(const std::vector<FoldName> &groups) {
-    auto inds = indices_from_names(indexer_, groups);
-    auto consensus_cov = symmetric_subset(cov_, inds);
+    const auto inds = indices_from_names(indexer_, groups);
+    const auto consensus_cov = symmetric_subset(cov_, inds);
     return differential_entropy(consensus_cov);
   }
 
@@ -93,7 +111,7 @@ public:
       : indexer_(indexer){};
 
   double operator()(const std::vector<FoldName> &groups) const {
-    auto inds = indices_from_names(indexer_, groups);
+    const auto inds = indices_from_names(indexer_, groups);
     // Negative because a lower metric is better.
     return (-1.0 * static_cast<double>(inds.size()));
   }
@@ -112,7 +130,7 @@ public:
       : targets_(targets), indexer_(indexer), cov_(cov){};
 
   double operator()(const std::vector<FoldName> &groups) {
-    auto inds = indices_from_names(indexer_, groups);
+    const auto inds = indices_from_names(indexer_, groups);
     const auto consensus_prior = symmetric_subset(cov_, inds);
     const auto consensus_targets = subset(targets_, inds);
     return chi_squared_cdf(consensus_targets.mean, consensus_prior);
@@ -145,11 +163,16 @@ get_gp_ransac_functions(const ModelType &model,
       get_gp_ransac_inlier_metric<ModelType, FeatureType, InlierMetric>(
           dataset, indexer, full_cov, model, inlier_metric);
 
-  ConsensusMetric consensus_metric_from_group(dataset.targets, indexer,
-                                              full_cov);
+  const ConsensusMetric consensus_metric_from_group(dataset.targets, indexer,
+                                                    full_cov);
+
+  const auto is_valid_candidate =
+      get_gp_ransac_is_valid_candidate<ModelType, FeatureType>(dataset, indexer,
+                                                               full_cov);
 
   return RansacFunctions<FitAndIndices<ModelType, FeatureType>>(
-      fitter, inlier_metric_from_group, consensus_metric_from_group);
+      fitter, inlier_metric_from_group, consensus_metric_from_group,
+      is_valid_candidate);
 };
 
 template <typename InlierMetric, typename ConsensusMetric,

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -43,16 +43,17 @@ public:
   auto get_model() const {
     auto covariance = make_simple_covariance_function();
 
-    double inlier_threshold = 1.;
-    std::size_t sample_size = 3;
-    std::size_t min_inliers = 3;
-    std::size_t max_iterations = 20;
+    RansacConfig config;
+    config.inlier_threshold = 1.;
+    config.random_sample_size = 3;
+    config.min_consensus_size = 3;
+    config.max_iterations = 20;
+    config.max_failed_candidates = 20;
 
     const auto gp = gp_from_covariance(covariance);
 
     DefaultGPRansacStrategy ransac_strategy;
-    return gp.ransac(ransac_strategy, inlier_threshold, sample_size,
-                     min_inliers, max_iterations);
+    return gp.ransac(ransac_strategy, config);
   }
 
   auto get_dataset() const { return make_toy_linear_data(); }
@@ -63,10 +64,12 @@ public:
   auto get_model() const {
     auto covariance = make_simple_covariance_function();
 
-    double inlier_threshold = 1.;
-    std::size_t sample_size = 3;
-    std::size_t min_inliers = 3;
-    std::size_t max_iterations = 20;
+    RansacConfig config;
+    config.inlier_threshold = 1.;
+    config.random_sample_size = 3;
+    config.min_consensus_size = 3;
+    config.max_iterations = 20;
+    config.max_failed_candidates = 20;
 
     const auto gp = gp_from_covariance(covariance);
 
@@ -74,8 +77,7 @@ public:
                                   LeaveOneOut>
         ransac_strategy;
 
-    return gp.ransac(ransac_strategy, inlier_threshold, sample_size,
-                     min_inliers, max_iterations);
+    return gp.ransac(ransac_strategy, config);
   }
 
   auto get_dataset() const { return make_toy_linear_data(); }
@@ -172,16 +174,17 @@ public:
   auto get_model() const {
     auto covariance = make_simple_covariance_function();
 
-    double inlier_threshold = 1.;
-    std::size_t sample_size = 3;
-    std::size_t min_inliers = 3;
-    std::size_t max_iterations = 20;
+    RansacConfig config;
+    config.inlier_threshold = 1.;
+    config.random_sample_size = 3;
+    config.min_consensus_size = 3;
+    config.max_iterations = 20;
+    config.max_failed_candidates = 20;
 
     AdaptedGaussianProcess<decltype(covariance)> gp(covariance);
 
     AdaptedRansacStrategy ransac_strategy;
-    return gp.ransac(ransac_strategy, inlier_threshold, sample_size,
-                     min_inliers, max_iterations);
+    return gp.ransac(ransac_strategy, config);
   }
 
   auto get_dataset() const { return make_adapted_toy_linear_data(); }

--- a/tests/test_ransac.cc
+++ b/tests/test_ransac.cc
@@ -143,7 +143,7 @@ inline bool never_accept_candidates(const std::vector<FoldName> &) {
 
 RansacConfig get_reasonable_ransac_config() {
   RansacConfig config;
-  config.inlier_threshold = -HUGE_VAL;
+  config.inlier_threshold = 1.;
   config.max_failed_candidates = 0;
   config.max_iterations = 20;
   config.min_consensus_size = 2;

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -12,6 +12,7 @@
 
 #include <albatross/Common>
 #include <albatross/GP>
+#include <albatross/Ransac>
 
 #include <albatross/serialize/Common>
 #include <albatross/serialize/GP>


### PR DESCRIPTION
This PR improves ransac in two different ways.

1. A `RansacOutput` struct is now returned which contains information about the inliers, outliers a return code and the final consensus metric all of which are intended to provide more information upstream when a model fit using RANAC has failed.
2. An `is_valid_candidate` tie in which lets you reject a candidate set.  I added this after I encountered an edge case in which a candidate set which contained an outlier was able to reasonably predict other outliers which in turn ended up in the final consensus set.  The default behavior for generic models is to accept all candidate sets (so no change from master) but for Gaussian process RANSAC the chi squared statistic of the candidate set is checked to do a first scan for outliers.