### PR TITLE
State Space Representations

### DIFF
--- a/examples/example_utils.h
+++ b/examples/example_utils.h
@@ -48,9 +48,6 @@ std::vector<double> random_points_on_line(const int n, const double low,
 std::vector<double> uniform_points_on_line(const std::size_t n,
                                            const double low,
                                            const double high) {
-  std::default_random_engine generator;
-  std::uniform_real_distribution<double> distribution(low, high);
-
   std::vector<double> xs;
   for (std::size_t i = 0; i < n; i++) {
     double ratio = (double)i / (double)(n - 1);

--- a/examples/plot_example_predictions.py
+++ b/examples/plot_example_predictions.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     # read in the training and prediction data
     train_path = args.train
     predictions_path = args.predictions
-    print train_path
+    print(train_path)
     train_data = pd.read_csv(train_path)
     x_name = 'feature'
     y_name = 'prediction'

--- a/examples/sparse_example.cc
+++ b/examples/sparse_example.cc
@@ -79,7 +79,7 @@ int main(int argc, char *argv[]) {
 
   LeaveOneOut loo;
   UniformlySpacedInducingPoints strategy(FLAGS_k);
-  auto model = sparse_gp_from_covariance(cov, strategy, loo, "example");
+  auto model = sparse_gp_from_covariance(cov, loo, strategy, "example");
   //  auto model = gp_from_covariance(cov, "example");
 
   if (FLAGS_tune) {

--- a/include/albatross/Common
+++ b/include/albatross/Common
@@ -37,6 +37,7 @@
 #include <albatross/src/details/method_inspection_macros.hpp>
 #include <albatross/src/details/error_handling.hpp>
 
+#include <albatross/src/utils/vector_utils.hpp>
 #include <albatross/src/utils/map_utils.hpp>
 
 #endif

--- a/include/albatross/CovarianceFunctions
+++ b/include/albatross/CovarianceFunctions
@@ -13,7 +13,7 @@
 #ifndef ALBATROSS_COVARIANCE_FUNCTIONS_H
 #define ALBATROSS_COVARIANCE_FUNCTIONS_H
 
-#include "Common"
+#include "Indexing"
 
 #include <albatross/src/core/declarations.hpp>
 #include <albatross/src/core/traits.hpp>

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -196,8 +196,8 @@ public:
   }
 
   template <typename X,
-  typename std::enable_if<has_valid_ssr_impl<Derived, X>::value,
-                                      int>::type = 0>
+            typename std::enable_if<has_valid_ssr_impl<Derived, X>::value,
+                                    int>::type = 0>
   auto state_space_representation(const std::vector<X> &xs) const {
     return derived()._ssr_impl(xs);
   }
@@ -307,26 +307,26 @@ public:
   }
 
   template <typename X,
-  typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
-                          has_valid_ssr_impl<RHS, X>::value,
-                                      int>::type = 0>
+            typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
+                                        has_valid_ssr_impl<RHS, X>::value,
+                                    int>::type = 0>
   auto _ssr_impl(const std::vector<X> &xs) const {
     return concatenate(this->lhs_.state_space_representation(xs),
-        this->rhs_.state_space_representation(xs));
+                       this->rhs_.state_space_representation(xs));
   }
 
   template <typename X,
-  typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
-                          !has_valid_ssr_impl<RHS, X>::value,
-                                      int>::type = 0>
+            typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
+                                        !has_valid_ssr_impl<RHS, X>::value,
+                                    int>::type = 0>
   auto _ssr_impl(const std::vector<X> &xs) const {
     return this->lhs_.state_space_representation(xs);
   }
 
   template <typename X,
-  typename std::enable_if<!has_valid_ssr_impl<LHS, X>::value &&
-                          has_valid_ssr_impl<RHS, X>::value,
-                                      int>::type = 0>
+            typename std::enable_if<!has_valid_ssr_impl<LHS, X>::value &&
+                                        has_valid_ssr_impl<RHS, X>::value,
+                                    int>::type = 0>
   auto _ssr_impl(const std::vector<X> &xs) const {
     return this->rhs_.state_space_representation(xs);
   }
@@ -405,26 +405,26 @@ public:
   }
 
   template <typename X,
-  typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
-                          has_valid_ssr_impl<RHS, X>::value,
-                                      int>::type = 0>
+            typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
+                                        has_valid_ssr_impl<RHS, X>::value,
+                                    int>::type = 0>
   auto _ssr_impl(const std::vector<X> &xs) const {
     return concatenate(this->lhs_.state_space_representation(xs),
-        this->rhs_.state_space_representation(xs));
+                       this->rhs_.state_space_representation(xs));
   }
 
   template <typename X,
-  typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
-                          !has_valid_ssr_impl<RHS, X>::value,
-                                      int>::type = 0>
+            typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
+                                        !has_valid_ssr_impl<RHS, X>::value,
+                                    int>::type = 0>
   auto _ssr_impl(const std::vector<X> &xs) const {
     return this->lhs_.state_space_representation(xs);
   }
 
   template <typename X,
-  typename std::enable_if<!has_valid_ssr_impl<LHS, X>::value &&
-                          has_valid_ssr_impl<RHS, X>::value,
-                                      int>::type = 0>
+            typename std::enable_if<!has_valid_ssr_impl<LHS, X>::value &&
+                                        has_valid_ssr_impl<RHS, X>::value,
+                                    int>::type = 0>
   auto _ssr_impl(const std::vector<X> &xs) const {
     return this->rhs_.state_space_representation(xs);
   }

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -195,6 +195,13 @@ public:
     return diag;
   }
 
+  template <typename X,
+  typename std::enable_if<has_valid_ssr_impl<Derived, X>::value,
+                                      int>::type = 0>
+  auto state_space_representation(const std::vector<X> &xs) const {
+    return derived()._ssr_impl(xs);
+  }
+
   /*
    * Stubs to catch the case where a covariance function was called
    * with arguments that aren't supported.
@@ -299,6 +306,31 @@ public:
     return this->rhs_(x, y);
   }
 
+  template <typename X,
+  typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
+                          has_valid_ssr_impl<RHS, X>::value,
+                                      int>::type = 0>
+  auto _ssr_impl(const std::vector<X> &xs) const {
+    return concatenate(this->lhs_.state_space_representation(xs),
+        this->rhs_.state_space_representation(xs));
+  }
+
+  template <typename X,
+  typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
+                          !has_valid_ssr_impl<RHS, X>::value,
+                                      int>::type = 0>
+  auto _ssr_impl(const std::vector<X> &xs) const {
+    return this->lhs_.state_space_representation(xs);
+  }
+
+  template <typename X,
+  typename std::enable_if<!has_valid_ssr_impl<LHS, X>::value &&
+                          has_valid_ssr_impl<RHS, X>::value,
+                                      int>::type = 0>
+  auto _ssr_impl(const std::vector<X> &xs) const {
+    return this->rhs_.state_space_representation(xs);
+  }
+
 protected:
   LHS lhs_;
   RHS rhs_;
@@ -370,6 +402,31 @@ public:
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->rhs_(x, y);
+  }
+
+  template <typename X,
+  typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
+                          has_valid_ssr_impl<RHS, X>::value,
+                                      int>::type = 0>
+  auto _ssr_impl(const std::vector<X> &xs) const {
+    return concatenate(this->lhs_.state_space_representation(xs),
+        this->rhs_.state_space_representation(xs));
+  }
+
+  template <typename X,
+  typename std::enable_if<has_valid_ssr_impl<LHS, X>::value &&
+                          !has_valid_ssr_impl<RHS, X>::value,
+                                      int>::type = 0>
+  auto _ssr_impl(const std::vector<X> &xs) const {
+    return this->lhs_.state_space_representation(xs);
+  }
+
+  template <typename X,
+  typename std::enable_if<!has_valid_ssr_impl<LHS, X>::value &&
+                          has_valid_ssr_impl<RHS, X>::value,
+                                      int>::type = 0>
+  auto _ssr_impl(const std::vector<X> &xs) const {
+    return this->rhs_.state_space_representation(xs);
   }
 
 protected:

--- a/include/albatross/src/covariance_functions/radial.hpp
+++ b/include/albatross/src/covariance_functions/radial.hpp
@@ -30,7 +30,7 @@ inline double squared_exponential_covariance(double distance,
 
 /*
  * SquaredExponential distance
- *  - c(d) = -exp((d/length_scale)^2)
+ *    covariance(d) = sigma**2 exp(-(d/length_scale)^2)
  */
 template <class DistanceMetricType>
 class SquaredExponential
@@ -65,7 +65,7 @@ public:
 
     double range = max - min;
     // using 1/10th of the length scale should result in grids with
-    // one percent decorrelation between them.
+    // one percent decorrelation between them. exp(- 0.1**2)
     double n = ceil(10 * range / squared_exponential_length_scale.value);
     n = std::max(n, 3.);
     return linspace(min, max, safe_cast_to_size_t(n));
@@ -97,7 +97,7 @@ inline double exponential_covariance(double distance, double length_scale,
 
 /*
  * Exponential distance
- *  - c(d) = -exp(|d|/length_scale)
+ *    covariance(d) = sigma**2 exp(-|d|/length_scale)
  */
 template <class DistanceMetricType>
 class Exponential : public CovarianceFunction<Exponential<DistanceMetricType>> {
@@ -116,6 +116,18 @@ public:
   }
 
   ~Exponential(){};
+
+  std::vector<double> _ssr_impl(const std::vector<double> &xs) const {
+    double min = *std::min_element(xs.begin(), xs.end());
+    double max = *std::max_element(xs.begin(), xs.end());
+
+    double range = max - min;
+    // using 1/20th of the length scale should result in grids with
+    // five percent decorrelation between them. exp(-0.05)
+    double n = ceil(20 * range / exponential_length_scale.value);
+    n = std::max(n, 3.);
+    return linspace(min, max, safe_cast_to_size_t(n));
+  }
 
   // This operator is only defined when the distance metric is also defined.
   template <typename X,

--- a/include/albatross/src/covariance_functions/radial.hpp
+++ b/include/albatross/src/covariance_functions/radial.hpp
@@ -59,6 +59,18 @@ public:
     return "squared_exponential[" + this->distance_metric_.get_name() + "]";
   }
 
+  std::vector<double> _ssr_impl(const std::vector<double> &xs) const {
+    double min = *std::min_element(xs.begin(), xs.end());
+    double max = *std::max_element(xs.begin(), xs.end());
+
+    double range = max - min;
+    // using 1/10th of the length scale should result in grids with
+    // one percent decorrelation between them.
+    double n = ceil(10 * range / squared_exponential_length_scale.value);
+    n = std::max(n, 3.);
+    return linspace(min, max, safe_cast_to_size_t(n));
+  }
+
   // This operator is only defined when the distance metric is also defined.
   template <typename X,
             typename std::enable_if<

--- a/include/albatross/src/covariance_functions/radial.hpp
+++ b/include/albatross/src/covariance_functions/radial.hpp
@@ -30,7 +30,7 @@ inline double squared_exponential_covariance(double distance,
 
 /*
  * SquaredExponential distance
- *    covariance(d) = sigma**2 exp(-(d/length_scale)^2)
+ *    covariance(d) = sigma^2 exp(-(d/length_scale)^2)
  */
 template <class DistanceMetricType>
 class SquaredExponential
@@ -97,7 +97,7 @@ inline double exponential_covariance(double distance, double length_scale,
 
 /*
  * Exponential distance
- *    covariance(d) = sigma**2 exp(-|d|/length_scale)
+ *    covariance(d) = sigma^2 exp(-|d|/length_scale)
  */
 template <class DistanceMetricType>
 class Exponential : public CovarianceFunction<Exponential<DistanceMetricType>> {

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -80,8 +80,22 @@ DEFINE_CLASS_METHOD_TRAITS(solve);
 
 DEFINE_CLASS_METHOD_TRAITS(_ssr_impl);
 
-template <typename T, typename X> class has_valid_ssr_impl {
-  using SsrCall = class_method__ssr_impl_traits<T, std::vector<X>>;
+template <typename T, typename FeatureType> class has_valid_ssr_impl {
+  using SsrCall = class_method__ssr_impl_traits<T, std::vector<FeatureType>>;
+
+public:
+  static constexpr bool value =
+      (SsrCall::is_defined && is_vector<typename SsrCall::return_type>::value);
+};
+
+DEFINE_CLASS_METHOD_TRAITS(state_space_representation);
+
+template <typename T, typename FeatureType>
+struct has_valid_state_space_representation {
+
+  using SsrCall =
+      class_method_state_space_representation_traits<T,
+                                                     std::vector<FeatureType>>;
 
 public:
   static constexpr bool value =

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -84,8 +84,8 @@ template <typename T, typename X> class has_valid_ssr_impl {
   using SsrCall = class_method__ssr_impl_traits<T, std::vector<X>>;
 
 public:
-  static constexpr bool value = (SsrCall::is_defined &&
-      is_vector<typename SsrCall::return_type>::value);
+  static constexpr bool value =
+      (SsrCall::is_defined && is_vector<typename SsrCall::return_type>::value);
 };
 
 /*

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -78,6 +78,16 @@ public:
 
 DEFINE_CLASS_METHOD_TRAITS(solve);
 
+DEFINE_CLASS_METHOD_TRAITS(_ssr_impl);
+
+template <typename T, typename X> class has_valid_ssr_impl {
+  using SsrCall = class_method__ssr_impl_traits<T, std::vector<X>>;
+
+public:
+  static constexpr bool value = (SsrCall::is_defined &&
+      is_vector<typename SsrCall::return_type>::value);
+};
+
 /*
  * Has valid caller for all variants
  */

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -334,6 +334,15 @@ public:
     return covariance_function_(features);
   }
 
+  template <typename FeatureType,
+            std::enable_if_t<has_valid_state_space_representation<
+                                 CovFunc, FeatureType>::value,
+                             int> = 0>
+  auto
+  state_space_representation(const std::vector<FeatureType> &features) const {
+    return covariance_function_.state_space_representation(features);
+  }
+
 protected:
   /*
    * CRTP Helpers

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -47,11 +47,25 @@ struct UniformlySpacedInducingPoints {
 
 struct StateSpaceInducingPointStrategy {
 
-  template <typename CovarianceFunction>
-  std::vector<double> operator()(const CovarianceFunction &cov,
-                                 const std::vector<double> &features) const {
+  template <typename CovarianceFunction, typename FeatureType,
+            std::enable_if_t<has_valid_state_space_representation<
+                                 CovarianceFunction, FeatureType>::value,
+                             int> = 0>
+  auto operator()(const CovarianceFunction &cov,
+                  const std::vector<FeatureType> &features) const {
     return cov.state_space_representation(features);
   }
+
+  template <typename CovarianceFunction, typename FeatureType,
+            std::enable_if_t<!has_valid_state_space_representation<
+                                 CovarianceFunction, FeatureType>::value,
+                             int> = 0>
+  auto operator()(const CovarianceFunction &cov,
+                  const std::vector<FeatureType> &features) const
+      ALBATROSS_FAIL(
+          CovarianceFunction,
+          "Covariance function is missing state_space_representation method, "
+          "be sure _ssr_impl has been defined for the types concerned");
 };
 
 /*

--- a/include/albatross/src/utils/vector_utils.hpp
+++ b/include/albatross/src/utils/vector_utils.hpp
@@ -25,7 +25,6 @@ inline std::vector<double> linspace(double a, double b, std::size_t n) {
   std::vector<double> xs(n);
   double val = a;
   for (auto &x : xs) {
-    assert(val <= b);
     x = val;
     val += step;
   }

--- a/include/albatross/src/utils/vector_utils.hpp
+++ b/include/albatross/src/utils/vector_utils.hpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_UTILS_VECTOR_UTILS_HPP_
+#define ALBATROSS_UTILS_VECTOR_UTILS_HPP_
+
+namespace albatross {
+
+inline std::size_t safe_cast_to_size_t(double x) {
+  assert(x < std::numeric_limits<std::size_t>::max());
+  return static_cast<std::size_t>(x);
+}
+
+inline std::vector<double> linspace(double a, double b, std::size_t n) {
+  double step = (b - a) / static_cast<double>(n - 1);
+  std::vector<double> xs(n);
+  double val = a;
+  for (auto &x : xs) {
+    assert(val <= b);
+    x = val;
+    val += step;
+  }
+  return xs;
+}
+
+} // namespace albatross
+
+#endif /* ALBATROSS_UTILS_VECTOR_UTILS_HPP_ */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(albatross_unit_tests 
   test_radial.cc
+  test_covariance_functions.cc
   )
 target_include_directories(albatross_unit_tests SYSTEM PRIVATE
   "${gtest_SOURCE_DIR}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,43 +1,5 @@
 add_executable(albatross_unit_tests 
-  test_block_utils.cc
-  test_call_trace.cc
-  test_callers.cc
-  test_concatenate.cc
-  test_core_dataset.cc
-  test_core_distribution.cc
-  test_core_model.cc
-  test_covariance_function.cc
-  test_covariance_functions.cc
-  test_cross_validation.cc
-  test_csv_utils.cc
-  test_distance_metrics.cc
-  test_eigen_utils.cc
-  test_evaluate.cc
-  test_gp.cc
-  test_group_by.cc
-  test_indexing.cc
-  test_linalg_utils.cc
-  test_map_utils.cc
-  test_model_adapter.cc
-  test_model_metrics.cc  
-  test_models.cc
-  test_parameter_handling_mixin.cc
-  test_prediction.cc
   test_radial.cc
-  test_random_utils.cc
-  test_ransac.cc
-  test_scaling_function.cc
-  test_serializable_ldlt.cc
-  test_serialize.cc
-  test_sparse_gp.cc
-  test_stats.cc
-  test_traits_cereal.cc
-  test_traits_core.cc
-  test_traits_details.cc
-  test_traits_covariance_functions.cc
-  test_traits_evaluation.cc
-  test_traits_indexing.cc
-  test_tune.cc
   )
 target_include_directories(albatross_unit_tests SYSTEM PRIVATE
   "${gtest_SOURCE_DIR}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,43 @@
 add_executable(albatross_unit_tests 
-  test_radial.cc
+  test_block_utils.cc
+  test_call_trace.cc
+  test_callers.cc
+  test_concatenate.cc
+  test_core_dataset.cc
+  test_core_distribution.cc
+  test_core_model.cc
+  test_covariance_function.cc
   test_covariance_functions.cc
+  test_cross_validation.cc
+  test_csv_utils.cc
+  test_distance_metrics.cc
+  test_eigen_utils.cc
+  test_evaluate.cc
+  test_gp.cc
+  test_group_by.cc
+  test_indexing.cc
+  test_linalg_utils.cc
+  test_map_utils.cc
+  test_model_adapter.cc
+  test_model_metrics.cc  
+  test_models.cc
+  test_parameter_handling_mixin.cc
+  test_prediction.cc
+  test_radial.cc
+  test_random_utils.cc
+  test_ransac.cc
+  test_scaling_function.cc
+  test_serializable_ldlt.cc
+  test_serialize.cc
+  test_sparse_gp.cc
+  test_stats.cc
+  test_traits_cereal.cc
+  test_traits_core.cc
+  test_traits_details.cc
+  test_traits_covariance_functions.cc
+  test_traits_evaluation.cc
+  test_traits_indexing.cc
+  test_tune.cc
   )
 target_include_directories(albatross_unit_tests SYSTEM PRIVATE
   "${gtest_SOURCE_DIR}"

--- a/tests/test_covariance_functions.cc
+++ b/tests/test_covariance_functions.cc
@@ -14,6 +14,8 @@
 #include <albatross/Core>
 #include <albatross/CovarianceFunctions>
 
+#include "test_covariance_utils.h"
+
 namespace albatross {
 
 std::vector<Eigen::Vector3d> points_on_a_line(const int n) {
@@ -217,6 +219,35 @@ TYPED_TEST(TestDoubleCovarianceFunctions, can_set_params) {
     EXPECT_DOUBLE_EQ(this->covariance_function.get_param_value(pair.first),
                      pair.second.value + to_add);
   }
+}
+
+class SsrX : public CovarianceFunction<SsrX> {
+public:
+  std::vector<X> _ssr_impl(const std::vector<double> &) const { return {X()}; }
+};
+
+class SsrY : public CovarianceFunction<SsrY> {
+public:
+  std::vector<Y> _ssr_impl(const std::vector<double> &) const { return {Y()}; }
+};
+
+TEST(test_covariance_functions, test_state_space_representation) {
+  SsrX with_x;
+  SsrY with_y;
+
+  auto with_both = with_x + with_y;
+
+  std::vector<double> features = {0.};
+
+  auto xs = with_x.state_space_representation(features);
+  EXPECT_TRUE(bool(std::is_same<decltype(xs), std::vector<X>>::value));
+
+  auto ys = with_y.state_space_representation(features);
+  EXPECT_TRUE(bool(std::is_same<decltype(ys), std::vector<Y>>::value));
+
+  auto xs_and_ys = with_both.state_space_representation(features);
+  EXPECT_TRUE(bool(
+      std::is_same<decltype(xs_and_ys), std::vector<variant<X, Y>>>::value));
 }
 
 } // namespace albatross

--- a/tests/test_radial.cc
+++ b/tests/test_radial.cc
@@ -68,7 +68,7 @@ public:
     return cov;
   }
 
-  double get_tolerance() const { return 0.1; }
+  double get_tolerance() const { return 1e-2; }
 };
 
 class ExponentialAngularSSRTest {
@@ -80,7 +80,7 @@ public:
     return cov;
   }
 
-  double get_tolerance() const { return 0.1; }
+  double get_tolerance() const { return 1e-2; }
 };
 
 template <typename T>
@@ -100,18 +100,8 @@ TYPED_TEST(CovarianceStateSpaceTester, test_state_space_representation) {
 
   const auto cov_func = this->test_case.covariance_function();
 
-  const auto ssr = cov_func.state_space_representation(xs);
-
-  const Eigen::MatrixXd expected = cov_func(xs, xs);
-
-  // This forms the covariance between xs via the state
-  // space representation, they should be very similar
-  const Eigen::MatrixXd cross = cov_func(xs, ssr);
-  const Eigen::MatrixXd ssr_cov = cov_func(ssr, ssr);
-  const Eigen::MatrixXd actual =
-      cross * ssr_cov.ldlt().solve(cross.transpose());
-
-  EXPECT_LT((expected - actual).norm(), this->test_case.get_tolerance());
+  expect_state_space_representation_quality(cov_func, xs,
+                                            this->test_case.get_tolerance());
 }
 
 } // namespace albatross

--- a/tests/test_traits_covariance_functions.cc
+++ b/tests/test_traits_covariance_functions.cc
@@ -331,31 +331,19 @@ TEST(test_traits_covariance_function, test_has_valid_variant_cov_call) {
 
 struct HasSSRX : public CovarianceFunction<HasSSRX> {
 
-  std::vector<double> _ssr_impl(const std::vector<X> &xs) const {
-    return {1.};
-  }
-
+  std::vector<double> _ssr_impl(const std::vector<X> &xs) const { return {1.}; }
 };
 
 struct HasSSRXY : public CovarianceFunction<HasSSRXY> {
 
-  std::vector<double> _ssr_impl(const std::vector<X> &xs) const {
-    return {1.};
-  }
+  std::vector<double> _ssr_impl(const std::vector<X> &xs) const { return {1.}; }
 
-  std::vector<double> _ssr_impl(const std::vector<Y> &ys) const {
-    return {1.};
-  }
+  std::vector<double> _ssr_impl(const std::vector<Y> &ys) const { return {1.}; }
 };
 
-struct WithoutSSR : public CovarianceFunction<WithoutSSR> {
+struct WithoutSSR : public CovarianceFunction<WithoutSSR> {};
 
-};
-
-struct AlsoWithoutSSR : public CovarianceFunction<AlsoWithoutSSR> {
-
-};
-
+struct AlsoWithoutSSR : public CovarianceFunction<AlsoWithoutSSR> {};
 
 TEST(test_traits_covariance_function, test_has_valid_ssr_impl) {
   EXPECT_TRUE(bool(has_valid_ssr_impl<HasSSRX, X>::value));
@@ -407,9 +395,6 @@ TEST(test_traits_covariance_function, test_has_valid_ssr_impl) {
   using ProductWithXWithXY = decltype(with_x * with_xy);
   EXPECT_TRUE(bool(has_valid_ssr_impl<ProductWithXWithXY, X>::value));
   EXPECT_TRUE(bool(has_valid_ssr_impl<ProductWithXWithXY, Y>::value));
-
-
 }
-
 
 } // namespace albatross

--- a/tests/test_traits_covariance_functions.cc
+++ b/tests/test_traits_covariance_functions.cc
@@ -329,4 +329,87 @@ TEST(test_traits_covariance_function, test_has_valid_variant_cov_call) {
                                                  variant<X, Y>>::value));
 }
 
+struct HasSSRX : public CovarianceFunction<HasSSRX> {
+
+  std::vector<double> _ssr_impl(const std::vector<X> &xs) const {
+    return {1.};
+  }
+
+};
+
+struct HasSSRXY : public CovarianceFunction<HasSSRXY> {
+
+  std::vector<double> _ssr_impl(const std::vector<X> &xs) const {
+    return {1.};
+  }
+
+  std::vector<double> _ssr_impl(const std::vector<Y> &ys) const {
+    return {1.};
+  }
+};
+
+struct WithoutSSR : public CovarianceFunction<WithoutSSR> {
+
+};
+
+struct AlsoWithoutSSR : public CovarianceFunction<AlsoWithoutSSR> {
+
+};
+
+
+TEST(test_traits_covariance_function, test_has_valid_ssr_impl) {
+  EXPECT_TRUE(bool(has_valid_ssr_impl<HasSSRX, X>::value));
+  EXPECT_FALSE(bool(has_valid_ssr_impl<HasSSRX, Y>::value));
+
+  EXPECT_TRUE(bool(has_valid_ssr_impl<HasSSRXY, X>::value));
+  EXPECT_TRUE(bool(has_valid_ssr_impl<HasSSRXY, Y>::value));
+
+  EXPECT_FALSE(bool(has_valid_ssr_impl<WithoutSSR, X>::value));
+  EXPECT_FALSE(bool(has_valid_ssr_impl<WithoutSSR, Y>::value));
+
+  HasSSRX with_x;
+  HasSSRXY with_xy;
+  WithoutSSR without;
+  AlsoWithoutSSR also_without;
+
+  // Sums
+
+  using SumWithoutAlso = decltype(without + also_without);
+  EXPECT_FALSE(bool(has_valid_ssr_impl<SumWithoutAlso, X>::value));
+  EXPECT_FALSE(bool(has_valid_ssr_impl<SumWithoutAlso, Y>::value));
+
+  using SumWithoutWithX = decltype(without + with_x);
+  EXPECT_TRUE(bool(has_valid_ssr_impl<SumWithoutWithX, X>::value));
+  EXPECT_FALSE(bool(has_valid_ssr_impl<SumWithoutWithX, Y>::value));
+
+  using SumWithoutWithXY = decltype(without + with_xy);
+  EXPECT_TRUE(bool(has_valid_ssr_impl<SumWithoutWithXY, X>::value));
+  EXPECT_TRUE(bool(has_valid_ssr_impl<SumWithoutWithXY, Y>::value));
+
+  using SumWithXWithXY = decltype(with_x + with_xy);
+  EXPECT_TRUE(bool(has_valid_ssr_impl<SumWithXWithXY, X>::value));
+  EXPECT_TRUE(bool(has_valid_ssr_impl<SumWithXWithXY, Y>::value));
+
+  // Products
+
+  using ProductWithoutAlso = decltype(without * also_without);
+  EXPECT_FALSE(bool(has_valid_ssr_impl<ProductWithoutAlso, X>::value));
+  EXPECT_FALSE(bool(has_valid_ssr_impl<ProductWithoutAlso, Y>::value));
+
+  using ProductWithoutWithX = decltype(without * with_x);
+  EXPECT_TRUE(bool(has_valid_ssr_impl<ProductWithoutWithX, X>::value));
+  EXPECT_FALSE(bool(has_valid_ssr_impl<ProductWithoutWithX, Y>::value));
+
+  using ProductWithoutWithXY = decltype(without * with_xy);
+  EXPECT_TRUE(bool(has_valid_ssr_impl<ProductWithoutWithXY, X>::value));
+  EXPECT_TRUE(bool(has_valid_ssr_impl<ProductWithoutWithXY, Y>::value));
+
+  using ProductWithXWithXY = decltype(with_x * with_xy);
+  EXPECT_TRUE(bool(has_valid_ssr_impl<ProductWithXWithXY, X>::value));
+  EXPECT_TRUE(bool(has_valid_ssr_impl<ProductWithXWithXY, Y>::value));
+
+
+}
+
+
 } // namespace albatross


### PR DESCRIPTION
This change adds another optional functionality to covariance functions, namely it let's you have the covariance function directly tell you what set of states should be able to capture it's behavior.

For example, the `SquaredExponential` covariance function now has an`_ssr_impl` method which uses it's length scale to determine the spacing of a grid that you'd need to reasonably approximate what the full covariance would capture.  This is used and tested in `test_sparse_gp.cc`.

Another example:
```
  cov.set_param_value("squared_exponential_length_scale", 100.);
  std::cout << "long length scale: ";
  for (const auto &d : cov.state_space_representation(dataset.features)) {
    std::cout << d << ", ";
  }
  std::cout << std::endl;

  cov.set_param_value("squared_exponential_length_scale", 1.);
  std::cout << "short length scale: ";
  for (const auto &d : cov.state_space_representation(dataset.features)) {
    std::cout << d << ", ";
  }
  std::cout << std::endl;

======================================

long length scale: 0, 3, 6, 9, 
short length scale: 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9, 9
```