### PR TITLE
Improve consistency of GrouperFunction use.

### DIFF
--- a/include/albatross/src/cereal/ransac.hpp
+++ b/include/albatross/src/cereal/ransac.hpp
@@ -53,14 +53,16 @@ inline void serialize(Archive &archive,
 }
 
 template <typename Archive, typename InlierMetric, typename ConsensusMetric,
-          typename GrouperFunction>
+          typename IsValidCandidateMetric, typename GrouperFunction>
 inline void
 serialize(Archive &archive,
           GaussianProcessRansacStrategy<InlierMetric, ConsensusMetric,
-                                        GrouperFunction> &strategy,
+                                        IsValidCandidateMetric, GrouperFunction>
+              &strategy,
           const std::uint32_t) {
   archive(cereal::make_nvp("inlier_metric", strategy.inlier_metric_));
   archive(cereal::make_nvp("consensus_metric", strategy.consensus_metric_));
+  archive(cereal::make_nvp("is_valid_candidate", strategy.is_valid_candidate_));
   archive(cereal::make_nvp("grouper_function", strategy.grouper_function_));
 }
 

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -130,8 +130,7 @@ struct GenericRansacStrategy;
 struct AlwaysAcceptCandidateMetric;
 
 template <typename InlierMetric, typename ConsensusMetric,
-          typename GrouperFunction,
-          typename IsValidCandidateMetric = AlwaysAcceptCandidateMetric>
+          typename IsValidCandidateMetric, typename GrouperFunction>
 struct GaussianProcessRansacStrategy;
 
 /*

--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -77,10 +77,11 @@ concatenate_mean_predictions(const GroupIndexer<GroupKey> &indexer,
   return pred;
 }
 
-template <typename CovarianceType, typename GroupKey>
+template <typename CovarianceType, typename GroupKey,
+          template <typename...> class PredictionContainer>
 inline MarginalDistribution concatenate_marginal_predictions(
     const GroupIndexer<GroupKey> &indexer,
-    const Grouped<GroupKey, Distribution<CovarianceType>> &preds) {
+    const PredictionContainer<GroupKey, Distribution<CovarianceType>> &preds) {
   assert(indexer.size() == preds.size());
 
   Eigen::Index n =

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -137,8 +137,7 @@ public:
     initialize_params();
   };
   SparseGaussianProcessRegression(
-      CovFunc &covariance_function,
-      GrouperFunction &independent_group_function_,
+      CovFunc &covariance_function, GrouperFunction independent_group_function_,
       InducingPointStrategy &inducing_point_strategy_,
       const std::string &model_name)
       : Base(covariance_function, model_name),
@@ -325,7 +324,7 @@ public:
 template <typename CovFunc, typename GrouperFunction,
           typename InducingPointStrategy>
 auto sparse_gp_from_covariance(CovFunc covariance_function,
-                               GrouperFunction &grouper_function,
+                               GrouperFunction grouper_function,
                                InducingPointStrategy &strategy,
                                const std::string &model_name) {
   return SparseGaussianProcessRegression<CovFunc, GrouperFunction,
@@ -335,7 +334,7 @@ auto sparse_gp_from_covariance(CovFunc covariance_function,
 
 template <typename CovFunc, typename GrouperFunction>
 auto sparse_gp_from_covariance(CovFunc covariance_function,
-                               GrouperFunction &grouper_function,
+                               GrouperFunction grouper_function,
                                const std::string &model_name) {
   StateSpaceInducingPointStrategy strategy;
   return sparse_gp_from_covariance(covariance_function, grouper_function,

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -74,6 +74,7 @@ public:
     const auto gp = gp_from_covariance(covariance);
 
     GaussianProcessRansacStrategy<ChiSquaredCdf, ChiSquaredConsensusMetric,
+                                  ChiSquaredIsValidCandidateMetric,
                                   LeaveOneOutGrouper>
         ransac_strategy;
 
@@ -155,7 +156,7 @@ public:
 struct AdaptedRansacStrategy
     : public GaussianProcessRansacStrategy<
           NegativeLogLikelihood<JointDistribution>, FeatureCountConsensusMetric,
-          LeaveOneOutGrouper> {
+          AlwaysAcceptCandidateMetric, LeaveOneOutGrouper> {
 
   template <typename ModelType>
   auto operator()(const ModelType &model,


### PR DESCRIPTION
The ransac strategies were some what inconsistent in the order of arguments, template parameters and constructor arguments.  This resolves several of those instances.