### PR TITLE
Refactor Distributions

### DIFF
--- a/include/albatross/src/cereal/distribution.hpp
+++ b/include/albatross/src/cereal/distribution.hpp
@@ -15,9 +15,16 @@
 
 namespace cereal {
 
-template <class CovarianceType, class Archive>
-inline void serialize(Archive &archive,
-                      albatross::Distribution<CovarianceType> &dist,
+template <class Archive>
+inline void serialize(Archive &archive, albatross::MarginalDistribution &dist,
+                      const std::uint32_t) {
+  archive(cereal::make_nvp("mean", dist.mean));
+  archive(cereal::make_nvp("covariance", dist.covariance));
+  archive(cereal::make_nvp("metadata", dist.metadata));
+}
+
+template <class Archive>
+inline void serialize(Archive &archive, albatross::JointDistribution &dist,
                       const std::uint32_t) {
   archive(cereal::make_nvp("mean", dist.mean));
   archive(cereal::make_nvp("covariance", dist.covariance));

--- a/include/albatross/src/core/concatenate.hpp
+++ b/include/albatross/src/core/concatenate.hpp
@@ -78,6 +78,14 @@ inline auto concatenate(const std::vector<std::vector<X>> &all_xs) {
   return features;
 }
 
+inline Eigen::VectorXd concatenate(const Eigen::VectorXd &x,
+                                   const Eigen::VectorXd &y) {
+  Eigen::VectorXd mean(x.size() + y.size());
+  mean.block(0, 0, x.size(), 1) = x;
+  mean.block(x.size(), 0, y.size(), 1) = y;
+  return mean;
+}
+
 /*
  * concatenate with two different non-variant types
  */

--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -56,6 +56,12 @@ template <typename FeatureType> struct RegressionDataset {
   group_by(GrouperFunc grouper) const;
 };
 
+template <typename FeatureType>
+inline auto create_dataset(const std::vector<FeatureType> &features,
+                           const MarginalDistribution &targets) {
+  return RegressionDataset<FeatureType>(features, targets);
+}
+
 /*
  * Convenience method which subsets the features and targets of a dataset.
  */

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -75,11 +75,11 @@ using ParameterStore = std::map<ParameterKey, Parameter>;
 /*
  * Distributions
  */
-template <typename CovarianceType> struct Distribution;
+template <typename Derived> struct DistributionBase;
 
-using JointDistribution = Distribution<Eigen::MatrixXd>;
 using DiagonalMatrixXd = Eigen::DiagonalMatrix<double, Eigen::Dynamic>;
-using MarginalDistribution = Distribution<DiagonalMatrixXd>;
+struct JointDistribution;
+struct MarginalDistribution;
 
 /*
  * Models

--- a/include/albatross/src/core/prediction.hpp
+++ b/include/albatross/src/core/prediction.hpp
@@ -93,12 +93,7 @@ public:
             const std::vector<FeatureType> &features) const {
     const auto joint_pred =
         model.predict_(features, fit, PredictTypeIdentity<JointDistribution>());
-    if (joint_pred.has_covariance()) {
-      Eigen::VectorXd diag = joint_pred.covariance.diagonal();
-      return MarginalDistribution(joint_pred.mean, diag.asDiagonal());
-    } else {
-      return MarginalDistribution(joint_pred.mean);
-    }
+    return joint_pred.marginal();
   }
 };
 

--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -77,11 +77,11 @@ concatenate_mean_predictions(const GroupIndexer<GroupKey> &indexer,
   return pred;
 }
 
-template <typename CovarianceType, typename GroupKey,
+template <typename DistributionType, typename GroupKey,
           template <typename...> class PredictionContainer>
 inline MarginalDistribution concatenate_marginal_predictions(
     const GroupIndexer<GroupKey> &indexer,
-    const PredictionContainer<GroupKey, Distribution<CovarianceType>> &preds) {
+    const PredictionContainer<GroupKey, DistributionType> &preds) {
   assert(indexer.size() == preds.size());
 
   Eigen::Index n =
@@ -119,11 +119,12 @@ Eigen::VectorXd cross_validated_scores(
   return combine(folds.apply(score_one_group));
 }
 
-template <typename FeatureType, typename CovarianceType, typename GroupKey>
-static inline Eigen::VectorXd cross_validated_scores(
-    const PredictionMetric<Eigen::VectorXd> &metric,
-    const RegressionFolds<GroupKey, FeatureType> &folds,
-    const Grouped<GroupKey, Distribution<CovarianceType>> &predictions) {
+template <typename FeatureType, typename DistributionType, typename GroupKey,
+          std::enable_if_t<is_distribution<DistributionType>::value, int> = 0>
+static inline Eigen::VectorXd
+cross_validated_scores(const PredictionMetric<Eigen::VectorXd> &metric,
+                       const RegressionFolds<GroupKey, FeatureType> &folds,
+                       const Grouped<GroupKey, DistributionType> &predictions) {
 
   const auto get_mean = [](const auto &pred) { return pred.mean; };
 

--- a/include/albatross/src/evaluation/prediction_metrics.hpp
+++ b/include/albatross/src/evaluation/prediction_metrics.hpp
@@ -99,9 +99,7 @@ negative_log_likelihood(const JointDistribution &prediction,
                         const MarginalDistribution &truth) {
   const Eigen::VectorXd mean = prediction.mean - truth.mean;
   Eigen::MatrixXd covariance(prediction.covariance);
-  if (truth.has_covariance()) {
-    covariance += truth.covariance;
-  }
+  covariance += truth.covariance;
   return albatross::negative_log_likelihood(mean, covariance);
 }
 
@@ -110,9 +108,7 @@ negative_log_likelihood(const MarginalDistribution &prediction,
                         const MarginalDistribution &truth) {
   const Eigen::VectorXd mean = prediction.mean - truth.mean;
   Eigen::VectorXd variance(prediction.covariance.diagonal());
-  if (truth.has_covariance()) {
-    variance += truth.covariance.diagonal();
-  }
+  variance += truth.covariance.diagonal();
   return albatross::negative_log_likelihood(mean, variance.asDiagonal());
 }
 
@@ -125,9 +121,7 @@ struct NegativeLogLikelihood : public PredictionMetric<PredictType> {
 inline double chi_squared_cdf(const JointDistribution &prediction,
                               const MarginalDistribution &truth) {
   Eigen::MatrixXd covariance(prediction.covariance);
-  if (truth.has_covariance()) {
-    covariance += truth.covariance;
-  }
+  covariance += truth.covariance;
   return chi_squared_cdf(prediction.mean - truth.mean, covariance);
 }
 

--- a/include/albatross/src/indexing/declarations.hpp
+++ b/include/albatross/src/indexing/declarations.hpp
@@ -36,6 +36,12 @@ template <typename SizeType>
 Eigen::MatrixXd subset_cols(const Eigen::MatrixXd &v,
                             const std::vector<SizeType> &col_indices);
 
+template <typename SizeType>
+void set_subset(const Eigen::VectorXd &from,
+                const std::vector<SizeType> &indices, Eigen::VectorXd *to);
+
+Eigen::VectorXd concatenate(const Eigen::VectorXd &x, const Eigen::VectorXd &y);
+
 } // namespace albatross
 
 #endif /* ALBATROSS_INDEXING_DECLARATIONS_HPP_ */

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -64,9 +64,7 @@ struct Fit<GPFit<CovarianceRepresentation, FeatureType>> {
 
     train_features = features;
     Eigen::MatrixXd cov(train_cov);
-    if (targets.has_covariance()) {
-      cov += targets.covariance;
-    }
+    cov += targets.covariance;
     assert(!cov.hasNaN());
     train_covariance = CovarianceRepresentation(cov);
     // Precompute the information vector
@@ -486,9 +484,7 @@ auto update(
   auto pred = fit_model.predict(dataset.features).joint();
 
   Eigen::VectorXd delta = dataset.targets.mean - pred.mean;
-  if (dataset.targets.has_covariance()) {
-    pred.covariance += dataset.targets.covariance;
-  }
+  pred.covariance += dataset.targets.covariance;
   const auto S_ldlt = pred.covariance.ldlt();
 
   const auto model = fit_model.get_model();

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -100,7 +100,7 @@ gp_marginal_prediction(const Eigen::MatrixXd &cross_cov,
   Eigen::VectorXd explained_variance =
       explained.cwiseProduct(cross_cov).array().colwise().sum();
   Eigen::VectorXd marginal_variance = prior_variance - explained_variance;
-  return MarginalDistribution(pred, marginal_variance.asDiagonal());
+  return MarginalDistribution(pred, marginal_variance);
 }
 
 template <typename CovarianceRepresentation>
@@ -395,8 +395,8 @@ gp_cross_validated_predictions(const RegressionDataset<FeatureType> &dataset,
     Eigen::VectorXd yi = subset(dataset.targets.mean, indices[i]);
     Eigen::VectorXd vi = subset(gp_fit.information, indices[i]);
     const auto A_ldlt = Eigen::SerializableLDLT(inverse_blocks[i].ldlt());
-    output[group_keys[i]] = MarginalDistribution(
-        yi - A_ldlt.solve(vi), A_ldlt.inverse_diagonal().asDiagonal());
+    output[group_keys[i]] =
+        MarginalDistribution(yi - A_ldlt.solve(vi), A_ldlt.inverse_diagonal());
   }
   return output;
 }

--- a/include/albatross/src/models/least_squares.hpp
+++ b/include/albatross/src/models/least_squares.hpp
@@ -23,6 +23,20 @@ template <typename ImplType> struct Fit<LeastSquares<ImplType>> {
   bool operator==(const Fit &other) const { return (coefs == other.coefs); }
 };
 
+inline bool all_same_value(const Eigen::VectorXd &x) {
+  if (x.size() == 0) {
+    return true;
+  } else {
+    const double first = x[0];
+    for (Eigen::Index i = 0; i < x.size(); ++i) {
+      if (x[i] != first) {
+        return false;
+      }
+    }
+    return true;
+  }
+}
+
 /*
  * This model supports a family of models which consist of
  * first creating a design matrix, A, then solving least squares.  Ie,
@@ -41,7 +55,7 @@ public:
                     const MarginalDistribution &targets) const {
     // The way this is currently implemented we assume all targets have the same
     // variance (or zero variance).
-    assert(!targets.has_covariance());
+    assert(all_same_value(targets.covariance.diagonal()));
     // Build the design matrix
     int m = static_cast<int>(features.size());
     int n = static_cast<int>(features[0].size());

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -211,10 +211,8 @@ public:
       auto subset_features =
           subset(out_of_order_measurement_features, pair.second);
       K_ff.blocks.emplace_back(this->covariance_function_(subset_features));
-      if (out_of_order_targets.has_covariance()) {
-        K_ff.blocks.back().diagonal() +=
-            subset(out_of_order_targets.covariance.diagonal(), pair.second);
-      }
+      K_ff.blocks.back().diagonal() +=
+          subset(out_of_order_targets.covariance.diagonal(), pair.second);
     }
 
     const auto features =

--- a/include/albatross/src/utils/csv_utils.hpp
+++ b/include/albatross/src/utils/csv_utils.hpp
@@ -145,7 +145,7 @@ to_map(const FeatureType &feature, double target, double target_variance,
 template <typename FeatureType, typename DistributionType>
 inline std::map<std::string, std::string>
 to_map(const RegressionDataset<FeatureType> &dataset,
-       const Distribution<DistributionType> &predictions, std::size_t i) {
+       const DistributionBase<DistributionType> &predictions, std::size_t i) {
   assert(dataset.targets.size() == predictions.size());
   assert(i < dataset.features.size() && i >= 0);
   const auto ei = static_cast<Eigen::Index>(i);
@@ -172,10 +172,10 @@ inline void replace_last_character_with_newline(std::ostream &stream) {
   stream << std::endl;
 }
 
-template <typename FeatureType, typename CovarianceType>
+template <typename FeatureType, typename DistributionType>
 inline std::vector<std::string>
 get_column_names(const RegressionDataset<FeatureType> &dataset,
-                 const Distribution<CovarianceType> &predictions) {
+                 const DistributionBase<DistributionType> &predictions) {
   const auto first_row = to_map(dataset, predictions, 0);
   return map_keys(first_row);
 }
@@ -200,10 +200,10 @@ inline void write_header(std::ostream &stream,
   replace_last_character_with_newline(stream);
 }
 
-template <typename FeatureType, typename CovarianceType>
+template <typename FeatureType, typename DistributionType>
 inline void write_to_csv(std::ostream &stream,
                          const RegressionDataset<FeatureType> &dataset,
-                         const Distribution<CovarianceType> &predictions,
+                         const DistributionBase<DistributionType> &predictions,
                          const std::vector<std::string> &columns) {
 
   for (std::size_t i = 0; i < dataset.features.size(); i++) {
@@ -215,7 +215,7 @@ inline void write_to_csv(std::ostream &stream,
 template <typename FeatureType, typename CovarianceType>
 inline void write_to_csv(std::ostream &stream,
                          const RegressionDataset<FeatureType> &dataset,
-                         const Distribution<CovarianceType> &predictions,
+                         const DistributionBase<CovarianceType> &predictions,
                          bool include_header = true) {
   const auto columns = get_column_names(dataset, predictions);
   if (include_header) {
@@ -236,11 +236,12 @@ inline void write_to_csv(std::ostream &stream,
   write_to_csv(stream, dataset, zero_predictions, include_header);
 }
 
-template <typename FeatureType, typename CovarianceType>
+template <typename FeatureType, typename DistributionType,
+          std::enable_if_t<is_distribution<DistributionType>::value, int> = 0>
 inline void
 write_to_csv(std::ostream &stream,
              const std::vector<RegressionDataset<FeatureType>> &datasets,
-             const std::vector<Distribution<CovarianceType>> &predictions) {
+             const std::vector<DistributionType> &predictions) {
   const auto columns = get_column_names(datasets[0], predictions[0]);
   write_header(stream, columns);
   assert(datasets.size() == predictions.size());

--- a/tests/test_core_distribution.cc
+++ b/tests/test_core_distribution.cc
@@ -28,11 +28,7 @@ TYPED_TEST_P(DistributionTest, test_subset) {
 
   expect_subset_equal(dist.mean, ss.mean, indices);
 
-  if (dist.has_covariance()) {
-    expect_subset_equal(dist.covariance, ss.covariance, indices);
-  } else {
-    EXPECT_FALSE(ss.has_covariance());
-  }
+  expect_subset_equal(dist.covariance, ss.covariance, indices);
 };
 
 REGISTER_TYPED_TEST_CASE_P(DistributionTest, test_subset);
@@ -45,14 +41,6 @@ Eigen::VectorXd arange(int k = 5) {
   return mean;
 }
 
-struct MarginalNoCovariance
-    : public DistributionTestCase<MarginalDistribution> {
-  virtual MarginalDistribution create() const {
-    Eigen::VectorXd mean = arange(5);
-    return MarginalDistribution(mean);
-  }
-};
-
 struct MarginalWithCovariance
     : public DistributionTestCase<MarginalDistribution> {
   virtual MarginalDistribution create() const {
@@ -60,16 +48,7 @@ struct MarginalWithCovariance
     Eigen::VectorXd mean = arange(k);
     Eigen::MatrixXd covariance = Eigen::MatrixXd::Random(k, k);
     covariance = covariance * covariance.transpose();
-
-    return MarginalDistribution(mean, mean.asDiagonal());
-  }
-};
-
-struct JointNoCovariance : public DistributionTestCase<JointDistribution> {
-  virtual JointDistribution create() const {
-    Eigen::Index k = 5;
-    Eigen::VectorXd mean = arange(k);
-    return JointDistribution(mean);
+    return MarginalDistribution(mean, covariance.diagonal().asDiagonal());
   }
 };
 
@@ -84,9 +63,7 @@ struct JointWithCovariance : public DistributionTestCase<JointDistribution> {
   }
 };
 
-typedef ::testing::Types<MarginalNoCovariance, MarginalWithCovariance,
-                         JointNoCovariance, JointWithCovariance>
-    ToTest;
+typedef ::testing::Types<MarginalWithCovariance, JointWithCovariance> ToTest;
 
 INSTANTIATE_TYPED_TEST_CASE_P(Albatross, DistributionTest, ToTest);
 

--- a/tests/test_core_distribution.cc
+++ b/tests/test_core_distribution.cc
@@ -31,7 +31,81 @@ TYPED_TEST_P(DistributionTest, test_subset) {
   expect_subset_equal(dist.covariance, ss.covariance, indices);
 };
 
-REGISTER_TYPED_TEST_CASE_P(DistributionTest, test_subset);
+TYPED_TEST_P(DistributionTest, test_multiply_with_matrix) {
+
+  TypeParam test_case;
+  const auto dist = test_case.create();
+
+  Eigen::MatrixXd mat = Eigen::MatrixXd::Random(dist.size() - 1, dist.size());
+
+  const auto transformed_distribution = dist * mat;
+
+  EXPECT_EQ(transformed_distribution.mean, mat * dist.mean);
+  EXPECT_EQ(transformed_distribution.covariance,
+            mat * dist.covariance * mat.transpose());
+};
+
+TYPED_TEST_P(DistributionTest, test_multiply_with_vector) {
+
+  TypeParam test_case;
+  const auto dist = test_case.create();
+
+  Eigen::VectorXd vector = Eigen::VectorXd::Random(dist.size());
+
+  const auto transformed_distribution = dist * vector;
+
+  double expected_mean = vector.dot(dist.mean);
+  double expected_variance = vector.dot(dist.covariance * vector);
+  EXPECT_EQ(transformed_distribution.mean[0], expected_mean);
+  EXPECT_EQ(transformed_distribution.covariance(0, 0), expected_variance);
+};
+
+TYPED_TEST_P(DistributionTest, test_multiply_by_scalar) {
+
+  TypeParam test_case;
+  const auto dist = test_case.create();
+
+  double scalar = 3.;
+
+  const auto transformed_distribution = dist * scalar;
+
+  EXPECT_EQ(transformed_distribution.mean, scalar * dist.mean);
+  Eigen::MatrixXd scaled = dist.covariance;
+  scaled *= scalar * scalar;
+  const Eigen::MatrixXd actual = transformed_distribution.covariance;
+  EXPECT_EQ(actual, scaled);
+};
+
+TYPED_TEST_P(DistributionTest, test_add) {
+
+  TypeParam test_case;
+  const auto dist = test_case.create();
+
+  const auto transformed_distribution = dist + dist;
+
+  EXPECT_EQ(transformed_distribution.mean, dist.mean + dist.mean);
+  const Eigen::MatrixXd expected = 2 * dist.covariance;
+  const Eigen::MatrixXd actual = transformed_distribution.covariance;
+  EXPECT_EQ(actual, expected);
+};
+
+TYPED_TEST_P(DistributionTest, test_subtract) {
+
+  TypeParam test_case;
+  const auto dist = test_case.create();
+
+  const auto transformed_distribution = dist - dist;
+
+  EXPECT_EQ(transformed_distribution.mean,
+            Eigen::VectorXd::Zero(dist.mean.size()));
+  const Eigen::MatrixXd expected = 2 * dist.covariance;
+  const Eigen::MatrixXd actual = transformed_distribution.covariance;
+  EXPECT_EQ(actual, expected);
+};
+
+REGISTER_TYPED_TEST_CASE_P(DistributionTest, test_subset,
+                           test_multiply_with_matrix, test_multiply_with_vector,
+                           test_multiply_by_scalar, test_add, test_subtract);
 
 Eigen::VectorXd arange(int k = 5) {
   Eigen::VectorXd mean(k);

--- a/tests/test_prediction.cc
+++ b/tests/test_prediction.cc
@@ -87,9 +87,10 @@ public:
   JointDistribution
   _predict_impl(const std::vector<X> &features, const Fit<JointOnlyModel> &,
                 PredictTypeIdentity<JointDistribution>) const {
-    auto mean =
-        Eigen::VectorXd::Zero(static_cast<Eigen::Index>(features.size()));
-    return JointDistribution(mean);
+    const Eigen::Index n = static_cast<Eigen::Index>(features.size());
+    const auto mean = Eigen::VectorXd::Zero(n);
+    const auto covariance = Eigen::MatrixXd::Zero(n, n);
+    return JointDistribution(mean, covariance);
   }
 };
 

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -111,27 +111,12 @@ struct FullJointDistribution : public SerializableType<JointDistribution> {
   }
 };
 
-struct MeanOnlyJointDistribution : public SerializableType<JointDistribution> {
-  JointDistribution create() const override {
-    Eigen::MatrixXd mean = Eigen::VectorXd::Ones(3);
-    return JointDistribution(mean);
-  }
-};
-
 struct FullMarginalDistribution
     : public SerializableType<MarginalDistribution> {
   MarginalDistribution create() const override {
     Eigen::VectorXd diag = Eigen::VectorXd::Ones(3);
     Eigen::VectorXd mean = Eigen::VectorXd::Ones(3);
     return MarginalDistribution(mean, diag.asDiagonal());
-  }
-};
-
-struct MeanOnlyMarginalDistribution
-    : public SerializableType<MarginalDistribution> {
-  MarginalDistribution create() const override {
-    Eigen::MatrixXd mean = Eigen::VectorXd::Ones(3);
-    return MarginalDistribution(mean);
   }
 };
 
@@ -290,8 +275,7 @@ REGISTER_TYPED_TEST_CASE_P(SerializeTest, test_roundtrip_serialize_json,
 typedef ::testing::Types<LDLT, ExplainedCovarianceRepresentation, EigenMatrix3d,
                          SerializableType<Eigen::Matrix2i>, EmptyEigenVectorXd,
                          EigenVectorXd, EmptyEigenMatrixXd, EigenMatrixXd,
-                         FullJointDistribution, MeanOnlyJointDistribution,
-                         FullMarginalDistribution, MeanOnlyMarginalDistribution,
+                         FullJointDistribution, FullMarginalDistribution,
                          ParameterStoreType, Dataset, DatasetWithMetadata,
                          SerializableType<MockModel>, VariantAsInt,
                          VariantAsDouble, BlockSymmetricMatrix>

--- a/tests/test_traits_core.cc
+++ b/tests/test_traits_core.cc
@@ -236,7 +236,8 @@ public:
   _predict_impl(const std::vector<X> &, const Fit<HasJointPredictImpl> &,
                 PredictTypeIdentity<JointDistribution>) const {
     const auto mean = Eigen::VectorXd::Zero(0);
-    return JointDistribution(mean);
+    const auto cov = Eigen::MatrixXd::Zero(0, 0);
+    return JointDistribution(mean, cov);
   }
 };
 
@@ -259,7 +260,8 @@ public:
   _predict_impl(const std::vector<X> &, const Fit<HasAllPredictImpls> &,
                 PredictTypeIdentity<JointDistribution>) const {
     const auto mean = Eigen::VectorXd::Zero(0);
-    return JointDistribution(mean);
+    const auto cov = Eigen::MatrixXd::Zero(0, 0);
+    return JointDistribution(mean, cov);
   }
 };
 


### PR DESCRIPTION
This change is broken into two parts.  In the first commit the `Distribution<CovarianceType>` class was converted into a CRTP style base class `DistributionBase<Derived>`.  The primary motivation for this was the desire to add additional functionality such as multiplication and summation operators and additional constructors for which the templated approach broke down.  This additional functionality was added in the second commit.

The only non-backward compatible change was the removal of the `has_covariance()` method which was adding significant complication to methods such as concatenation.