### PR TITLE
Bug Fixes: Reorder and fix callers.

### DIFF
--- a/include/albatross/CovarianceFunctions
+++ b/include/albatross/CovarianceFunctions
@@ -26,6 +26,7 @@
 #include <albatross/src/covariance_functions/covariance_function.hpp>
 #include <albatross/src/covariance_functions/call_trace.hpp>
 #include <albatross/src/covariance_functions/measurement.hpp>
+#include <albatross/src/covariance_functions/linear_combination.hpp>
 #include <albatross/src/covariance_functions/distance_metrics.hpp>
 #include <albatross/src/covariance_functions/noise.hpp>
 #include <albatross/src/covariance_functions/polynomials.hpp>

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -92,6 +92,9 @@ struct NullLeastSquaresImpl {};
 
 template <typename ImplType = NullLeastSquaresImpl> class LeastSquares;
 
+template <typename FeatureType>
+struct LinearCombination;
+
 /*
  * Cross Validation
  */

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -92,8 +92,7 @@ struct NullLeastSquaresImpl {};
 
 template <typename ImplType = NullLeastSquaresImpl> class LeastSquares;
 
-template <typename FeatureType>
-struct LinearCombination;
+template <typename FeatureType> struct LinearCombination;
 
 /*
  * Cross Validation

--- a/include/albatross/src/covariance_functions/callers.hpp
+++ b/include/albatross/src/covariance_functions/callers.hpp
@@ -17,6 +17,11 @@ namespace albatross {
 
 template <typename X> struct LinearCombination {
 
+  static_assert(
+      !is_measurement<X>::value,
+      "Putting a Measurement type inside a LinearCombination will lead to "
+      "unexpected behavior due to the ordering of the DefaultCaller");
+
   LinearCombination(){};
 
   LinearCombination(const std::vector<X> &values_)
@@ -359,9 +364,9 @@ template <typename SubCaller> struct VariantForwarder {
 /*
  * This defines the order of operations of the covariance function Callers.
  */
-using DefaultCaller =
-    internal::VariantForwarder<internal::MeasurementForwarder<
-    internal::LinearCombinationCaller<internal::SymmetricCaller<internal::DirectCaller>>>>;
+using DefaultCaller = internal::VariantForwarder<
+    internal::MeasurementForwarder<internal::LinearCombinationCaller<
+        internal::SymmetricCaller<internal::DirectCaller>>>>;
 
 template <typename Caller, typename CovFunc, typename... Args>
 class caller_has_valid_call

--- a/include/albatross/src/covariance_functions/callers.hpp
+++ b/include/albatross/src/covariance_functions/callers.hpp
@@ -15,28 +15,6 @@
 
 namespace albatross {
 
-template <typename X> struct LinearCombination {
-
-  static_assert(
-      !is_measurement<X>::value,
-      "Putting a Measurement type inside a LinearCombination will lead to "
-      "unexpected behavior due to the ordering of the DefaultCaller");
-
-  LinearCombination(){};
-
-  LinearCombination(const std::vector<X> &values_)
-      : values(values_), coefficients(Eigen::VectorXd::Ones(values_.size())){};
-
-  LinearCombination(const std::vector<X> &values_,
-                    const Eigen::VectorXd &coefficients_)
-      : values(values_), coefficients(coefficients_) {
-    assert(values_.size() == static_cast<std::size_t>(coefficients_.size()));
-  };
-
-  std::vector<X> values;
-  Eigen::VectorXd coefficients;
-};
-
 /*
  * Implementing a CovarianceFunction requires defining a method with
  * signature:
@@ -364,9 +342,9 @@ template <typename SubCaller> struct VariantForwarder {
 /*
  * This defines the order of operations of the covariance function Callers.
  */
-using DefaultCaller = internal::VariantForwarder<
-    internal::MeasurementForwarder<internal::LinearCombinationCaller<
-        internal::SymmetricCaller<internal::DirectCaller>>>>;
+using DefaultCaller = internal::VariantForwarder<internal::MeasurementForwarder<
+    internal::LinearCombinationCaller<internal::VariantForwarder<
+        internal::SymmetricCaller<internal::DirectCaller>>>>>;
 
 template <typename Caller, typename CovFunc, typename... Args>
 class caller_has_valid_call

--- a/include/albatross/src/covariance_functions/callers.hpp
+++ b/include/albatross/src/covariance_functions/callers.hpp
@@ -359,9 +359,9 @@ template <typename SubCaller> struct VariantForwarder {
 /*
  * This defines the order of operations of the covariance function Callers.
  */
-using DefaultCaller = internal::LinearCombinationCaller<
+using DefaultCaller =
     internal::VariantForwarder<internal::MeasurementForwarder<
-        internal::SymmetricCaller<internal::DirectCaller>>>>;
+    internal::LinearCombinationCaller<internal::SymmetricCaller<internal::DirectCaller>>>>;
 
 template <typename Caller, typename CovFunc, typename... Args>
 class caller_has_valid_call

--- a/include/albatross/src/covariance_functions/linear_combination.hpp
+++ b/include/albatross/src/covariance_functions/linear_combination.hpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_COVARIANCE_FUNCTIONS_LINEAR_COMBINATION_HPP_
+#define ALBATROSS_COVARIANCE_FUNCTIONS_LINEAR_COMBINATION_HPP_
+
+namespace albatross {
+
+template <typename X> struct LinearCombination {
+
+  static_assert(
+      !is_measurement<X>::value,
+      "Putting a Measurement type inside a LinearCombination will lead to "
+      "unexpected behavior due to the ordering of the DefaultCaller");
+
+  LinearCombination(){};
+
+  LinearCombination(const std::vector<X> &values_)
+      : values(values_), coefficients(Eigen::VectorXd::Ones(values_.size())){};
+
+  LinearCombination(const std::vector<X> &values_,
+                    const Eigen::VectorXd &coefficients_)
+      : values(values_), coefficients(coefficients_) {
+    assert(values_.size() == static_cast<std::size_t>(coefficients_.size()));
+  };
+
+  std::vector<X> values;
+  Eigen::VectorXd coefficients;
+};
+
+template <typename X> inline auto sum(const X &x, const X &y) {
+  Eigen::Vector2d coefs;
+  coefs << 1., 1.;
+  return LinearCombination<X>({x, y}, coefs);
+}
+
+template <typename X, typename Y> inline auto sum(const X &x, const Y &y) {
+  variant<X, Y> vx = x;
+  variant<X, Y> vy = y;
+  return sum(vx, vy);
+}
+
+template <typename X> inline auto mean(const std::vector<X> &xs) {
+  const auto n = static_cast<Eigen::Index>(xs.size());
+  Eigen::VectorXd coefs(n);
+  coefs.fill(1. / n);
+  return LinearCombination<X>(xs, coefs);
+}
+
+template <typename X> inline auto difference(const X &x, const X &y) {
+  Eigen::Vector2d coefs;
+  coefs << 1., -1.;
+  return LinearCombination<X>({x, y}, coefs);
+}
+
+template <typename X, typename Y>
+inline auto difference(const X &x, const Y &y) {
+  variant<X, Y> vx = x;
+  variant<X, Y> vy = y;
+  return difference(vx, vy);
+}
+
+} // namespace albatross
+
+#endif /* ALBATROSS_COVARIANCE_FUNCTIONS_LINEAR_COMBINATION_HPP_ */

--- a/include/albatross/src/covariance_functions/measurement.hpp
+++ b/include/albatross/src/covariance_functions/measurement.hpp
@@ -17,6 +17,11 @@ namespace albatross {
 
 template <typename X> struct Measurement {
 
+  static_assert(!is_variant<X>::value,
+                "Wrapping a variant in the measurement tag can lead to "
+                "unexpected behavior.  It's preferable to convert to a variant "
+                "of measurements, see as_measurement()");
+
   Measurement() : value(){};
 
   Measurement(const X &x) { value = x; }

--- a/include/albatross/src/details/traits.hpp
+++ b/include/albatross/src/details/traits.hpp
@@ -62,13 +62,27 @@ template <typename T>
 struct is_vector<std::vector<T>> : public std::true_type {};
 
 /*
+ * is_templated_type
+ */
+template <template <typename...> class Wrapper, typename T>
+struct is_templated_type : public std::false_type {};
+
+template <template <typename...> class Wrapper, typename... Ts>
+struct is_templated_type<Wrapper, Wrapper<Ts...>> : public std::true_type {};
+
+/*
  * is_variant
  */
 
-template <typename T> struct is_variant : public std::false_type {};
+template <typename T>
+struct is_variant : public is_templated_type<variant, T> {};
 
-template <typename... Ts>
-struct is_variant<variant<Ts...>> : public std::true_type {};
+/*
+ * is_measurement
+ */
+
+template <typename T>
+struct is_measurement : public is_templated_type<Measurement, T> {};
 
 /*
  * is_in_variant

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -197,11 +197,8 @@ public:
     const auto u = inducing_point_strategy(this->covariance_function_,
                                            out_of_order_features);
 
-    std::vector<Measurement<FeatureType>> out_of_order_measurement_features;
-    for (const auto &f : out_of_order_features) {
-      out_of_order_measurement_features.emplace_back(
-          Measurement<FeatureType>(f));
-    }
+    const auto out_of_order_measurement_features =
+        as_measurements(out_of_order_features);
 
     std::vector<std::size_t> reordered_inds;
     BlockDiagonal K_ff;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,45 @@
 add_executable(albatross_unit_tests 
+  test_apply.cc
+  test_block_utils.cc
+  test_call_trace.cc
+  test_callers.cc
+  test_concatenate.cc
+  test_core_dataset.cc
+  test_core_distribution.cc
+  test_core_model.cc
+  test_covariance_function.cc
+  test_covariance_functions.cc
+  test_cross_validation.cc
+  test_csv_utils.cc
+  test_distance_metrics.cc
+  test_eigen_utils.cc
+  test_evaluate.cc
+  test_gp.cc
+  test_group_by.cc
+  test_indexing.cc
+  test_linalg_utils.cc
+  test_map_utils.cc
+  test_model_adapter.cc
+  test_model_metrics.cc  
+  test_models.cc
+  test_parameter_handling_mixin.cc
+  test_prediction.cc
+  test_radial.cc
+  test_random_utils.cc
+  test_ransac.cc
+  test_scaling_function.cc
+  test_serializable_ldlt.cc
+  test_serialize.cc
+  test_sparse_gp.cc
+  test_stats.cc
+  test_traits_cereal.cc
+  test_traits_core.cc
   test_traits_details.cc
+  test_traits_covariance_functions.cc
+  test_traits_evaluation.cc
+  test_traits_indexing.cc
+  test_tune.cc
+  test_variant_utils.cc
   )
 target_include_directories(albatross_unit_tests SYSTEM PRIVATE
   "${gtest_SOURCE_DIR}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,45 +1,5 @@
 add_executable(albatross_unit_tests 
-  test_apply.cc
-  test_block_utils.cc
-  test_call_trace.cc
-  test_callers.cc
-  test_concatenate.cc
-  test_core_dataset.cc
-  test_core_distribution.cc
-  test_core_model.cc
-  test_covariance_function.cc
-  test_covariance_functions.cc
-  test_cross_validation.cc
-  test_csv_utils.cc
-  test_distance_metrics.cc
-  test_eigen_utils.cc
-  test_evaluate.cc
-  test_gp.cc
-  test_group_by.cc
-  test_indexing.cc
-  test_linalg_utils.cc
-  test_map_utils.cc
-  test_model_adapter.cc
-  test_model_metrics.cc  
-  test_models.cc
-  test_parameter_handling_mixin.cc
-  test_prediction.cc
-  test_radial.cc
-  test_random_utils.cc
-  test_ransac.cc
-  test_scaling_function.cc
-  test_serializable_ldlt.cc
-  test_serialize.cc
-  test_sparse_gp.cc
-  test_stats.cc
-  test_traits_cereal.cc
-  test_traits_core.cc
   test_traits_details.cc
-  test_traits_covariance_functions.cc
-  test_traits_evaluation.cc
-  test_traits_indexing.cc
-  test_tune.cc
-  test_variant_utils.cc
   )
 target_include_directories(albatross_unit_tests SYSTEM PRIVATE
   "${gtest_SOURCE_DIR}"

--- a/tests/test_traits_details.cc
+++ b/tests/test_traits_details.cc
@@ -35,6 +35,7 @@ TEST(test_traits_core, test_variant_size) {
 TEST(test_traits_core, test_is_variant) {
   EXPECT_TRUE(is_variant<variant<int>>::value);
   EXPECT_TRUE(bool(is_variant<variant<int, double>>::value));
+  EXPECT_FALSE(bool(is_variant<Measurement<int>>::value));
   EXPECT_FALSE(is_variant<int>::value);
   EXPECT_FALSE(is_variant<double>::value);
 }
@@ -136,6 +137,15 @@ TEST(test_traits_core, test_is_sub_variant) {
   EXPECT_FALSE(bool(is_sub_variant<variant<Y, X>, variant<Y, Z>>::value));
   EXPECT_FALSE(bool(is_sub_variant<variant<X, Y>, variant<Y, Z>>::value));
   EXPECT_FALSE(bool(is_sub_variant<variant<X>, variant<Y, Z>>::value));
+}
+
+TEST(test_traits_core, test_is_measurement) {
+  EXPECT_TRUE(is_measurement<Measurement<int>>::value);
+  EXPECT_TRUE(bool(is_measurement<Measurement<double>>::value));
+  EXPECT_TRUE(bool(is_measurement<Measurement<variant<int, double>>>::value));
+  EXPECT_FALSE(is_measurement<int>::value);
+  EXPECT_FALSE(is_measurement<double>::value);
+  EXPECT_FALSE(is_measurement<variant<double>>::value);
 }
 
 class Complete {};


### PR DESCRIPTION
These two small changes fix a few confusing issues that are both a result of the order in which types such as `variant<>`, `Measurement<>` and `LinearCombination<>` are nested.

For example, after this PR the covariance functions here are some valid features types:
```
Measurement<Foo>
LinearCombination<Foo>
Measurement<LinearCombination<Foo>>
variant<Measurement<int>, Measurement<double>>
variant<Measurement<Foo>, Foo, LinearCombination<Foo>, 
 Measurement<LinearCombination<Foo>>>
```
While these would be invalid (and will fail with static asserts):
```
Measurement<variant<int, double>>
LinearCombination<Measurement<Foo>>
variant<int, LinearCombination<Measurement<Foo>>>
```

