### PR TITLE
Group By: Use is_invocable

### DIFF
--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -105,7 +105,7 @@ public:
    */
   template <
       typename ApplyFunction,
-      typename ApplyType = typename details::key_value_apply_return_type<
+      typename ApplyType = typename details::key_value_apply_result<
           ApplyFunction, KeyType, ValueType>::type,
       typename std::enable_if<details::is_valid_key_value_apply_function<
                                   ApplyFunction, KeyType, ValueType>::value &&
@@ -119,7 +119,7 @@ public:
 
   template <
       typename ApplyFunction,
-      typename ApplyType = typename details::key_value_apply_return_type<
+      typename ApplyType = typename details::key_value_apply_result<
           ApplyFunction, KeyType, ValueType>::type,
       typename std::enable_if<details::is_valid_key_value_apply_function<
                                   ApplyFunction, KeyType, ValueType>::value &&
@@ -134,7 +134,7 @@ public:
   }
 
   template <typename ApplyFunction,
-            typename ApplyType = typename details::value_only_apply_return_type<
+            typename ApplyType = typename details::value_only_apply_result<
                 ApplyFunction, ValueType>::type,
             typename std::enable_if<details::is_valid_value_only_apply_function<
                                         ApplyFunction, ValueType>::value &&
@@ -149,7 +149,7 @@ public:
   }
 
   template <typename ApplyFunction,
-            typename ApplyType = typename details::value_only_apply_return_type<
+            typename ApplyType = typename details::value_only_apply_result<
                 ApplyFunction, ValueType>::type,
             typename std::enable_if<details::is_valid_value_only_apply_function<
                                         ApplyFunction, ValueType>::value &&
@@ -176,7 +176,7 @@ public:
   using Base::Base;
 
   template <typename ApplyFunction,
-            typename ApplyType = typename details::key_value_apply_return_type<
+            typename ApplyType = typename details::key_value_apply_result<
                 ApplyFunction, KeyType, GroupIndices>::type,
             typename std::enable_if<
                 details::is_valid_index_apply_function<ApplyFunction, KeyType,
@@ -258,8 +258,8 @@ template <typename GrouperFunction> struct IndexerBuilder {
           int>::type = 0>
   static auto build(const GrouperFunction &grouper_function,
                     const Iterable &iterable) {
-    using GroupKey = typename details::grouper_return_type<GrouperFunction,
-                                                           IterableValue>::type;
+    using GroupKey =
+        typename details::grouper_result<GrouperFunction, IterableValue>::type;
     GroupIndexer<GroupKey> output;
     std::size_t i = 0;
     for (const auto &value : iterable) {
@@ -351,7 +351,7 @@ public:
   }
 
   template <typename ApplyFunction,
-            typename ApplyType = typename details::key_value_apply_return_type<
+            typename ApplyType = typename details::key_value_apply_result<
                 ApplyFunction, KeyType, GroupIndices>::type,
             typename std::enable_if<
                 details::is_valid_index_apply_function<ApplyFunction, KeyType,
@@ -367,7 +367,7 @@ public:
   }
 
   template <typename ApplyFunction,
-            typename ApplyType = typename details::key_value_apply_return_type<
+            typename ApplyType = typename details::key_value_apply_result<
                 ApplyFunction, KeyType, GroupIndices>::type,
             typename std::enable_if<
                 details::is_valid_index_apply_function<ApplyFunction, KeyType,

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -54,6 +54,8 @@ public:
 
   std::size_t size() const { return map_.size(); }
 
+  const ValueType &at(const KeyType &key) const { return map_.at(key); }
+
   ValueType &operator[](const KeyType &key) { return map_[key]; }
 
   bool operator==(const GroupedBase<KeyType, ValueType> &other) const {
@@ -61,6 +63,10 @@ public:
   }
 
   auto find(const KeyType &key) const { return map_.find(key); }
+
+  std::vector<KeyType> keys() const { return map_keys(map_); }
+
+  std::vector<ValueType> values() const { return map_values(map_); }
 
   /*
    * Filtering a Grouped object consists of deciding which of the

--- a/include/albatross/src/indexing/traits.hpp
+++ b/include/albatross/src/indexing/traits.hpp
@@ -48,64 +48,39 @@ public:
   static constexpr bool value = false;
 };
 
-/*
- * This checks that a given type can be called with the following
- * argument types.
- *
- * Only works for non-overloaded methods, but does work with
- * lambda functions and function pointers.
- */
-template <typename T, typename... Args> class callable_traits {
-  template <typename C, typename ReturnType = decltype(
-                            std::declval<C>()(std::declval<Args>()...))>
-  static TypePair<std::true_type, ReturnType> test(C *);
-  template <typename> static TypePair<std::false_type, void> test(...);
-
-public:
-  static constexpr bool is_defined = decltype(test<T>(0))::first_type::value;
-  using return_type = typename decltype(test<T>(0))::second_type;
-};
-
-/*
- * Here we only care about the `is_defined` trait.
- */
-template <typename T, typename... Args> struct can_be_called_with {
-  static constexpr bool value = callable_traits<T, Args...>::is_defined;
-};
-
 template <typename T, typename... Args>
-class can_be_called_with_const_ref
-    : public can_be_called_with<const T, typename const_ref<Args>::type...> {};
-
-/*
- * Stores the return type resulting from calling T with Args, if the
- * call isn't valid the resulting type will be void.
- */
-template <typename T, typename... Args> struct return_type_when_called_with {
-  using type = typename callable_traits<T, Args...>::return_type;
-};
+class is_invocable_const_ref
+    : public is_invocable<const T, typename const_ref<Args>::type...> {};
 
 /*
  * A GrouperFunction is a function which takes a single const ref argument
  * and returns a non-void type which will end up being the key used in group by.
  */
 template <typename GrouperFunction, typename ValueType>
-struct grouper_return_type
-    : public return_type_when_called_with<GrouperFunction,
-                                          typename const_ref<ValueType>::type> {
-};
+struct grouper_result
+    : public invoke_result<GrouperFunction,
+                           typename const_ref<ValueType>::type> {};
 
 template <typename GrouperFunction, typename ValueType>
-struct group_key_is_valid {
-  static constexpr bool value = is_valid_map_key<
-      typename grouper_return_type<GrouperFunction, ValueType>::type>::value;
+class group_key_is_valid {
+
+  template <
+      typename C,
+      typename std::enable_if_t<
+          is_valid_map_key<typename grouper_result<C, ValueType>::type>::value,
+          int> = 0>
+  static std::true_type test(C *);
+  template <typename> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<GrouperFunction>(0))::value;
 };
 
 template <typename GrouperFunction, typename ValueType>
 struct is_valid_grouper {
 
   static constexpr bool value =
-      can_be_called_with_const_ref<GrouperFunction, ValueType>::value &&
+      is_invocable_const_ref<GrouperFunction, ValueType>::value &&
       group_key_is_valid<GrouperFunction, ValueType>::value;
 };
 
@@ -115,49 +90,66 @@ struct is_valid_grouper {
  * the value can be modified.
  */
 template <typename ApplyFunction, typename KeyType, typename ArgType>
-struct key_value_apply_return_type
-    : public return_type_when_called_with<
-          ApplyFunction, typename const_ref<KeyType>::type, ArgType> {};
+struct key_value_apply_result
+    : public invoke_result<ApplyFunction, typename const_ref<KeyType>::type,
+                           ArgType> {};
 
 template <typename ApplyFunction, typename ArgType>
-struct value_only_apply_return_type
-    : public return_type_when_called_with<ApplyFunction, ArgType> {};
+struct value_only_apply_result : public invoke_result<ApplyFunction, ArgType> {
+};
 
 template <typename ApplyFunction, typename KeyType, typename ArgType>
 struct is_valid_key_value_apply_function
-    : public can_be_called_with_const_ref<
+    : public is_invocable_const_ref<
           ApplyFunction, typename const_ref<KeyType>::type, ArgType> {};
 
 template <typename ApplyFunction, typename ArgType>
 struct is_valid_value_only_apply_function
-    : public can_be_called_with_const_ref<ApplyFunction, ArgType> {};
+    : public is_invocable_const_ref<ApplyFunction, ArgType> {};
 
 template <typename ApplyFunction, typename KeyType, typename ArgType>
 struct is_valid_index_apply_function
-    : public can_be_called_with_const_ref<
-          ApplyFunction, typename const_ref<KeyType>::type,
-          typename const_ref<GroupIndices>::type> {};
+    : public is_invocable_const_ref<ApplyFunction,
+                                    typename const_ref<KeyType>::type,
+                                    typename const_ref<GroupIndices>::type> {};
 
+template <typename Expected, typename FilterFunction, typename... Args>
+struct invoke_result_is_same {
+
+  template <typename C,
+            typename std::enable_if_t<
+                std::is_same<typename invoke_result<C, Args...>::type,
+                             Expected>::value,
+                int> = 0>
+  static std::true_type test(C *);
+  template <typename> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<FilterFunction>(0))::value;
+};
+
+/*
+ * Check for valid filter functions.
+ */
 template <typename FilterFunction, typename... Args>
-struct returns_bool_when_called_with {
-  static constexpr bool value = std::is_same<
-      typename return_type_when_called_with<FilterFunction, Args...>::type,
-      bool>::value;
+class is_valid_filter_function {
+  template <typename C,
+            typename std::enable_if_t<
+                invoke_result_is_same<bool, C, Args...>::value, int> = 0>
+  static std::true_type test(C *);
+  template <typename> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<FilterFunction>(0))::value;
 };
 
 template <typename FilterFunction, typename KeyType, typename ArgType>
-struct is_valid_key_value_filter_function {
-  static constexpr bool value =
-      can_be_called_with_const_ref<FilterFunction, KeyType, ArgType>::value &&
-      returns_bool_when_called_with<FilterFunction, KeyType, ArgType>::value;
-};
+struct is_valid_key_value_filter_function
+    : public is_valid_filter_function<FilterFunction, KeyType, ArgType> {};
 
 template <typename FilterFunction, typename ArgType>
-struct is_valid_value_only_filter_function {
-  static constexpr bool value =
-      can_be_called_with_const_ref<FilterFunction, ArgType>::value &&
-      returns_bool_when_called_with<FilterFunction, ArgType>::value;
-};
+struct is_valid_value_only_filter_function
+    : public is_valid_filter_function<FilterFunction, ArgType> {};
 
 /*
  * The following traits are required in order to allow inspection of
@@ -175,8 +167,7 @@ struct group_by_traits<
     GroupBy<RegressionDataset<FeatureType>, GrouperFunction>> {
   using ValueType = RegressionDataset<FeatureType>;
   using IterableType = FeatureType;
-  using KeyType =
-      typename grouper_return_type<GrouperFunction, IterableType>::type;
+  using KeyType = typename grouper_result<GrouperFunction, IterableType>::type;
   using GrouperType = GrouperFunction;
 };
 
@@ -184,8 +175,7 @@ template <typename FeatureType, typename GrouperFunction>
 struct group_by_traits<GroupBy<std::vector<FeatureType>, GrouperFunction>> {
   using ValueType = std::vector<FeatureType>;
   using IterableType = FeatureType;
-  using KeyType =
-      typename grouper_return_type<GrouperFunction, IterableType>::type;
+  using KeyType = typename grouper_result<GrouperFunction, IterableType>::type;
   using GrouperType = GrouperFunction;
 };
 

--- a/tests/test_group_by.cc
+++ b/tests/test_group_by.cc
@@ -125,10 +125,10 @@ struct CustomClassMethodGrouper {
   auto get_grouper() const { return CustomNearestEvenNumber(); }
 };
 
-struct CustomFunctionPointerGrouper {
+struct CustomFunctionGrouper {
   auto get_parent() const { return test_integer_dataset(); }
 
-  auto get_grouper() const { return &custom_nearest_even_number; }
+  auto get_grouper() const { return custom_nearest_even_number; }
 };
 
 template <typename CaseType> class GroupByTester : public ::testing::Test {
@@ -140,14 +140,14 @@ typedef ::testing::Types<BoolClassMethodGrouper, BoolLambdaGrouper,
                          BoolFunctionPointerGrouper, IntClassMethodGrouper,
                          StringClassMethodGrouper, BoolClassMethodVectorGrouper,
                          LeaveOneOutTest, CustomClassMethodGrouper,
-                         CustomFunctionPointerGrouper>
+                         CustomFunctionGrouper>
     GrouperTestCases;
 
 TYPED_TEST_CASE_P(GroupByTester);
 
 template <typename GrouperFunction, typename ValueType,
-          typename GroupKey = typename details::grouper_return_type<
-              GrouperFunction, ValueType>::type,
+          typename GroupKey = typename details::grouper_result<GrouperFunction,
+                                                               ValueType>::type,
           typename std::enable_if<
               !std::is_same<GrouperFunction, LeaveOneOutGrouper>::value,
               int>::type = 0>
@@ -158,8 +158,8 @@ void expect_group_key_matches_expected(const GrouperFunction &grouper,
 }
 
 template <typename GrouperFunction, typename ValueType,
-          typename GroupKey = typename details::grouper_return_type<
-              GrouperFunction, ValueType>::type,
+          typename GroupKey = typename details::grouper_result<GrouperFunction,
+                                                               ValueType>::type,
           typename std::enable_if<
               std::is_same<GrouperFunction, LeaveOneOutGrouper>::value,
               int>::type = 0>

--- a/tests/test_group_by.cc
+++ b/tests/test_group_by.cc
@@ -197,6 +197,20 @@ void expect_same_but_maybe_out_of_order(const std::vector<FeatureType> &x,
   EXPECT_EQ(vector_set_difference(x, y).size(), 0);
 }
 
+TYPED_TEST_P(GroupByTester, test_groupby_access_methods) {
+  auto parent = this->test_case.get_parent();
+  const auto grouper = group_by(parent, this->test_case.get_grouper());
+
+  const auto const_groups = grouper.groups();
+  assert(const_groups.size() > 0);
+  const auto first_key = const_groups.keys()[0];
+  const_groups.at(first_key);
+
+  auto groups = grouper.groups();
+  groups.at(first_key);
+  groups[first_key];
+}
+
 TYPED_TEST_P(GroupByTester, test_groupby_combine) {
   auto parent = this->test_case.get_parent();
   const auto grouped = group_by(parent, this->test_case.get_grouper());
@@ -314,9 +328,9 @@ TYPED_TEST_P(GroupByTester, test_groupby_filter) {
             filtered.size());
 }
 
-REGISTER_TYPED_TEST_CASE_P(GroupByTester, test_groupby_groups,
-                           test_groupby_counts, test_groupby_combine,
-                           test_groupby_modify_combine,
+REGISTER_TYPED_TEST_CASE_P(GroupByTester, test_groupby_access_methods,
+                           test_groupby_groups, test_groupby_counts,
+                           test_groupby_combine, test_groupby_modify_combine,
                            test_groupby_apply_combine, test_groupby_apply_void,
                            test_groupby_filter, test_groupby_apply_value_only,
                            test_groupby_index_apply);


### PR DESCRIPTION
Previous we were using a custom `callable_traits` struct which mostly worked but didn't deal with a lot of edge cases.  C++17 has `std::is_invocable` and `std::invoke_result` which do exactly what we need.  We need `albatross` to work with C++ 14, but the implementation provided [here](https://en.cppreference.com/w/cpp/utility/functional/invoke).