### PR TITLE
Add Test Utils

### DIFF
--- a/include/albatross/src/indexing/traits.hpp
+++ b/include/albatross/src/indexing/traits.hpp
@@ -167,6 +167,8 @@ struct group_by_traits<
     GroupBy<RegressionDataset<FeatureType>, GrouperFunction>> {
   using ValueType = RegressionDataset<FeatureType>;
   using IterableType = FeatureType;
+  static_assert(is_valid_grouper<GrouperFunction, IterableType>::value,
+                "Invalid Grouper Function");
   using KeyType = typename grouper_result<GrouperFunction, IterableType>::type;
   using GrouperType = GrouperFunction;
 };
@@ -175,6 +177,8 @@ template <typename FeatureType, typename GrouperFunction>
 struct group_by_traits<GroupBy<std::vector<FeatureType>, GrouperFunction>> {
   using ValueType = std::vector<FeatureType>;
   using IterableType = FeatureType;
+  static_assert(is_valid_grouper<GrouperFunction, IterableType>::value,
+                "Invalid Grouper Function");
   using KeyType = typename grouper_result<GrouperFunction, IterableType>::type;
   using GrouperType = GrouperFunction;
 };

--- a/include/albatross/tests/Utils
+++ b/include/albatross/tests/Utils
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_TESTS_UTILS_H
+#define ALBATROSS_TESTS_UTILS_H
+
+#include "../../../tests/test_utils.h"
+#include "../../../tests/test_covariance_utils.h"
+
+#endif

--- a/tests/test_callers.cc
+++ b/tests/test_callers.cc
@@ -12,8 +12,9 @@
 
 #include <albatross/CovarianceFunctions>
 
-#include "test_covariance_utils.h"
 #include <gtest/gtest.h>
+
+#include "test_covariance_utils.h"
 
 namespace albatross {
 


### PR DESCRIPTION
This adds a helper for testing covariance functions which allows you to make sure groups are independent and adds the plumbing to make it easily accessible from third party libraries via `#include <albatross/test/Utils>`