### PR TITLE
Variant Utils

### DIFF
--- a/include/albatross/src/utils/variant_utils.hpp
+++ b/include/albatross/src/utils/variant_utils.hpp
@@ -25,8 +25,8 @@ template <typename X> struct ToVariantIdentity {};
  */
 template <typename... Ts, typename X>
 inline std::enable_if_t<is_sub_variant<X, variant<Ts...>>::value, void>
-set_variant(variant<Ts...> &to_set, const X &x) {
-  x.match([&to_set](const auto &v) { to_set = v; });
+set_variant(const X &x, variant<Ts...> *to_set) {
+  x.match([&to_set](const auto &v) { *to_set = v; });
 }
 
 /*
@@ -35,19 +35,19 @@ set_variant(variant<Ts...> &to_set, const X &x) {
 template <typename... Ts, typename X>
 inline std::enable_if_t<
     !is_variant<X>::value && is_in_variant<X, variant<Ts...>>::value, void>
-set_variant(variant<Ts...> &to_set, const X &x) {
-  to_set = x;
+set_variant(const X &x, variant<Ts...> *to_set) {
+  *to_set = x;
 }
 
 /*
  * Convert a vector of one type
  */
 template <typename... Ts, typename X>
-inline void set_variants(std::vector<variant<Ts...>> &to_set,
-                         const std::vector<X> &xs) {
-  to_set.resize(xs.size());
+inline void set_variants(const std::vector<X> &xs,
+                         std::vector<variant<Ts...>> *to_set) {
+  to_set->resize(xs.size());
   for (std::size_t i = 0; i < xs.size(); ++i) {
-    set_variant(to_set[i], xs[i]);
+    set_variant(xs[i], &to_set->operator[](i));
   }
 }
 
@@ -57,7 +57,7 @@ inline std::vector<OutputType>
 to_variant_vector(const std::vector<X> &xs,
                   details::ToVariantIdentity<OutputType> && = {}) {
   std::vector<OutputType> output;
-  set_variants(output, xs);
+  set_variants(xs, &output);
   return output;
 }
 

--- a/include/albatross/src/utils/variant_utils.hpp
+++ b/include/albatross/src/utils/variant_utils.hpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_UTILS_VARIANT_UTILS_HPP_
+#define ALBATROSS_UTILS_VARIANT_UTILS_HPP_
+
+namespace albatross {
+
+namespace details {
+template <typename X> struct ToVariantIdentity {};
+} // namespace details
+
+/*
+ * In this case X is a variant which is compatible so we need to
+ * convert it.
+ */
+template <typename... Ts, typename X>
+inline std::enable_if_t<is_sub_variant<X, variant<Ts...>>::value, void>
+set_variant(variant<Ts...> &to_set, const X &x) {
+  x.match([&to_set](const auto &v) { to_set = v; });
+}
+
+/*
+ * In this case X is not a variant so we can simply assign it.
+ */
+template <typename... Ts, typename X>
+inline std::enable_if_t<
+    !is_variant<X>::value && is_in_variant<X, variant<Ts...>>::value, void>
+set_variant(variant<Ts...> &to_set, const X &x) {
+  to_set = x;
+}
+
+/*
+ * Convert a vector of one type
+ */
+template <typename... Ts, typename X>
+inline void set_variants(std::vector<variant<Ts...>> &to_set,
+                         const std::vector<X> &xs) {
+  to_set.resize(xs.size());
+  for (std::size_t i = 0; i < xs.size(); ++i) {
+    set_variant(to_set[i], xs[i]);
+  }
+}
+
+template <typename OutputType, typename X,
+          std::enable_if_t<is_variant<OutputType>::value, int> = 0>
+inline std::vector<OutputType>
+to_variant_vector(const std::vector<X> &xs,
+                  details::ToVariantIdentity<OutputType> && = {}) {
+  std::vector<OutputType> output;
+  set_variants(output, xs);
+  return output;
+}
+
+} // namespace albatross
+
+#endif /* ALBATROSS_UTILS_VARIANT_UTILS_HPP_ */

--- a/include/albatross/utils/VariantUtils
+++ b/include/albatross/utils/VariantUtils
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_UTILS_VARIANT_UTILS_H
+#define ALBATROSS_UTILS_VARIANT_UTILS_H
+
+#include "../src/utils/variant_utils.hpp"
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(albatross_unit_tests
   test_traits_evaluation.cc
   test_traits_indexing.cc
   test_tune.cc
+  test_variant_utils.cc
   )
 target_include_directories(albatross_unit_tests SYSTEM PRIVATE
   "${gtest_SOURCE_DIR}"

--- a/tests/test_traits_details.cc
+++ b/tests/test_traits_details.cc
@@ -60,6 +60,84 @@ TEST(test_traits_core, test_is_in_variant) {
   EXPECT_FALSE(bool(is_in_variant<variant<X>, variant<X, Y, Z>>::value));
 }
 
+struct Foo {};
+
+template <typename T> struct is_foo : public std::is_same<T, Foo> {};
+
+TEST(test_traits_core, test_variant_any) {
+  struct X {};
+  struct Y {};
+  struct Z {};
+
+  EXPECT_FALSE(bool(variant_any<is_foo, variant<>>::value));
+
+  EXPECT_TRUE(bool(variant_any<is_foo, variant<Foo>>::value));
+  EXPECT_FALSE(bool(variant_any<is_foo, variant<X>>::value));
+
+  EXPECT_TRUE(bool(variant_any<is_foo, variant<Foo, X>>::value));
+  EXPECT_TRUE(bool(variant_any<is_foo, variant<X, Foo>>::value));
+  EXPECT_TRUE(bool(variant_any<is_foo, variant<Y, Foo>>::value));
+  EXPECT_FALSE(bool(variant_any<is_foo, variant<X, Y>>::value));
+
+  EXPECT_TRUE(bool(variant_any<is_foo, variant<Foo, X, Y>>::value));
+  EXPECT_TRUE(bool(variant_any<is_foo, variant<X, Y, Foo>>::value));
+  EXPECT_TRUE(bool(variant_any<is_foo, variant<Y, Foo, X>>::value));
+  EXPECT_FALSE(bool(variant_any<is_foo, variant<X, Y, Z>>::value));
+}
+
+struct Bar {};
+
+template <typename T> struct is_foo_or_bar {
+  static constexpr bool value =
+      std::is_same<T, Foo>::value || std::is_same<T, Bar>::value;
+};
+
+TEST(test_traits_core, test_variant_all) {
+  struct X {};
+  struct Y {};
+  struct Z {};
+
+  EXPECT_TRUE(bool(variant_all<is_foo_or_bar, variant<>>::value));
+
+  EXPECT_TRUE(bool(variant_all<is_foo_or_bar, variant<Foo>>::value));
+  EXPECT_TRUE(bool(variant_all<is_foo_or_bar, variant<Bar>>::value));
+  EXPECT_FALSE(bool(variant_all<is_foo_or_bar, variant<Y>>::value));
+
+  EXPECT_TRUE(bool(variant_all<is_foo_or_bar, variant<Foo, Bar>>::value));
+  EXPECT_TRUE(bool(variant_all<is_foo_or_bar, variant<Bar, Foo>>::value));
+  EXPECT_FALSE(bool(variant_all<is_foo_or_bar, variant<Y, Foo>>::value));
+  EXPECT_FALSE(bool(variant_all<is_foo_or_bar, variant<X, Y>>::value));
+
+  EXPECT_FALSE(bool(variant_all<is_foo_or_bar, variant<Foo, Bar, Y>>::value));
+  EXPECT_FALSE(bool(variant_all<is_foo_or_bar, variant<X, Bar, Foo>>::value));
+  EXPECT_FALSE(bool(variant_all<is_foo_or_bar, variant<Y, Foo, X>>::value));
+  EXPECT_FALSE(bool(variant_all<is_foo_or_bar, variant<X, Y, Z>>::value));
+}
+
+TEST(test_traits_core, test_is_sub_variant) {
+  struct X {};
+  struct Y {};
+  struct Z {};
+
+  EXPECT_FALSE(bool(is_sub_variant<X, variant<X>>::value));
+  EXPECT_FALSE(bool(is_sub_variant<variant<X>, X>::value));
+  EXPECT_FALSE(bool(is_sub_variant<X, variant<>>::value));
+
+  EXPECT_TRUE(bool(is_sub_variant<variant<>, variant<>>::value));
+
+  EXPECT_TRUE(bool(is_sub_variant<variant<>, variant<X>>::value));
+  EXPECT_TRUE(bool(is_sub_variant<variant<X>, variant<X>>::value));
+  EXPECT_FALSE(bool(is_sub_variant<variant<Y>, variant<X>>::value));
+
+  EXPECT_TRUE(bool(is_sub_variant<variant<X>, variant<X, Y>>::value));
+  EXPECT_TRUE(bool(is_sub_variant<variant<X>, variant<Y, X>>::value));
+  EXPECT_TRUE(bool(is_sub_variant<variant<X, Y>, variant<X, Y>>::value));
+  EXPECT_TRUE(bool(is_sub_variant<variant<Y, X>, variant<Y, X>>::value));
+  EXPECT_FALSE(bool(is_sub_variant<variant<Y, X>, variant<Y, Z>>::value));
+  EXPECT_FALSE(bool(is_sub_variant<variant<X, Y>, variant<Y, Z>>::value));
+  EXPECT_FALSE(bool(is_sub_variant<variant<X>, variant<Y, Z>>::value));
+}
+
 class Complete {};
 
 class Incomplete;

--- a/tests/test_variant_utils.cc
+++ b/tests/test_variant_utils.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/Common>
+#include <albatross/utils/VariantUtils>
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+TEST(test_variant_utils, test_set_variant_two_types) {
+
+  variant<int, double> foo;
+  const int one = 1;
+  const double two = 2.;
+
+  variant<double, int> bar;
+
+  set_variant(foo, one);
+  EXPECT_TRUE(foo.is<int>());
+  EXPECT_EQ(foo.get<int>(), one);
+
+  set_variant(foo, two);
+  EXPECT_TRUE(foo.is<double>());
+  EXPECT_EQ(foo.get<double>(), two);
+
+  bar = one;
+  set_variant(foo, bar);
+  EXPECT_TRUE(foo.is<int>());
+  EXPECT_EQ(foo.get<int>(), one);
+
+  bar = two;
+  set_variant(foo, bar);
+  EXPECT_TRUE(foo.is<double>());
+  EXPECT_EQ(foo.get<double>(), two);
+}
+
+struct X {
+  double value;
+  bool operator==(const X &other) const { return value == other.value; }
+};
+
+TEST(test_variant_utils, test_set_variant_three_types) {
+
+  variant<int, double, X> foo;
+  const int one = 1;
+  const double two = 2.;
+  const X x = {3.};
+
+  variant<double, int> double_int;
+
+  double_int = one;
+  set_variant(foo, double_int);
+  EXPECT_TRUE(foo.is<int>());
+  EXPECT_EQ(foo.get<int>(), one);
+
+  double_int = two;
+  set_variant(foo, double_int);
+  EXPECT_TRUE(foo.is<double>());
+  EXPECT_EQ(foo.get<double>(), two);
+
+  variant<double, X> double_x;
+
+  double_x = x;
+  set_variant(foo, double_x);
+  EXPECT_TRUE(foo.is<X>());
+  EXPECT_EQ(foo.get<X>(), x);
+
+  double_x = two;
+  set_variant(foo, double_x);
+  EXPECT_TRUE(foo.is<double>());
+  EXPECT_EQ(foo.get<double>(), two);
+}
+
+TEST(test_variant_utils, test_to_variant_vector) {
+  const auto doubles = linspace(0., 10., 11);
+  const auto variants = to_variant_vector<variant<int, double, X>>(doubles);
+  EXPECT_EQ(variants.size(), doubles.size());
+
+  for (std::size_t i = 0; i < variants.size(); ++i) {
+    EXPECT_TRUE(variants[i].is<double>());
+    EXPECT_EQ(variants[i].get<double>(), doubles[i]);
+  }
+
+  double a = 1.;
+  double b = 2.;
+  X x_a = {a};
+  X x_b = {b};
+
+  std::vector<variant<double, X>> mixed;
+  mixed.emplace_back(a);
+  mixed.emplace_back(b);
+  mixed.emplace_back(x_a);
+  mixed.emplace_back(x_b);
+
+  auto from_mixed = to_variant_vector<variant<int, double, X>>(mixed);
+  for (std::size_t i = 0; i < mixed.size(); ++i) {
+    mixed[i].match([&](auto v) {
+      EXPECT_TRUE(from_mixed[i].is<decltype(v)>());
+      EXPECT_EQ(from_mixed[i].get<decltype(v)>(), v);
+    });
+  }
+}
+
+} // namespace albatross

--- a/tests/test_variant_utils.cc
+++ b/tests/test_variant_utils.cc
@@ -24,21 +24,21 @@ TEST(test_variant_utils, test_set_variant_two_types) {
 
   variant<double, int> bar;
 
-  set_variant(foo, one);
+  set_variant(one, &foo);
   EXPECT_TRUE(foo.is<int>());
   EXPECT_EQ(foo.get<int>(), one);
 
-  set_variant(foo, two);
+  set_variant(two, &foo);
   EXPECT_TRUE(foo.is<double>());
   EXPECT_EQ(foo.get<double>(), two);
 
   bar = one;
-  set_variant(foo, bar);
+  set_variant(bar, &foo);
   EXPECT_TRUE(foo.is<int>());
   EXPECT_EQ(foo.get<int>(), one);
 
   bar = two;
-  set_variant(foo, bar);
+  set_variant(bar, &foo);
   EXPECT_TRUE(foo.is<double>());
   EXPECT_EQ(foo.get<double>(), two);
 }
@@ -58,24 +58,24 @@ TEST(test_variant_utils, test_set_variant_three_types) {
   variant<double, int> double_int;
 
   double_int = one;
-  set_variant(foo, double_int);
+  set_variant(double_int, &foo);
   EXPECT_TRUE(foo.is<int>());
   EXPECT_EQ(foo.get<int>(), one);
 
   double_int = two;
-  set_variant(foo, double_int);
+  set_variant(double_int, &foo);
   EXPECT_TRUE(foo.is<double>());
   EXPECT_EQ(foo.get<double>(), two);
 
   variant<double, X> double_x;
 
   double_x = x;
-  set_variant(foo, double_x);
+  set_variant(double_x, &foo);
   EXPECT_TRUE(foo.is<X>());
   EXPECT_EQ(foo.get<X>(), x);
 
   double_x = two;
-  set_variant(foo, double_x);
+  set_variant(double_x, &foo);
   EXPECT_TRUE(foo.is<double>());
   EXPECT_EQ(foo.get<double>(), two);
 }


### PR DESCRIPTION
Add VariantUtils which adds tools for applying trait logic to variant types as well as ways to easily convert between possibly different variant types.

Specifically it deals with situations where you may have compatible but not equivalent variant types such as,
```
variant<X. Y> foo;
variant<Y, X> bar;
```
where assignment operators don't work (ie, `foo = bar` won't compile).  For those situations you can now do:
```
set_variant(foo, bar);
```
similarly you can convert vectors of variants,
```
std::vector<variant<X, Y>> foos;

std::vector<variant<Y, X>> bars = to_variant_vector<variant<Y, X>>(foos);
```