### PR TITLE
Linear Combinations

### DIFF
--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -136,20 +136,10 @@ public:
             typename std::enable_if<has_valid_caller<Derived, X, X>::value,
                                     int>::type = 0>
   Eigen::MatrixXd operator()(const std::vector<X> &xs) const {
-    int n = static_cast<int>(xs.size());
-    Eigen::MatrixXd C(n, n);
-
-    int i, j;
-    std::size_t si, sj;
-    for (i = 0; i < n; i++) {
-      si = static_cast<std::size_t>(i);
-      for (j = 0; j <= i; j++) {
-        sj = static_cast<std::size_t>(j);
-        C(i, j) = call(xs[si], xs[sj]);
-        C(j, i) = C(i, j);
-      }
-    }
-    return C;
+    auto caller = [&](const auto &x, const auto &y) {
+      return this->call(x, y);
+    };
+    return compute_covariance_matrix(caller, xs);
   }
 
   /*
@@ -160,20 +150,10 @@ public:
                                     int>::type = 0>
   Eigen::MatrixXd operator()(const std::vector<X> &xs,
                              const std::vector<Y> &ys) const {
-    int m = static_cast<int>(xs.size());
-    int n = static_cast<int>(ys.size());
-    Eigen::MatrixXd C(m, n);
-
-    int i, j;
-    std::size_t si, sj;
-    for (i = 0; i < m; i++) {
-      si = static_cast<std::size_t>(i);
-      for (j = 0; j < n; j++) {
-        sj = static_cast<std::size_t>(j);
-        C(i, j) = call(xs[si], ys[sj]);
-      }
-    }
-    return C;
+    auto caller = [&](const auto &x, const auto &y) {
+      return this->call(x, y);
+    };
+    return compute_covariance_matrix(caller, xs, ys);
   }
 
   /*

--- a/include/albatross/src/details/traits.hpp
+++ b/include/albatross/src/details/traits.hpp
@@ -221,6 +221,13 @@ public:
   static constexpr bool value = decltype(test<F>(0))::value;
 };
 
+template <class F, class ReturnType, class... Args>
+struct is_invocable_with_result {
+  static constexpr bool value = std::is_same<
+      ReturnType,
+      typename detail::invoke_result<void, F, Args...>::type>::value;
+};
+
 } // namespace albatross
 
 #endif /* INCLUDE_ALBATROSS_SRC_DETAILS_TRAITS_HPP_ */

--- a/tests/test_callers.cc
+++ b/tests/test_callers.cc
@@ -89,6 +89,27 @@ TEST(test_callers, test_measurement_caller) {
   expect_all_calls_false<MeasCaller, Measurement, Measurement>();
 }
 
+TEST(test_callers, test_linear_combination_caller) {
+  using Caller = internal::LinearCombinationCaller<
+      internal::SymmetricCaller<internal::DirectCaller>>;
+
+  HasMultiple cov_func;
+
+  LinearCombination<X> two_xs({X(), X()});
+  X x;
+  Y y;
+
+  const auto one_x = Caller::call(cov_func, x, x);
+  const auto two_x = Caller::call(cov_func, x, two_xs);
+  EXPECT_EQ(two_x, 2 * one_x);
+  const auto four_x = Caller::call(cov_func, two_xs, two_xs);
+  EXPECT_EQ(four_x, 4 * one_x);
+
+  const auto one_xy = Caller::call(cov_func, y, x);
+  const auto two_xy = Caller::call(cov_func, y, two_xs);
+  EXPECT_EQ(two_xy, 2 * one_xy);
+}
+
 template <typename T, typename VariantType> struct VariantOrRaw {
 
   template <typename C,

--- a/tests/test_concatenate.cc
+++ b/tests/test_concatenate.cc
@@ -96,11 +96,11 @@ TEST(test_concatenate, test_different_types_repeated) {
   EXPECT_EQ(actual, expected);
 }
 
-struct X {
+struct ConcatenateTest {
 
-  X(const int &x_) : x(x_){};
+  ConcatenateTest(const int &x_) : x(x_){};
 
-  bool operator==(const X &other) const { return x == other.x; }
+  bool operator==(const ConcatenateTest &other) const { return x == other.x; }
 
   int x;
 };
@@ -109,8 +109,9 @@ TEST(test_concatenate, test_different_types_twice) {
 
   std::vector<int> first = {1, 2, 3};
   std::vector<double> second = {4., 5., 6.};
-  std::vector<X> third = {X(10), X(11)};
-  std::vector<variant<int, double, X>> expected;
+  std::vector<ConcatenateTest> third = {ConcatenateTest(10),
+                                        ConcatenateTest(11)};
+  std::vector<variant<int, double, ConcatenateTest>> expected;
 
   for (const auto &x : first) {
     expected.push_back(x);
@@ -118,8 +119,8 @@ TEST(test_concatenate, test_different_types_twice) {
   for (const auto &x : second) {
     expected.push_back(x);
   }
-  for (const auto &x : third) {
-    expected.push_back(x);
+  for (const auto &y : third) {
+    expected.push_back(y);
   }
 
   const auto once = concatenate(first, second);

--- a/tests/test_variant_utils.cc
+++ b/tests/test_variant_utils.cc
@@ -43,17 +43,19 @@ TEST(test_variant_utils, test_set_variant_two_types) {
   EXPECT_EQ(foo.get<double>(), two);
 }
 
-struct X {
+struct VariantUtilsTestType {
   double value;
-  bool operator==(const X &other) const { return value == other.value; }
+  bool operator==(const VariantUtilsTestType &other) const {
+    return value == other.value;
+  }
 };
 
 TEST(test_variant_utils, test_set_variant_three_types) {
 
-  variant<int, double, X> foo;
+  variant<int, double, VariantUtilsTestType> foo;
   const int one = 1;
   const double two = 2.;
-  const X x = {3.};
+  const VariantUtilsTestType x = {3.};
 
   variant<double, int> double_int;
 
@@ -67,12 +69,12 @@ TEST(test_variant_utils, test_set_variant_three_types) {
   EXPECT_TRUE(foo.is<double>());
   EXPECT_EQ(foo.get<double>(), two);
 
-  variant<double, X> double_x;
+  variant<double, VariantUtilsTestType> double_x;
 
   double_x = x;
   set_variant(double_x, &foo);
-  EXPECT_TRUE(foo.is<X>());
-  EXPECT_EQ(foo.get<X>(), x);
+  EXPECT_TRUE(foo.is<VariantUtilsTestType>());
+  EXPECT_EQ(foo.get<VariantUtilsTestType>(), x);
 
   double_x = two;
   set_variant(double_x, &foo);
@@ -82,7 +84,8 @@ TEST(test_variant_utils, test_set_variant_three_types) {
 
 TEST(test_variant_utils, test_to_variant_vector) {
   const auto doubles = linspace(0., 10., 11);
-  const auto variants = to_variant_vector<variant<int, double, X>>(doubles);
+  const auto variants =
+      to_variant_vector<variant<int, double, VariantUtilsTestType>>(doubles);
   EXPECT_EQ(variants.size(), doubles.size());
 
   for (std::size_t i = 0; i < variants.size(); ++i) {
@@ -92,16 +95,17 @@ TEST(test_variant_utils, test_to_variant_vector) {
 
   double a = 1.;
   double b = 2.;
-  X x_a = {a};
-  X x_b = {b};
+  VariantUtilsTestType x_a = {a};
+  VariantUtilsTestType x_b = {b};
 
-  std::vector<variant<double, X>> mixed;
+  std::vector<variant<double, VariantUtilsTestType>> mixed;
   mixed.emplace_back(a);
   mixed.emplace_back(b);
   mixed.emplace_back(x_a);
   mixed.emplace_back(x_b);
 
-  auto from_mixed = to_variant_vector<variant<int, double, X>>(mixed);
+  auto from_mixed =
+      to_variant_vector<variant<int, double, VariantUtilsTestType>>(mixed);
   for (std::size_t i = 0; i < mixed.size(); ++i) {
     mixed[i].match([&](auto v) {
       EXPECT_TRUE(from_mixed[i].is<decltype(v)>());


### PR DESCRIPTION
This PR creates a way to express new features which are linear combinations of other features.

This allows us to place priors on sums, averages and differences of quantities.  For example, you may be dealing with a time series for which you have some direct observations of the time series, but also some other types of measurements which observe the difference in the time series.  Without this change you could model that with something along the lines of:

```
struct Time {double t;};
struct Diff {double t_1; double t_2;};
double temporal(double x, double y) {return exp(-abs(x - y));};

struct MyCov : public CovarianceFunction<MyCov> {
  double _call_impl(const Time &x, const Time &y) const {
    return temporal(x.t, y.t);
  }

  double _call_impl(const Time &x, const Diff &y) const {
    return temporal(x.t, y.t_1) - temporal(x.t, y.t_2);
  }

  double _call_impl(const Diff &x, const Diff &y) const {
    return temporal(x.t_1, y.t_1) + temporal(x.t_2, y.t_2) - 2 * temporal(x.t_1, y.t_2);
  }
}
```
After this change you could only define a single method,
```
struct MyCov : public CovarianceFunction<MyCov> {
  double _call_impl(const Time &x, const Time &y) const {
    return temporal(x.t, y.t);
  }
}
```
and instead of having a different struct, `Diff` you would use:
```
std::vector<Time> diff_times = {t_1, t_2};
Eigen::Vector2d diff_coefs;
diff_coefs << 1., -1;
diff = LinearCombination<Time>(diff_times, diff_coefs);
```
and the covariance function would deal with the linear combination internally.