### PR TITLE
Configurable Is Valid Candidate

### DIFF
--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -133,8 +133,11 @@ template <typename InlierMetric, typename ConsensusMetric,
           typename IndexingFunction>
 struct GenericRansacStrategy;
 
+struct AlwaysAcceptCandidateMetric;
+
 template <typename InlierMetric, typename ConsensusMetric,
-          typename IndexingFunction>
+          typename IndexingFunction,
+          typename IsValidCandidateMetric = AlwaysAcceptCandidateMetric>
 struct GaussianProcessRansacStrategy;
 
 /*

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -164,8 +164,10 @@ struct AdaptedRansacStrategy : public GaussianProcessRansacStrategy<
         adapted::convert_features(dataset.features), dataset.targets);
     const auto indexer = get_indexer(converted);
     const FeatureCountConsensusMetric consensus_metric;
+    const AlwaysAcceptCandidateMetric always_accept;
     return get_gp_ransac_functions(model, converted, indexer,
-                                   this->inlier_metric_, consensus_metric);
+                                   this->inlier_metric_, consensus_metric,
+                                   always_accept);
   }
 };
 


### PR DESCRIPTION
Allows the is valid candidate metric to be configurable for `GaussianProcessRansac` which now always accepts the candidate by default (instead of doing a chi squared acceptance test).