### PR TITLE
Actually Use Group By

### DIFF
--- a/include/albatross/src/cereal/evaluation.hpp
+++ b/include/albatross/src/cereal/evaluation.hpp
@@ -13,21 +13,10 @@
 #ifndef ALBATROSS_SRC_CEREAL_EVALUATION_HPP_
 #define ALBATROSS_SRC_CEREAL_EVALUATION_HPP_
 
-using albatross::LeaveOneGroupOut;
-using albatross::LeaveOneOut;
 using albatross::ModelMetric;
 using albatross::PredictionMetric;
 
 namespace cereal {
-
-template <typename Archive, typename FeatureType>
-inline void serialize(Archive &archive, LeaveOneGroupOut<FeatureType> &logo,
-                      const std::uint32_t) {
-  archive(cereal::make_nvp("grouper", logo.grouper));
-};
-
-template <typename Archive>
-inline void serialize(Archive &, LeaveOneOut &loo, const std::uint32_t){};
 
 template <typename Archive, typename MetricType>
 inline void serialize(Archive &, ModelMetric<MetricType> &loo,

--- a/include/albatross/src/cereal/ransac.hpp
+++ b/include/albatross/src/cereal/ransac.hpp
@@ -22,8 +22,8 @@ using albatross::RansacOutput;
 
 namespace cereal {
 
-template <typename Archive>
-inline void serialize(Archive &archive, RansacOutput &ransac_output,
+template <typename Archive, typename GroupKey>
+inline void serialize(Archive &archive, RansacOutput<GroupKey> &ransac_output,
                       const std::uint32_t) {
   archive(cereal::make_nvp("return_code", ransac_output.return_code));
   archive(cereal::make_nvp("inliers", ransac_output.inliers));
@@ -32,35 +32,36 @@ inline void serialize(Archive &archive, RansacOutput &ransac_output,
 }
 
 template <typename Archive, typename ModelType, typename StrategyType,
-          typename FeatureType>
-inline void serialize(Archive &archive,
-                      Fit<RansacFit<ModelType, StrategyType, FeatureType>> &fit,
-                      const std::uint32_t) {
+          typename FeatureType, typename GroupKey>
+inline void
+serialize(Archive &archive,
+          Fit<RansacFit<ModelType, StrategyType, FeatureType, GroupKey>> &fit,
+          const std::uint32_t) {
   archive(cereal::make_nvp("maybe_empty_fit_model", fit.maybe_empty_fit_model));
   archive(cereal::make_nvp("ransac_output", fit.ransac_output));
 }
 
 template <typename Archive, typename InlierMetric, typename ConsensusMetric,
-          typename IndexingFunction>
+          typename GrouperFunction>
 inline void serialize(Archive &archive,
                       GenericRansacStrategy<InlierMetric, ConsensusMetric,
-                                            IndexingFunction> &strategy,
+                                            GrouperFunction> &strategy,
                       const std::uint32_t) {
   archive(cereal::make_nvp("inlier_metric", strategy.inlier_metric_));
   archive(cereal::make_nvp("consensus_metric", strategy.consensus_metric_));
-  archive(cereal::make_nvp("indexing_function", strategy.indexing_function_));
+  archive(cereal::make_nvp("grouper_function", strategy.grouper_function_));
 }
 
 template <typename Archive, typename InlierMetric, typename ConsensusMetric,
-          typename IndexingFunction>
+          typename GrouperFunction>
 inline void
 serialize(Archive &archive,
           GaussianProcessRansacStrategy<InlierMetric, ConsensusMetric,
-                                        IndexingFunction> &strategy,
+                                        GrouperFunction> &strategy,
           const std::uint32_t) {
   archive(cereal::make_nvp("inlier_metric", strategy.inlier_metric_));
   archive(cereal::make_nvp("consensus_metric", strategy.consensus_metric_));
-  archive(cereal::make_nvp("indexing_function", strategy.indexing_function_));
+  archive(cereal::make_nvp("grouper_function", strategy.grouper_function_));
 }
 
 } // namespace cereal

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -52,7 +52,7 @@ template <typename GroupKey, typename ValueType> class Grouped;
 template <typename GroupKey>
 using GroupIndexer = Grouped<GroupKey, GroupIndices>;
 
-struct LeaveOneOut;
+struct LeaveOneOutGrouper;
 
 template <typename ValueType, typename GrouperFunction> class GroupBy;
 
@@ -94,23 +94,15 @@ template <typename ImplType = NullLeastSquaresImpl> class LeastSquares;
 /*
  * Cross Validation
  */
-using FoldIndices = std::vector<std::size_t>;
-using FoldName = std::string;
-using FoldIndexer = std::map<FoldName, FoldIndices>;
-
 template <typename FeatureType> struct RegressionFold;
+
+template <typename GroupKey, typename FeatureType>
+using RegressionFolds = Grouped<GroupKey, RegressionFold<FeatureType>>;
 
 template <typename FeatureType>
 using GroupFunction = std::string (*)(const FeatureType &);
 
-template <typename FeatureType>
-using IndexerFunction = FoldIndexer (*)(const RegressionDataset<FeatureType> &);
-
 template <typename ModelType> class CrossValidation;
-
-template <typename FeatureType> struct LeaveOneGroupOut;
-
-struct LeaveOneOut;
 
 template <typename MetricType> class ModelMetric;
 
@@ -120,23 +112,24 @@ template <typename RequiredPredictType> struct PredictionMetric;
  * RANSAC
  */
 
-struct RansacOutput;
+template <typename GroupKey> struct RansacOutput;
 
 struct RansacConfig;
 
 template <typename ModelType, typename StrategyType> class Ransac;
 
-template <typename ModelType, typename StrategyType, typename FeatureType>
+template <typename ModelType, typename StrategyType, typename FeatureType,
+          typename GroupKey>
 struct RansacFit;
 
 template <typename InlierMetric, typename ConsensusMetric,
-          typename IndexingFunction>
+          typename GrouperFunction>
 struct GenericRansacStrategy;
 
 struct AlwaysAcceptCandidateMetric;
 
 template <typename InlierMetric, typename ConsensusMetric,
-          typename IndexingFunction,
+          typename GrouperFunction,
           typename IsValidCandidateMetric = AlwaysAcceptCandidateMetric>
 struct GaussianProcessRansacStrategy;
 

--- a/include/albatross/src/evaluation/cross_validation.hpp
+++ b/include/albatross/src/evaluation/cross_validation.hpp
@@ -15,29 +15,47 @@
 
 namespace albatross {
 
+template <typename ModelType, typename FeatureType>
+auto predict_fold(const ModelType &model,
+                  const RegressionFold<FeatureType> &fold) {
+  return model.fit(fold.train_dataset).predict(fold.test_dataset.features);
+};
+
 /*
  * This is a specialization of the `Prediction` class which adds some
  * cross validation specific methods, and specializes the standard
  * methods (such as mean, marginal, joint).
  */
-template <typename ModelType, typename FeatureType>
-class Prediction<CrossValidation<ModelType>, FeatureType, FoldIndexer> {
+template <typename ModelType, typename FeatureType, typename GroupKey>
+class Prediction<CrossValidation<ModelType>, FeatureType,
+                 GroupIndexer<GroupKey>> {
 public:
   Prediction(const ModelType &model,
              const RegressionDataset<FeatureType> &dataset,
-             const FoldIndexer &indexer)
+             const GroupIndexer<GroupKey> &indexer)
       : model_(model), dataset_(dataset), indexer_(indexer) {}
+
+  auto predictions() const {
+
+    const auto predict_one_group = [&](const auto &,
+                                       const GroupIndices &test_indices) {
+      return predict_fold(model_, create_fold(test_indices, dataset_));
+    };
+
+    return indexer_.index_apply(predict_one_group);
+  }
 
   // MEAN
 
   // Cross validation specialized means().
-  template <
-      typename DummyType = ModelType,
-      typename std::enable_if<has_valid_cv_mean<DummyType, FeatureType>::value,
-                              int>::type = 0>
-  std::map<std::string, Eigen::VectorXd> means() const {
-    return model_.cross_validated_predictions(
-        dataset_, indexer_, PredictTypeIdentity<Eigen::VectorXd>());
+  template <typename DummyType = ModelType,
+            typename std::enable_if<
+                has_valid_cv_mean<DummyType, FeatureType, GroupKey>::value,
+                int>::type = 0>
+  Grouped<GroupKey, Eigen::VectorXd> means() const {
+    return Grouped<GroupKey, Eigen::VectorXd>(
+        model_.cross_validated_predictions(
+            dataset_, indexer_, PredictTypeIdentity<Eigen::VectorXd>()));
   }
 
   // Generic means();
@@ -46,12 +64,10 @@ public:
                 has_mean<Prediction<
                     DummyType, FeatureType,
                     typename fit_type<DummyType, FeatureType>::type>>::value &&
-                    !has_valid_cv_mean<DummyType, FeatureType>::value,
+                    !has_valid_cv_mean<DummyType, FeatureType, GroupKey>::value,
                 int>::type = 0>
-  std::map<std::string, Eigen::VectorXd> means() const {
-    const auto folds = folds_from_fold_indexer(dataset_, indexer_);
-    const auto predictions = albatross::get_predictions(model_, folds);
-    return get_means(predictions);
+  Grouped<GroupKey, Eigen::VectorXd> means() const {
+    return get_means(predictions());
   }
 
   // No valid method of computing the means.
@@ -60,16 +76,16 @@ public:
                 !has_mean<Prediction<
                     DummyType, FeatureType,
                     typename fit_type<DummyType, FeatureType>::type>>::value &&
-                    !has_valid_cv_mean<DummyType, FeatureType>::value,
+                    !has_valid_cv_mean<DummyType, FeatureType, GroupKey>::value,
                 int>::type = 0>
-  std::map<std::string, Eigen::VectorXd> means() const = delete;
+  Grouped<GroupKey, Eigen::VectorXd> means() const = delete;
 
   template <typename DummyType = ModelType,
             typename std::enable_if<
                 has_mean<Prediction<
                     DummyType, FeatureType,
                     typename fit_type<DummyType, FeatureType>::type>>::value ||
-                    has_valid_cv_mean<DummyType, FeatureType>::value,
+                    has_valid_cv_mean<DummyType, FeatureType, GroupKey>::value,
                 int>::type = 0>
   Eigen::VectorXd mean() const {
     return concatenate_mean_predictions(indexer_, means());
@@ -81,7 +97,7 @@ public:
                 !has_mean<Prediction<
                     DummyType, FeatureType,
                     typename fit_type<DummyType, FeatureType>::type>>::value &&
-                    !has_valid_cv_mean<DummyType, FeatureType>::value,
+                    !has_valid_cv_mean<DummyType, FeatureType, GroupKey>::value,
                 int>::type = 0>
 
   Eigen::VectorXd mean() const = delete;
@@ -89,96 +105,98 @@ public:
   // Marginal
 
   // Cross validation specialized marginals()
-  template <
-      typename DummyType = ModelType,
-      typename std::enable_if<
-          has_valid_cv_marginal<DummyType, FeatureType>::value, int>::type = 0>
-  std::map<std::string, MarginalDistribution> marginals() const {
+  template <typename DummyType = ModelType,
+            typename std::enable_if<
+                has_valid_cv_marginal<DummyType, FeatureType, GroupKey>::value,
+                int>::type = 0>
+  Grouped<GroupKey, MarginalDistribution> marginals() const {
     return model_.cross_validated_predictions(
         dataset_, indexer_, PredictTypeIdentity<MarginalDistribution>());
   }
 
   // Generic marginals()
-  template <typename DummyType = ModelType,
-            typename std::enable_if<
-                has_marginal<Prediction<
-                    DummyType, FeatureType,
-                    typename fit_type<DummyType, FeatureType>::type>>::value &&
-                    !has_valid_cv_marginal<DummyType, FeatureType>::value,
-                int>::type = 0>
-  std::map<std::string, MarginalDistribution> marginals() const {
-    const auto folds = folds_from_fold_indexer(dataset_, indexer_);
-    const auto predictions = albatross::get_predictions(model_, folds);
-    return get_marginals(predictions);
+  template <
+      typename DummyType = ModelType,
+      typename std::enable_if<
+          has_marginal<Prediction<
+              DummyType, FeatureType,
+              typename fit_type<DummyType, FeatureType>::type>>::value &&
+              !has_valid_cv_marginal<DummyType, FeatureType, GroupKey>::value,
+          int>::type = 0>
+  Grouped<GroupKey, MarginalDistribution> marginals() const {
+    return get_marginals(predictions());
   }
 
   // No valid way of computing marginals.
-  template <typename DummyType = ModelType,
-            typename std::enable_if<
-                !has_marginal<Prediction<
-                    DummyType, FeatureType,
-                    typename fit_type<DummyType, FeatureType>::type>>::value &&
-                    !has_valid_cv_marginal<DummyType, FeatureType>::value,
-                int>::type = 0>
+  template <
+      typename DummyType = ModelType,
+      typename std::enable_if<
+          !has_marginal<Prediction<
+              DummyType, FeatureType,
+              typename fit_type<DummyType, FeatureType>::type>>::value &&
+              !has_valid_cv_marginal<DummyType, FeatureType, GroupKey>::value,
+          int>::type = 0>
   MarginalDistribution marginals() const = delete;
 
   // No valid way of computing marginals.
-  template <typename DummyType = ModelType,
-            typename std::enable_if<
-                has_marginal<Prediction<
-                    DummyType, FeatureType,
-                    typename fit_type<DummyType, FeatureType>::type>>::value ||
-                    has_valid_cv_marginal<DummyType, FeatureType>::value,
-                int>::type = 0>
+  template <
+      typename DummyType = ModelType,
+      typename std::enable_if<
+          has_marginal<Prediction<
+              DummyType, FeatureType,
+              typename fit_type<DummyType, FeatureType>::type>>::value ||
+              has_valid_cv_marginal<DummyType, FeatureType, GroupKey>::value,
+          int>::type = 0>
   MarginalDistribution marginal() const {
     return concatenate_marginal_predictions(indexer_, marginals());
   }
 
   // No valid way of computing marginals.
-  template <typename DummyType = ModelType,
-            typename std::enable_if<
-                !has_marginal<Prediction<
-                    DummyType, FeatureType,
-                    typename fit_type<DummyType, FeatureType>::type>>::value &&
-                    !has_valid_cv_marginal<DummyType, FeatureType>::value,
-                int>::type = 0>
+  template <
+      typename DummyType = ModelType,
+      typename std::enable_if<
+          !has_marginal<Prediction<
+              DummyType, FeatureType,
+              typename fit_type<DummyType, FeatureType>::type>>::value &&
+              !has_valid_cv_marginal<DummyType, FeatureType, GroupKey>::value,
+          int>::type = 0>
   MarginalDistribution marginal() const = delete;
 
   // JOINT
 
   // Cross validation specific joints().
-  template <
-      typename DummyType = ModelType,
-      typename std::enable_if<has_valid_cv_joint<DummyType, FeatureType>::value,
-                              int>::type = 0>
-  std::map<std::string, JointDistribution> joints() const {
+  template <typename DummyType = ModelType,
+            typename std::enable_if<
+                has_valid_cv_joint<DummyType, FeatureType, GroupKey>::value,
+                int>::type = 0>
+  Grouped<GroupKey, JointDistribution> joints() const {
     return model_.cross_validated_predictions(
         dataset_, indexer_, PredictTypeIdentity<JointDistribution>());
   }
 
   // Generic joints().
-  template <typename DummyType = ModelType,
-            typename std::enable_if<
-                has_joint<Prediction<
-                    DummyType, FeatureType,
-                    typename fit_type<DummyType, FeatureType>::type>>::value &&
-                    !has_valid_cv_joint<DummyType, FeatureType>::value,
-                int>::type = 0>
-  std::map<std::string, JointDistribution> joints() const {
-    const auto folds = folds_from_fold_indexer(dataset_, indexer_);
-    const auto predictions = albatross::get_predictions(model_, folds);
-    return get_joints(predictions);
+  template <
+      typename DummyType = ModelType,
+      typename std::enable_if<
+          has_joint<Prediction<
+              DummyType, FeatureType,
+              typename fit_type<DummyType, FeatureType>::type>>::value &&
+              !has_valid_cv_joint<DummyType, FeatureType, GroupKey>::value,
+          int>::type = 0>
+  Grouped<GroupKey, JointDistribution> joints() const {
+    return get_joints(predictions());
   }
 
   // No valid way of computing joints().
-  template <typename DummyType = ModelType,
-            typename std::enable_if<
-                !has_joint<Prediction<
-                    DummyType, FeatureType,
-                    typename fit_type<DummyType, FeatureType>::type>>::value &&
-                    !has_valid_cv_joint<DummyType, FeatureType>::value,
-                int>::type = 0>
-  std::map<std::string, JointDistribution> joints() const = delete;
+  template <
+      typename DummyType = ModelType,
+      typename std::enable_if<
+          !has_joint<Prediction<
+              DummyType, FeatureType,
+              typename fit_type<DummyType, FeatureType>::type>>::value &&
+              !has_valid_cv_joint<DummyType, FeatureType, GroupKey>::value,
+          int>::type = 0>
+  Grouped<GroupKey, JointDistribution> joints() const = delete;
 
   template <typename DummyType = ModelType>
   JointDistribution joint() const =
@@ -195,34 +213,46 @@ private:
 
   auto get(get_type<Eigen::VectorXd>) const { return this->mean(); }
 
-  auto get(get_type<std::map<std::string, Eigen::VectorXd>>) const {
+  auto get(get_type<std::map<GroupKey, Eigen::VectorXd>>) const {
+    return this->means().get_map();
+  }
+
+  auto get(get_type<Grouped<GroupKey, Eigen::VectorXd>>) const {
     return this->means();
   }
 
   auto get(get_type<MarginalDistribution>) const { return this->marginal(); }
 
-  auto get(get_type<std::map<std::string, MarginalDistribution>>) const {
+  auto get(get_type<std::map<GroupKey, MarginalDistribution>>) const {
+    return this->marginals().get_map();
+  }
+
+  auto get(get_type<Grouped<GroupKey, MarginalDistribution>>) const {
     return this->marginals();
   }
 
   auto get(get_type<JointDistribution>) const { return this->joint(); }
 
-  auto get(get_type<std::map<std::string, JointDistribution>>) const {
+  auto get(get_type<std::map<GroupKey, JointDistribution>>) const {
     return this->joints();
+  }
+
+  auto get(get_type<Grouped<GroupKey, JointDistribution>>) const {
+    return this->joints().get_map();
   }
 
   const ModelType model_;
   const RegressionDataset<FeatureType> dataset_;
-  const FoldIndexer indexer_;
+  const GroupIndexer<GroupKey> indexer_;
 };
 
 /*
  * Cross Validation
  */
 
-template <typename ModelType, typename FeatureType>
+template <typename ModelType, typename FeatureType, typename GroupKey>
 using CVPrediction =
-    Prediction<CrossValidation<ModelType>, FeatureType, FoldIndexer>;
+    Prediction<CrossValidation<ModelType>, FeatureType, GroupIndexer<GroupKey>>;
 
 template <typename ModelType> class CrossValidation {
 
@@ -231,55 +261,58 @@ template <typename ModelType> class CrossValidation {
 public:
   CrossValidation(const ModelType &model) : model_(model){};
 
-  // get_predictions
+  // Predict
 
-  template <typename FeatureType>
-  auto
-  get_predictions(const std::vector<RegressionFold<FeatureType>> &folds) const {
-    return albatross::get_predictions(model_, folds);
-  }
-
-  template <typename FeatureType, typename IndexFunc>
-  auto get_predictions(const RegressionDataset<FeatureType> &dataset,
-                       const IndexFunc &index_function) const {
-    const auto indexer = index_function(dataset);
-    const auto folds = folds_from_fold_indexer(dataset, indexer);
-    return get_predictions(folds);
-  }
-
-  // get_prediction
-  template <typename FeatureType>
-  CVPrediction<ModelType, FeatureType>
+  template <typename FeatureType, typename GroupKey>
+  CVPrediction<ModelType, FeatureType, GroupKey>
   predict(const RegressionDataset<FeatureType> &dataset,
-          const FoldIndexer &indexer) const {
-    return CVPrediction<ModelType, FeatureType>(model_, dataset, indexer);
+          const GroupIndexer<GroupKey> &indexer) const {
+    return CVPrediction<ModelType, FeatureType, GroupKey>(model_, dataset,
+                                                          indexer);
   }
 
-  template <typename FeatureType, typename IndexFunc>
+  template <typename FeatureType, typename GrouperFunction>
   auto predict(const RegressionDataset<FeatureType> &dataset,
-               const IndexFunc &index_function) const {
-    const auto indexer = index_function(dataset);
-    return predict(dataset, indexer);
+               const GrouperFunction &grouper_function) const {
+    return predict(dataset, dataset.group_by(grouper_function).indexers());
+  }
+
+  // Predictions
+
+  template <typename FeatureType, typename GrouperFunction>
+  auto predictions(const RegressionDataset<FeatureType> &dataset,
+                   const GrouperFunction &grouper) const {
+    return predict(dataset, grouper).predictions();
+  }
+
+  template <typename GroupKey, typename FeatureType>
+  auto predictions(const RegressionFolds<GroupKey, FeatureType> &folds) const {
+    const auto predict_one_fold = [&](const auto &, const auto &fold) {
+      return predict_fold(model_, fold);
+    };
+    return folds.apply(predict_one_fold);
   }
 
   // Scores
 
-  template <typename RequiredPredictType, typename FeatureType>
+  template <typename RequiredPredictType, typename GroupKey,
+            typename FeatureType>
   Eigen::VectorXd
   scores(const PredictionMetric<RequiredPredictType> &metric,
-         const std::vector<RegressionFold<FeatureType>> &folds) const {
-    const auto preds = get_predictions(folds);
+         const RegressionFolds<GroupKey, FeatureType> &folds) const {
+    const auto preds = predictions(folds);
     return cross_validated_scores(metric, folds, preds);
   }
 
-  template <typename RequiredPredictType, typename FeatureType>
+  template <typename RequiredPredictType, typename FeatureType,
+            typename GroupKey>
   Eigen::VectorXd scores(const PredictionMetric<RequiredPredictType> &metric,
                          const RegressionDataset<FeatureType> &dataset,
-                         const FoldIndexer &indexer) const {
-    const auto folds = folds_from_fold_indexer(dataset, indexer);
+                         const GroupIndexer<GroupKey> &indexer) const {
+    const auto folds = folds_from_group_indexer(dataset, indexer);
     const auto prediction = predict(dataset, indexer);
     const auto predictions =
-        prediction.template get<std::map<std::string, RequiredPredictType>>();
+        prediction.template get<Grouped<GroupKey, RequiredPredictType>>();
     return cross_validated_scores(metric, folds, predictions);
   }
 
@@ -288,7 +321,7 @@ public:
   Eigen::VectorXd scores(const PredictionMetric<RequiredPredictType> &metric,
                          const RegressionDataset<FeatureType> &dataset,
                          const IndexFunc &index_function) const {
-    const auto indexer = index_function(dataset);
+    const auto indexer = group_by(dataset, index_function).indexers();
     return scores(metric, dataset, indexer);
   }
 };

--- a/include/albatross/src/evaluation/folds.hpp
+++ b/include/albatross/src/evaluation/folds.hpp
@@ -21,161 +21,94 @@ namespace albatross {
 template <typename FeatureType> struct RegressionFold {
   RegressionDataset<FeatureType> train_dataset;
   RegressionDataset<FeatureType> test_dataset;
-  FoldName name;
-  FoldIndices test_indices;
+  GroupIndices test_indices;
+
+  RegressionFold() : train_dataset(), test_dataset(), test_indices(){};
 
   RegressionFold(const RegressionDataset<FeatureType> &train_dataset_,
                  const RegressionDataset<FeatureType> &test_dataset_,
-                 const FoldName &name_, const FoldIndices &test_indices_)
-      : train_dataset(train_dataset_), test_dataset(test_dataset_), name(name_),
+                 const GroupIndices &test_indices_)
+      : train_dataset(train_dataset_), test_dataset(test_dataset_),
         test_indices(test_indices_){};
 };
 
-/*
- * Leave One Out
- */
 template <typename FeatureType>
-static inline FoldIndexer
-leave_one_out_indexer(const std::vector<FeatureType> &features) {
-  FoldIndexer groups;
-  for (std::size_t i = 0; i < features.size(); i++) {
-    FoldName group_name = std::to_string(i);
-    groups[group_name] = {i};
-  }
-  return groups;
-}
+inline RegressionFold<FeatureType>
+create_fold(const GroupIndices &test_indices,
+            const RegressionDataset<FeatureType> &dataset) {
 
-template <typename FeatureType>
-static inline FoldIndexer
-leave_one_out_indexer(const RegressionDataset<FeatureType> &dataset) {
-  return leave_one_out_indexer(dataset.features);
-}
+  const auto train_indices = indices_complement(test_indices, dataset.size());
 
-struct LeaveOneOut {
+  std::vector<FeatureType> train_features =
+      subset(dataset.features, train_indices);
+  MarginalDistribution train_targets = subset(dataset.targets, train_indices);
 
-  template <typename FeatureType>
-  FoldIndexer operator()(const RegressionDataset<FeatureType> &dataset) const {
-    return leave_one_out_indexer(dataset);
-  }
+  std::vector<FeatureType> test_features =
+      subset(dataset.features, test_indices);
+  MarginalDistribution test_targets = subset(dataset.targets, test_indices);
 
-  template <typename FeatureType>
-  FoldIndexer operator()(const std::vector<FeatureType> &features) const {
-    return leave_one_out_indexer(features);
-  }
-};
+  assert(train_features.size() == train_targets.size());
+  assert(test_features.size() == test_targets.size());
+  assert(test_targets.size() + train_targets.size() == dataset.size());
 
-/*
- * Leave One Group Out
- */
-
-template <typename FeatureType, typename GetGroupName>
-static inline FoldIndexer
-leave_one_group_out_indexer(const std::vector<FeatureType> &features,
-                            const GetGroupName &get_group_name) {
-  FoldIndexer groups;
-  for (std::size_t i = 0; i < features.size(); i++) {
-    const std::string k = get_group_name(features[i]);
-    // Get the existing indices if we've already encountered this group_name
-    // otherwise initialize a new one.
-    FoldIndices indices;
-    if (groups.find(k) == groups.end()) {
-      indices = FoldIndices();
-    } else {
-      indices = groups[k];
-    }
-    // Add the current index.
-    indices.push_back(i);
-    groups[k] = indices;
-  }
-  return groups;
-}
-
-template <typename FeatureType> struct LeaveOneGroupOut {
-
-  LeaveOneGroupOut(GroupFunction<FeatureType> grouper_) : grouper(grouper_){};
-
-  FoldIndexer operator()(const std::vector<FeatureType> &features) const {
-    return leave_one_group_out_indexer(features, grouper);
-  }
-
-  FoldIndexer operator()(const RegressionDataset<FeatureType> &dataset) const {
-    return leave_one_group_out_indexer(dataset.features, grouper);
-  }
-
-  GroupFunction<FeatureType> grouper;
+  const RegressionDataset<FeatureType> train_split(train_features,
+                                                   train_targets);
+  const RegressionDataset<FeatureType> test_split(test_features, test_targets);
+  return RegressionFold<FeatureType>(train_split, test_split, test_indices);
 };
 
 /*
  * Each flavor of cross validation can be described by a set of
- * FoldIndices, which store which indices should be used for the
- * test cases.  This function takes a map from FoldName to
- * FoldIndices and a dataset and creates the resulting folds.
+ * GroupIndices, which store which indices should be used for the
+ * test cases.  This function takes a map from GroupKey to
+ * GroupIndices and a dataset and creates the resulting folds.
  */
-template <typename FeatureType>
-static inline std::vector<RegressionFold<FeatureType>>
-folds_from_fold_indexer(const RegressionDataset<FeatureType> &dataset,
-                        const FoldIndexer &groups) {
-  const std::size_t n = dataset.features.size();
-  std::vector<RegressionFold<FeatureType>> folds;
-  // For each fold, partition into train and test sets.
-  for (const auto &pair : groups) {
-    // These get exposed inside the returned RegressionFold and because
-    // we'd like to prevent modification of the output from this function
-    // from changing the input FoldIndexer we perform a copy here.
-    const FoldName group_name(pair.first);
-    const FoldIndices test_indices(pair.second);
-    const auto train_indices = indices_complement(test_indices, n);
+template <typename FeatureType, typename GroupKey>
+inline RegressionFolds<GroupKey, FeatureType>
+folds_from_group_indexer(const RegressionDataset<FeatureType> &dataset,
+                         const GroupIndexer<GroupKey> &groups) {
 
-    std::vector<FeatureType> train_features =
-        subset(dataset.features, train_indices);
-    MarginalDistribution train_targets = subset(dataset.targets, train_indices);
+  const auto create_one_fold = [&dataset](const GroupKey &,
+                                          const GroupIndices &test_indices) {
+    return create_fold(test_indices, dataset);
+  };
 
-    std::vector<FeatureType> test_features =
-        subset(dataset.features, test_indices);
-    MarginalDistribution test_targets = subset(dataset.targets, test_indices);
-
-    assert(train_features.size() == train_targets.size());
-    assert(test_features.size() == test_targets.size());
-    assert(test_targets.size() + train_targets.size() == n);
-
-    const RegressionDataset<FeatureType> train_split(train_features,
-                                                     train_targets);
-    const RegressionDataset<FeatureType> test_split(test_features,
-                                                    test_targets);
-    folds.push_back(RegressionFold<FeatureType>(train_split, test_split,
-                                                group_name, test_indices));
-  }
-  return folds;
+  return groups.apply(create_one_fold);
 }
 
 /*
  * Extracts the fold indexer that would have created a set of folds
  */
-template <typename FeatureType>
-static inline FoldIndexer
-fold_indexer_from_folds(const std::vector<RegressionFold<FeatureType>> &folds) {
-  FoldIndexer output;
+template <typename GroupKey, typename FeatureType>
+inline GroupIndexer<GroupKey>
+group_indexer_from_folds(const std::map<GroupKey, FeatureType> &folds) {
+  GroupIndexer<GroupKey> output;
   for (const auto &fold : folds) {
-    assert(!map_contains(output, fold.name));
-    output[fold.name] = fold.test_indices;
+    assert(!map_contains(output, fold.first));
+    output[fold.first] = fold.second.test_indices;
   }
   return output;
 }
 
-template <typename FeatureType>
-static inline std::vector<RegressionFold<FeatureType>>
-folds_from_grouper(const RegressionDataset<FeatureType> &dataset,
-                   const GroupFunction<FeatureType> &grouper) {
-  const LeaveOneGroupOut<FeatureType> by_group(grouper);
-  const auto indexer = by_group(dataset);
-  return folds_from_fold_indexer(dataset, indexer);
+template <typename FeatureType, typename GrouperFunction>
+inline auto folds_from_grouper(const RegressionDataset<FeatureType> &dataset,
+                               GrouperFunction grouper) {
+
+  const auto create_one_fold = [&dataset](const auto &,
+                                          const GroupIndices &test_indices) {
+    return create_fold(test_indices, dataset);
+  };
+
+  return dataset.group_by(grouper).index_apply(create_one_fold);
 }
 
 /*
  * Inspects a bunch of folds and creates a set of all the indicies
  * in an original dataset that comprise the test_datasets and the folds.
  */
-inline std::set<std::size_t> unique_indices(const FoldIndexer &indexer) {
+template <typename GroupKey>
+inline std::set<std::size_t>
+unique_indices(const GroupIndexer<GroupKey> &indexer) {
   std::set<std::size_t> indices;
   for (const auto &pair : indexer) {
     indices.insert(pair.second.begin(), pair.second.end());
@@ -183,7 +116,9 @@ inline std::set<std::size_t> unique_indices(const FoldIndexer &indexer) {
   return indices;
 }
 
-inline std::size_t dataset_size_from_indexer(const FoldIndexer &indexer) {
+template <typename GroupKey>
+inline std::size_t
+dataset_size_from_indexer(const GroupIndexer<GroupKey> &indexer) {
   const auto unique_inds = unique_indices(indexer);
 
   // Make sure there were no duplicate test indices.
@@ -206,10 +141,10 @@ inline std::size_t dataset_size_from_indexer(const FoldIndexer &indexer) {
   return n + 1;
 }
 
-template <typename FeatureType>
+template <typename GroupKey, typename FeatureType>
 inline std::size_t
-dataset_size_from_folds(const std::vector<RegressionFold<FeatureType>> &folds) {
-  return dataset_size_from_indexer(fold_indexer_from_folds(folds));
+dataset_size_from_folds(const RegressionFolds<GroupKey, FeatureType> &folds) {
+  return dataset_size_from_indexer(group_indexer_from_folds(folds));
 }
 
 } // namespace albatross

--- a/include/albatross/src/evaluation/traits.hpp
+++ b/include/albatross/src/evaluation/traits.hpp
@@ -18,16 +18,18 @@ namespace albatross {
 /*
  * Cross validation traits
  */
-template <typename T, typename FeatureType, typename PredictType>
+template <typename T, typename FeatureType, typename PredictType,
+          typename GroupKey>
 class has_valid_cross_validated_predictions {
+
   template <typename C,
             typename ReturnType =
                 decltype(std::declval<const C>().cross_validated_predictions(
                     std::declval<const RegressionDataset<FeatureType> &>(),
-                    std::declval<const FoldIndexer &>(),
+                    std::declval<const GroupIndexer<GroupKey> &>(),
                     std::declval<PredictTypeIdentity<PredictType>>()))>
   static typename std::enable_if<
-      std::is_same<std::map<std::string, PredictType>, ReturnType>::value,
+      std::is_same<std::map<GroupKey, PredictType>, ReturnType>::value,
       std::true_type>::type
   test(C *);
   template <typename> static std::false_type test(...);
@@ -36,17 +38,20 @@ public:
   static constexpr bool value = decltype(test<T>(0))::value;
 };
 
-template <typename T, typename FeatureType>
+template <typename T, typename FeatureType, typename GroupKey>
 using has_valid_cv_mean =
-    has_valid_cross_validated_predictions<T, FeatureType, Eigen::VectorXd>;
+    has_valid_cross_validated_predictions<T, FeatureType, Eigen::VectorXd,
+                                          GroupKey>;
 
-template <typename T, typename FeatureType>
+template <typename T, typename FeatureType, typename GroupKey>
 using has_valid_cv_marginal =
-    has_valid_cross_validated_predictions<T, FeatureType, MarginalDistribution>;
+    has_valid_cross_validated_predictions<T, FeatureType, MarginalDistribution,
+                                          GroupKey>;
 
-template <typename T, typename FeatureType>
+template <typename T, typename FeatureType, typename GroupKey>
 using has_valid_cv_joint =
-    has_valid_cross_validated_predictions<T, FeatureType, JointDistribution>;
+    has_valid_cross_validated_predictions<T, FeatureType, JointDistribution,
+                                          GroupKey>;
 
 /*
  * PredictionMetrics

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -36,6 +36,7 @@ template <typename KeyType, typename ValueType> class GroupedBase {
 public:
   GroupedBase() : map_(){};
   GroupedBase(const GroupedBase &other) = default;
+  GroupedBase(std::map<KeyType, ValueType> &&map) : map_(std::move(map)){};
   GroupedBase(const std::map<KeyType, ValueType> &map) : map_(map){};
 
   void emplace(const KeyType &k, ValueType &&v) {
@@ -67,6 +68,8 @@ public:
   std::vector<KeyType> keys() const { return map_keys(map_); }
 
   std::vector<ValueType> values() const { return map_values(map_); }
+
+  std::map<KeyType, ValueType> get_map() const { return map_; }
 
   /*
    * Filtering a Grouped object consists of deciding which of the
@@ -172,7 +175,10 @@ protected:
 };
 
 template <typename KeyType, typename ValueType>
-class Grouped : public GroupedBase<KeyType, ValueType> {};
+class Grouped : public GroupedBase<KeyType, ValueType> {
+  using Base = GroupedBase<KeyType, ValueType>;
+  using Base::Base;
+};
 
 template <typename KeyType>
 class Grouped<KeyType, GroupIndices>
@@ -236,16 +242,25 @@ Eigen::VectorXd combine(const Map<KeyType, double> &groups) {
 template <typename KeyType, typename ValueType>
 class CombinableBase : public GroupedBase<KeyType, ValueType> {
 public:
+  using Base = GroupedBase<KeyType, ValueType>;
+  using Base::Base;
+
   ValueType combine() const { return albatross::combine(*this); }
 };
 
 template <typename KeyType, typename FeatureType>
 class Grouped<KeyType, RegressionDataset<FeatureType>>
-    : public CombinableBase<KeyType, RegressionDataset<FeatureType>> {};
+    : public CombinableBase<KeyType, RegressionDataset<FeatureType>> {
+  using Base = CombinableBase<KeyType, RegressionDataset<FeatureType>>;
+  using Base::Base;
+};
 
 template <typename KeyType, typename FeatureType>
 class Grouped<KeyType, std::vector<FeatureType>>
-    : public CombinableBase<KeyType, std::vector<FeatureType>> {};
+    : public CombinableBase<KeyType, std::vector<FeatureType>> {
+  using Base = CombinableBase<KeyType, std::vector<FeatureType>>;
+  using Base::Base;
+};
 
 /*
  * Not all GrouperFunctions actually take Values as input, the leave one

--- a/include/albatross/src/indexing/subset.hpp
+++ b/include/albatross/src/indexing/subset.hpp
@@ -180,12 +180,12 @@ indices_complement(const std::vector<std::size_t> &indices,
   return std::vector<std::size_t>(complement.begin(), complement.end());
 }
 
-inline FoldIndices indices_from_names(const FoldIndexer &indexer,
-                                      const std::vector<FoldName> &names) {
-  FoldIndices output;
-  for (const auto &name : names) {
-    output.insert(output.end(), indexer.at(name).begin(),
-                  indexer.at(name).end());
+template <typename GroupType>
+inline GroupIndices indices_from_groups(const GroupIndexer<GroupType> &indexer,
+                                        const std::vector<GroupType> &keys) {
+  GroupIndices output;
+  for (const auto &key : keys) {
+    output.insert(output.end(), indexer.at(key).begin(), indexer.at(key).end());
   }
   return output;
 }

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -354,73 +354,73 @@ protected:
   std::string model_name_;
 };
 
-template <typename FeatureType, typename GPType>
-std::map<std::string, JointDistribution>
+template <typename FeatureType, typename GPType, typename GroupKey>
+std::map<GroupKey, JointDistribution>
 gp_cross_validated_predictions(const RegressionDataset<FeatureType> &dataset,
-                               const FoldIndexer &fold_indexer,
+                               const GroupIndexer<GroupKey> &group_indexer,
                                const GPType &model,
                                PredictTypeIdentity<JointDistribution>) {
 
   const auto fit_model = model.fit(dataset);
   const auto gp_fit = fit_model.get_fit();
 
-  const std::vector<FoldIndices> indices = map_values(fold_indexer);
-  const std::vector<std::string> fold_names = map_keys(fold_indexer);
+  const std::vector<GroupIndices> indices = map_values(group_indexer);
+  const std::vector<GroupKey> group_keys = map_keys(group_indexer);
   const auto inverse_blocks = gp_fit.train_covariance.inverse_blocks(indices);
 
-  std::map<std::string, JointDistribution> output;
+  std::map<GroupKey, JointDistribution> output;
   for (std::size_t i = 0; i < inverse_blocks.size(); i++) {
     Eigen::VectorXd yi = subset(dataset.targets.mean, indices[i]);
     Eigen::VectorXd vi = subset(gp_fit.information, indices[i]);
     const auto A_inv = inverse_blocks[i].inverse();
-    output[fold_names[i]] = JointDistribution(yi - A_inv * vi, A_inv);
+    output[group_keys[i]] = JointDistribution(yi - A_inv * vi, A_inv);
   }
   return output;
 }
 
-template <typename FeatureType, typename GPType>
-std::map<std::string, MarginalDistribution>
+template <typename FeatureType, typename GPType, typename GroupKey>
+std::map<GroupKey, MarginalDistribution>
 gp_cross_validated_predictions(const RegressionDataset<FeatureType> &dataset,
-                               const FoldIndexer &fold_indexer,
+                               const GroupIndexer<GroupKey> &group_indexer,
                                const GPType &model,
                                PredictTypeIdentity<MarginalDistribution>) {
 
   const auto fit_model = model.fit(dataset);
   const auto gp_fit = fit_model.get_fit();
 
-  const std::vector<FoldIndices> indices = map_values(fold_indexer);
-  const std::vector<std::string> fold_names = map_keys(fold_indexer);
+  const std::vector<GroupIndices> indices = map_values(group_indexer);
+  const std::vector<GroupKey> group_keys = map_keys(group_indexer);
   const auto inverse_blocks = gp_fit.train_covariance.inverse_blocks(indices);
 
-  std::map<std::string, MarginalDistribution> output;
+  std::map<GroupKey, MarginalDistribution> output;
   for (std::size_t i = 0; i < inverse_blocks.size(); i++) {
     Eigen::VectorXd yi = subset(dataset.targets.mean, indices[i]);
     Eigen::VectorXd vi = subset(gp_fit.information, indices[i]);
     const auto A_ldlt = Eigen::SerializableLDLT(inverse_blocks[i].ldlt());
-    output[fold_names[i]] = MarginalDistribution(
+    output[group_keys[i]] = MarginalDistribution(
         yi - A_ldlt.solve(vi), A_ldlt.inverse_diagonal().asDiagonal());
   }
   return output;
 }
 
-template <typename FeatureType, typename GPType>
-std::map<std::string, Eigen::VectorXd>
+template <typename FeatureType, typename GPType, typename GroupKey>
+std::map<GroupKey, Eigen::VectorXd>
 gp_cross_validated_predictions(const RegressionDataset<FeatureType> &dataset,
-                               const FoldIndexer &fold_indexer,
+                               const GroupIndexer<GroupKey> &group_indexer,
                                const GPType &model,
                                PredictTypeIdentity<Eigen::VectorXd>) {
   const auto fit_model = model.fit(dataset);
   const auto gp_fit = fit_model.get_fit();
-  const std::vector<FoldIndices> indices = map_values(fold_indexer);
-  const std::vector<std::string> fold_names = map_keys(fold_indexer);
+  const std::vector<GroupIndices> indices = map_values(group_indexer);
+  const std::vector<GroupKey> group_keys = map_keys(group_indexer);
   const auto inverse_blocks = gp_fit.train_covariance.inverse_blocks(indices);
 
-  std::map<std::string, Eigen::VectorXd> output;
+  std::map<GroupKey, Eigen::VectorXd> output;
   for (std::size_t i = 0; i < inverse_blocks.size(); i++) {
     Eigen::VectorXd yi = subset(dataset.targets.mean, indices[i]);
     Eigen::VectorXd vi = subset(gp_fit.information, indices[i]);
     const auto A_ldlt = Eigen::SerializableLDLT(inverse_blocks[i].ldlt());
-    output[fold_names[i]] = yi - A_ldlt.solve(vi);
+    output[group_keys[i]] = yi - A_ldlt.solve(vi);
   }
   return output;
 }
@@ -435,12 +435,12 @@ public:
   using Base = GaussianProcessBase<CovFunc, GaussianProcessRegression<CovFunc>>;
   using Base::Base;
 
-  template <typename FeatureType, typename PredictType>
-  std::map<std::string, PredictType>
+  template <typename FeatureType, typename PredictType, typename GroupKey>
+  std::map<GroupKey, PredictType>
   cross_validated_predictions(const RegressionDataset<FeatureType> &dataset,
-                              const FoldIndexer &fold_indexer,
+                              const GroupIndexer<GroupKey> &group_indexer,
                               PredictTypeIdentity<PredictType> identity) const {
-    return gp_cross_validated_predictions(dataset, fold_indexer, *this,
+    return gp_cross_validated_predictions(dataset, group_indexer, *this,
                                           identity);
   }
 };

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -143,8 +143,7 @@ public:
       const std::string &model_name)
       : Base(covariance_function, model_name),
         inducing_point_strategy(inducing_point_strategy_),
-independent_group_function(
-            independent_group_indexing_function_) {
+        independent_group_function(independent_group_function_) {
     initialize_params();
   };
   SparseGaussianProcessRegression(CovFunc &covariance_function,
@@ -185,9 +184,8 @@ independent_group_function(
   template <typename FeatureType>
   auto _fit_impl(const std::vector<FeatureType> &out_of_order_features,
                  const MarginalDistribution &out_of_order_targets) const {
-    static_assert(
-        is_invocable<IndexingFunction, std::vector<FeatureType>>::value,
-        "IndexingFunction is not defined for the required types");
+    static_assert(is_invocable<GrouperFunction, FeatureType>::value,
+                  "GrouperFunction is not defined for the required types");
     static_assert(
         is_invocable<InducingPointStrategy, CovFunc,
                      std::vector<FeatureType>>::value,
@@ -324,14 +322,14 @@ independent_group_function(
   GrouperFunction independent_group_function;
 };
 
-template <typename CovFunc, typename InducingPointStrategy,
-          typename GrouperFunction>
+template <typename CovFunc, typename GrouperFunction,
+          typename InducingPointStrategy>
 auto sparse_gp_from_covariance(CovFunc covariance_function,
-                               GrouperFunction &grouper_function,                               
+                               GrouperFunction &grouper_function,
                                InducingPointStrategy &strategy,
                                const std::string &model_name) {
-  return SparseGaussianProcessRegression<CovFunc, InducingPointStrategy,
-                                         GrouperFunction>(
+  return SparseGaussianProcessRegression<CovFunc, GrouperFunction,
+                                         InducingPointStrategy>(
       covariance_function, grouper_function, strategy, model_name);
 };
 
@@ -340,9 +338,8 @@ auto sparse_gp_from_covariance(CovFunc covariance_function,
                                GrouperFunction &grouper_function,
                                const std::string &model_name) {
   StateSpaceInducingPointStrategy strategy;
-  return SparseGaussianProcessRegression<CovFunc, GrouperFunction,
-                                         StateSpaceInducingPointStrategy>(
-      covariance_function, grouper_function, strategy, model_name);
+  return sparse_gp_from_covariance(covariance_function, grouper_function,
+                                   strategy, model_name);
 };
 
 } // namespace albatross

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -74,7 +74,7 @@ public:
     const auto gp = gp_from_covariance(covariance);
 
     GaussianProcessRansacStrategy<ChiSquaredCdf, ChiSquaredConsensusMetric,
-                                  LeaveOneOut>
+                                  LeaveOneOutGrouper>
         ransac_strategy;
 
     return gp.ransac(ransac_strategy, config);
@@ -111,12 +111,12 @@ public:
 
   using FitType = Fit<GPFit<Eigen::SerializableLDLT, double>>;
 
-  template <typename FeatureType, typename PredictType>
-  std::map<std::string, PredictType>
+  template <typename FeatureType, typename PredictType, typename GroupKey>
+  std::map<GroupKey, PredictType>
   cross_validated_predictions(const RegressionDataset<FeatureType> &dataset,
-                              const FoldIndexer &fold_indexer,
+                              const GroupIndexer<GroupKey> &group_indexer,
                               PredictTypeIdentity<PredictType> identity) const {
-    return gp_cross_validated_predictions(dataset, fold_indexer, *this,
+    return gp_cross_validated_predictions(dataset, group_indexer, *this,
                                           identity);
   }
 

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -152,14 +152,14 @@ public:
   auto get_dataset() const { return make_adapted_toy_linear_data(); }
 };
 
-struct AdaptedRansacStrategy : public GaussianProcessRansacStrategy<
-                                   NegativeLogLikelihood<JointDistribution>,
-                                   FeatureCountConsensusMetric, LeaveOneOut> {
+struct AdaptedRansacStrategy
+    : public GaussianProcessRansacStrategy<
+          NegativeLogLikelihood<JointDistribution>, FeatureCountConsensusMetric,
+          LeaveOneOutGrouper> {
 
   template <typename ModelType>
-  RansacFunctions<FitAndIndices<ModelType, double>>
-  operator()(const ModelType &model,
-             const RegressionDataset<AdaptedFeature> &dataset) const {
+  auto operator()(const ModelType &model,
+                  const RegressionDataset<AdaptedFeature> &dataset) const {
     const RegressionDataset<double> converted(
         adapted::convert_features(dataset.features), dataset.targets);
     const auto indexer = get_indexer(converted);

--- a/tests/test_scaling_function.cc
+++ b/tests/test_scaling_function.cc
@@ -109,7 +109,7 @@ TEST(test_scaling_functions, test_predicts) {
   auto model = gp_from_covariance(covariance_function);
 
   RootMeanSquareError rmse;
-  LeaveOneOut loo;
+  LeaveOneOutGrouper loo;
   auto cv_scores = model.cross_validate().scores(rmse, dataset, loo);
   EXPECT_LE(cv_scores.mean(), 0.01);
 }

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -23,8 +23,9 @@ std::string get_group(const double &f) {
   return std::to_string(static_cast<int>(f) / 10);
 }
 
-struct LeaveOneIntervalOut : public LeaveOneGroupOut<double> {
-  LeaveOneIntervalOut() : LeaveOneGroupOut<double>(get_group){};
+struct LeaveOneIntervalOut {
+
+  std::string operator()(const double &f) const { return get_group(f); }
 };
 
 template <typename IndexerType>
@@ -33,7 +34,7 @@ public:
   IndexerType indexer;
 };
 
-typedef ::testing::Types<LeaveOneOut, LeaveOneIntervalOut>
+typedef ::testing::Types<LeaveOneOutGrouper, LeaveOneIntervalOut>
     IndependenceAssumptions;
 TYPED_TEST_CASE(SparseGaussianProcessTest, IndependenceAssumptions);
 

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -28,19 +28,19 @@ struct LeaveOneIntervalOut {
   std::string operator()(const double &f) const { return get_group(f); }
 };
 
-template <typename IndexerType>
+template <typename GrouperFunction>
 class SparseGaussianProcessTest : public ::testing::Test {
 public:
-  IndexerType indexer;
+  GrouperFunction grouper;
 };
 
 typedef ::testing::Types<LeaveOneOutGrouper, LeaveOneIntervalOut>
     IndependenceAssumptions;
 TYPED_TEST_CASE(SparseGaussianProcessTest, IndependenceAssumptions);
 
-template <typename CovFunc, typename Indexer>
+template <typename CovFunc, typename GrouperFunction>
 void expect_sparse_gp_performance(const CovFunc &covariance,
-                                  const Indexer &indexer,
+                                  const GrouperFunction &grouper,
                                   double sparse_error_threshold,
                                   double really_sparse_error_threshold) {
 
@@ -49,18 +49,18 @@ void expect_sparse_gp_performance(const CovFunc &covariance,
 
   UniformlySpacedInducingPoints strategy(8);
   auto sparse =
-      sparse_gp_from_covariance(covariance, indexer, strategy, "sparse");
+      sparse_gp_from_covariance(covariance, grouper, strategy, "sparse");
   sparse.set_param(details::inducing_nugget_name(), 1e-3);
   sparse.set_param(details::measurement_nugget_name(), 1e-12);
 
   UniformlySpacedInducingPoints bad_strategy(3);
-  auto really_sparse = sparse_gp_from_covariance(covariance, indexer,
+  auto really_sparse = sparse_gp_from_covariance(covariance, grouper,
                                                  bad_strategy, "really_sparse");
   really_sparse.set_param(details::inducing_nugget_name(), 1e-3);
   really_sparse.set_param(details::measurement_nugget_name(), 1e-12);
 
   auto state_space =
-      sparse_gp_from_covariance(covariance, indexer, "state_space");
+      sparse_gp_from_covariance(covariance, grouper, "state_space");
   state_space.set_param(details::inducing_nugget_name(), 1e-3);
   state_space.set_param(details::measurement_nugget_name(), 1e-12);
 
@@ -104,27 +104,27 @@ void expect_sparse_gp_performance(const CovFunc &covariance,
 
 TYPED_TEST(SparseGaussianProcessTest, test_sanity) {
 
-  auto indexer = this->indexer;
+  auto grouper = this->grouper;
   auto covariance = make_simple_covariance_function();
 
   // When the length scale is large the model with more inducing points
   // gets very nearly singular.  this checks to make sure that's dealt with
   // gracefully.
   covariance.set_param("squared_exponential_length_scale", 1000.);
-  expect_sparse_gp_performance(covariance, indexer, 1e-2, 0.5);
+  expect_sparse_gp_performance(covariance, grouper, 1e-2, 0.5);
 
   covariance.set_param("squared_exponential_length_scale", 100.);
-  expect_sparse_gp_performance(covariance, indexer, 1e-2, 0.5);
+  expect_sparse_gp_performance(covariance, grouper, 1e-2, 0.5);
 
   // Then when the length scale is shorter, the really sparse model
   // should become significantly worse than the sparse one.
   covariance.set_param("squared_exponential_length_scale", 10.);
-  expect_sparse_gp_performance(covariance, indexer, 5e-2, 100.);
+  expect_sparse_gp_performance(covariance, grouper, 5e-2, 100.);
 }
 
 TYPED_TEST(SparseGaussianProcessTest, test_scales) {
 
-  auto indexer = this->indexer;
+  auto grouper = this->grouper;
 
   auto large_dataset = make_toy_sine_data(5., 10., 0.1, 1000);
 
@@ -140,7 +140,7 @@ TYPED_TEST(SparseGaussianProcessTest, test_scales) {
 
   UniformlySpacedInducingPoints strategy(100);
   auto sparse =
-      sparse_gp_from_covariance(covariance, indexer, strategy, "sparse");
+      sparse_gp_from_covariance(covariance, grouper, strategy, "sparse");
 
   start = high_resolution_clock::now();
   auto sparse_fit = sparse.fit(large_dataset);

--- a/tests/test_traits_evaluation.cc
+++ b/tests/test_traits_evaluation.cc
@@ -23,79 +23,92 @@ struct Y {};
  */
 class HasMeanPredictImpl {
 public:
-  template <typename FeatureType>
-  std::map<std::string, Eigen::VectorXd>
+  template <typename FeatureType, typename GroupKey>
+  std::map<GroupKey, Eigen::VectorXd>
   cross_validated_predictions(const RegressionDataset<FeatureType> &,
-                              const FoldIndexer &,
+                              const GroupIndexer<GroupKey> &,
                               PredictTypeIdentity<Eigen::VectorXd>) const {
-    return std::map<std::string, Eigen::VectorXd>();
+    return std::map<GroupKey, Eigen::VectorXd>();
   }
 };
 
 class HasMarginalPredictImpl {
 public:
-  template <typename FeatureType>
-  std::map<std::string, MarginalDistribution>
+  template <typename FeatureType, typename GroupKey>
+  std::map<GroupKey, MarginalDistribution>
   cross_validated_predictions(const RegressionDataset<FeatureType> &,
-                              const FoldIndexer &,
+                              const GroupIndexer<GroupKey> &,
                               PredictTypeIdentity<MarginalDistribution>) const {
-    return std::map<std::string, MarginalDistribution>();
+    return std::map<GroupKey, MarginalDistribution>();
   }
 };
 
 class HasJointPredictImpl {
 public:
-  template <typename FeatureType>
-  std::map<std::string, JointDistribution>
+  template <typename FeatureType, typename GroupKey>
+  std::map<GroupKey, JointDistribution>
   cross_validated_predictions(const RegressionDataset<FeatureType> &,
-                              const FoldIndexer &,
+                              const GroupIndexer<GroupKey> &,
                               PredictTypeIdentity<JointDistribution>) const {
-    return std::map<std::string, JointDistribution>();
+    return std::map<GroupKey, JointDistribution>();
   }
 };
 
 class HasAllPredictImpls {
 public:
-  std::map<std::string, Eigen::VectorXd>
-  cross_validated_predictions(const RegressionDataset<X> &, const FoldIndexer &,
+  template <typename GroupKey>
+  std::map<GroupKey, Eigen::VectorXd>
+  cross_validated_predictions(const RegressionDataset<X> &,
+                              const GroupIndexer<GroupKey> &,
                               PredictTypeIdentity<Eigen::VectorXd>) const {
-    return std::map<std::string, Eigen::VectorXd>();
+    return std::map<GroupKey, Eigen::VectorXd>();
   }
 
-  template <typename FeatureType>
-  std::map<std::string, MarginalDistribution>
+  template <typename FeatureType, typename GroupKey>
+  std::map<GroupKey, MarginalDistribution>
   cross_validated_predictions(const RegressionDataset<FeatureType> &,
-                              const FoldIndexer &,
+                              const GroupIndexer<GroupKey> &,
                               PredictTypeIdentity<MarginalDistribution>) const {
-    return std::map<std::string, MarginalDistribution>();
+    return std::map<GroupKey, MarginalDistribution>();
   }
 
-  std::map<std::string, JointDistribution>
-  cross_validated_predictions(const RegressionDataset<X> &, const FoldIndexer &,
+  template <typename GroupKey>
+  std::map<GroupKey, JointDistribution>
+  cross_validated_predictions(const RegressionDataset<X> &,
+                              const GroupIndexer<GroupKey> &,
                               PredictTypeIdentity<JointDistribution>) const {
-    return std::map<std::string, JointDistribution>();
+    return std::map<GroupKey, JointDistribution>();
   }
 };
 
+struct TestKey {};
+
 TEST(test_traits_core, test_has_cross_validated_predictions) {
-  EXPECT_TRUE(bool(has_valid_cv_mean<HasMeanPredictImpl, X>::value));
-  EXPECT_FALSE(bool(has_valid_cv_marginal<HasMeanPredictImpl, X>::value));
-  EXPECT_FALSE(bool(has_valid_cv_joint<HasMeanPredictImpl, X>::value));
+  EXPECT_TRUE(bool(has_valid_cv_mean<HasMeanPredictImpl, X, TestKey>::value));
+  EXPECT_FALSE(
+      bool(has_valid_cv_marginal<HasMeanPredictImpl, X, TestKey>::value));
+  EXPECT_FALSE(bool(has_valid_cv_joint<HasMeanPredictImpl, X, TestKey>::value));
 
-  EXPECT_FALSE(bool(has_valid_cv_mean<HasMarginalPredictImpl, X>::value));
-  EXPECT_TRUE(bool(has_valid_cv_marginal<HasMarginalPredictImpl, X>::value));
-  EXPECT_FALSE(bool(has_valid_cv_joint<HasMarginalPredictImpl, X>::value));
+  EXPECT_FALSE(
+      bool(has_valid_cv_mean<HasMarginalPredictImpl, X, TestKey>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cv_marginal<HasMarginalPredictImpl, X, TestKey>::value));
+  EXPECT_FALSE(
+      bool(has_valid_cv_joint<HasMarginalPredictImpl, X, TestKey>::value));
 
-  EXPECT_FALSE(bool(has_valid_cv_mean<HasJointPredictImpl, X>::value));
-  EXPECT_FALSE(bool(has_valid_cv_marginal<HasJointPredictImpl, X>::value));
-  EXPECT_TRUE(bool(has_valid_cv_joint<HasJointPredictImpl, X>::value));
+  EXPECT_FALSE(bool(has_valid_cv_mean<HasJointPredictImpl, X, TestKey>::value));
+  EXPECT_FALSE(
+      bool(has_valid_cv_marginal<HasJointPredictImpl, X, TestKey>::value));
+  EXPECT_TRUE(bool(has_valid_cv_joint<HasJointPredictImpl, X, TestKey>::value));
 
-  EXPECT_TRUE(bool(has_valid_cv_mean<HasAllPredictImpls, X>::value));
-  EXPECT_FALSE(bool(has_valid_cv_mean<HasAllPredictImpls, Y>::value));
-  EXPECT_TRUE(bool(has_valid_cv_marginal<HasAllPredictImpls, X>::value));
-  EXPECT_TRUE(bool(has_valid_cv_marginal<HasAllPredictImpls, Y>::value));
-  EXPECT_TRUE(bool(has_valid_cv_joint<HasAllPredictImpls, X>::value));
-  EXPECT_FALSE(bool(has_valid_cv_joint<HasAllPredictImpls, Y>::value));
+  EXPECT_TRUE(bool(has_valid_cv_mean<HasAllPredictImpls, X, TestKey>::value));
+  EXPECT_FALSE(bool(has_valid_cv_mean<HasAllPredictImpls, Y, TestKey>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cv_marginal<HasAllPredictImpls, X, TestKey>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cv_marginal<HasAllPredictImpls, Y, TestKey>::value));
+  EXPECT_TRUE(bool(has_valid_cv_joint<HasAllPredictImpls, X, TestKey>::value));
+  EXPECT_FALSE(bool(has_valid_cv_joint<HasAllPredictImpls, Y, TestKey>::value));
 }
 
 } // namespace albatross

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -29,7 +29,7 @@ TEST(test_tune, test_single_dataset) {
   auto params = tuner.tune();
 
   NegativeLogLikelihood<JointDistribution> nll;
-  LeaveOneOut loo;
+  LeaveOneOutGrouper loo;
   const auto scores = model.cross_validate().scores(nll, dataset, loo);
 
   model.set_params(params);


### PR DESCRIPTION
In #160 a `group_by` method was added for use with `vector` and `RegressionDataset` but until this change it wasn't actually used anywhere.  Switching to `group_by` means that a grouping function can return anything which is a valid `std::map` key (instead of being restricted to a `std::string`).  As a result:

- Cross validation was refactored to remove `LeaveOneOut` and `LeaveOneGroupOut` in favor of using grouper functions (this refactor is arguably the biggest "actual" change in this PR).
- Anything which works with groups (`Ransac`, `SparseGaussianProcess`, etc ...) needed to also keep track of the `GroupKey` now (the majority of changed lines come from this).
- `RegressionFolds` is now a map from `GroupKey` to `RegressionFold` (instead of a vector of folds).  As a result the `RegressionFold` no longer contains the `FoldName` member (pretty minor change).
- Some trait logic had to be updated to consider the `GroupKey`.