### PR TITLE
Add free functions for using apply directly on vectors.

### DIFF
--- a/include/albatross/src/indexing/apply.hpp
+++ b/include/albatross/src/indexing/apply.hpp
@@ -30,6 +30,34 @@ inline auto filter(const std::vector<ValueType> &values,
   return output;
 }
 
+template <typename ValueType, typename ApplyFunction,
+          typename ApplyType = typename details::value_only_apply_result<
+              ApplyFunction, ValueType>::type,
+          typename std::enable_if<details::is_valid_value_only_apply_function<
+                                      ApplyFunction, ValueType>::value &&
+                                      std::is_same<void, ApplyType>::value,
+                                  int>::type = 0>
+void apply(const std::vector<ValueType> &xs, const ApplyFunction &f) {
+  for (const auto &x : xs) {
+    f(x);
+  }
+}
+
+template <typename ValueType, typename ApplyFunction,
+          typename ApplyType = typename details::value_only_apply_result<
+              ApplyFunction, ValueType>::type,
+          typename std::enable_if<details::is_valid_value_only_apply_function<
+                                      ApplyFunction, ValueType>::value &&
+                                      !std::is_same<void, ApplyType>::value,
+                                  int>::type = 0>
+auto apply(const std::vector<ValueType> &xs, const ApplyFunction &f) {
+  std::vector<ApplyType> output;
+  for (const auto &x : xs) {
+    output.emplace_back(f(x));
+  }
+  return output;
+}
+
 } // namespace albatross
 
 #endif /* ALBATROSS_INDEXING_APPLY_HPP_ */

--- a/include/albatross/src/indexing/apply.hpp
+++ b/include/albatross/src/indexing/apply.hpp
@@ -38,9 +38,7 @@ template <typename ValueType, typename ApplyFunction,
                                       std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
 void apply(const std::vector<ValueType> &xs, const ApplyFunction &f) {
-  for (const auto &x : xs) {
-    f(x);
-  }
+  std::for_each(xs.begin(), xs.end(), f);
 }
 
 template <typename ValueType, typename ApplyFunction,
@@ -51,10 +49,8 @@ template <typename ValueType, typename ApplyFunction,
                                       !std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
 auto apply(const std::vector<ValueType> &xs, const ApplyFunction &f) {
-  std::vector<ApplyType> output;
-  for (const auto &x : xs) {
-    output.emplace_back(f(x));
-  }
+  std::vector<ApplyType> output(xs.size());
+  std::transform(xs.begin(), xs.end(), output.begin(), f);
   return output;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(albatross_unit_tests 
+  test_apply.cc
   test_block_utils.cc
   test_call_trace.cc
   test_callers.cc

--- a/tests/test_apply.cc
+++ b/tests/test_apply.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/Indexing>
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+struct Foo {
+  Foo() : value(){};
+  Foo(const double &x) : value(x){};
+
+  bool operator==(const Foo &other) const {
+    return fabs(other.value - value) < std::numeric_limits<double>::epsilon();
+  }
+
+  double value;
+};
+
+TEST(test_apply, test_vector_apply) {
+
+  const auto xs = linspace(0., 10., 11);
+
+  const auto make_foo = [](const double &x) { return Foo(x); };
+
+  const auto applied = apply(xs, make_foo);
+
+  std::vector<Foo> expected;
+  for (const auto &x : xs) {
+    expected.emplace_back(Foo(x));
+  }
+
+  EXPECT_EQ(expected, applied);
+}
+
+TEST(test_apply, test_vector_apply_void) {
+
+  const auto xs = linspace(0., 10., 11);
+
+  std::size_t call_count = 0;
+
+  const auto count_calls = [&](const double &x) { ++call_count; };
+
+  apply(xs, count_calls);
+
+  EXPECT_EQ(call_count, xs.size());
+}
+
+} // namespace albatross

--- a/tests/test_apply.cc
+++ b/tests/test_apply.cc
@@ -15,6 +15,10 @@
 
 namespace albatross {
 
+std::vector<double> test_double_vector() { return linspace(0., 10., 11); }
+
+double square(double x) { return x * x; }
+
 struct Foo {
   Foo() : value(){};
   Foo(const double &x) : value(x){};
@@ -26,20 +30,94 @@ struct Foo {
   double value;
 };
 
-TEST(test_apply, test_vector_apply) {
+Foo make_foo(double x) { return Foo(x); }
 
-  const auto xs = linspace(0., 10., 11);
+class Square {
+public:
+  double operator()(double x) const { return square(x); }
+};
 
-  const auto make_foo = [](const double &x) { return Foo(x); };
+/*
+ * Test Cases
+ */
 
-  const auto applied = apply(xs, make_foo);
+struct SquareClassMethodApply {
 
-  std::vector<Foo> expected;
-  for (const auto &x : xs) {
-    expected.emplace_back(Foo(x));
+  auto get_parent() const { return test_double_vector(); }
+
+  auto get_function() const { return Square(); }
+};
+
+struct SquareFunctionPointerApply {
+
+  auto get_parent() const { return test_double_vector(); }
+
+  auto get_function() const { return &square; }
+};
+
+struct SquareFunctionApply {
+
+  auto get_parent() const { return test_double_vector(); }
+
+  auto get_function() const { return square; }
+};
+
+struct SquareLambdaApply {
+
+  auto get_parent() const { return test_double_vector(); }
+
+  auto get_function() const {
+    const auto lambda_square = [](double x) { return square(x); };
+    return lambda_square;
+  }
+};
+
+struct MakeFooFunctionApply {
+
+  auto get_parent() const { return test_double_vector(); }
+
+  auto get_function() const { return make_foo; }
+};
+
+template <typename CaseType> class ApplyTester : public ::testing::Test {
+public:
+  CaseType test_case;
+};
+
+typedef ::testing::Types<SquareClassMethodApply, SquareFunctionPointerApply,
+                         SquareFunctionApply, SquareLambdaApply>
+    ApplyTestCases;
+
+TYPED_TEST_CASE_P(ApplyTester);
+
+TYPED_TEST_P(ApplyTester, test_apply_sanity) {
+  auto parent = this->test_case.get_parent();
+  const auto actual = apply(parent, this->test_case.get_function());
+
+  typename std::remove_const<decltype(actual)>::type expected;
+  for (const auto &x : parent) {
+    expected.emplace_back(this->test_case.get_function()(x));
   }
 
-  EXPECT_EQ(expected, applied);
+  EXPECT_EQ(expected, actual);
+}
+
+REGISTER_TYPED_TEST_CASE_P(ApplyTester, test_apply_sanity);
+
+INSTANTIATE_TYPED_TEST_CASE_P(test_apply, ApplyTester, ApplyTestCases);
+
+TEST(test_apply, test_vector_apply_free_function) {
+
+  const auto xs = linspace(0., 10., 11);
+  const auto actual = apply(xs, square);
+
+  std::vector<double> expected;
+  for (const auto &x : xs) {
+    expected.push_back(x * x);
+  }
+
+  EXPECT_EQ(expected.size(), actual.size());
+  EXPECT_EQ(expected, actual);
 }
 
 TEST(test_apply, test_vector_apply_void) {


### PR DESCRIPTION
This change lets you do things like:

```
std::vector<T> foo;
const auto bar = apply(foo, convert_foo_to_bar);
```

It's not unlike `std::transform` but supports situations where the apply function returns `void` and doesn't require knowing the type of the transformed type ahead of time.