### PR TITLE
Random Covariance

### DIFF
--- a/include/albatross/src/utils/eigen_utils.hpp
+++ b/include/albatross/src/utils/eigen_utils.hpp
@@ -142,31 +142,6 @@ inline auto truncated_psd_solve(
   return output;
 }
 
-template <typename _Scalar, int _Rows, int _Cols,
-          typename RandomNumberGenerator>
-void gaussian_fill(Eigen::Matrix<_Scalar, _Rows, _Cols> &matrix, double mean,
-                   double sd, RandomNumberGenerator &rng) {
-  std::normal_distribution<_Scalar> dist(mean, sd);
-  for (Eigen::Index i = 0; i < matrix.rows(); ++i) {
-    for (Eigen::Index j = 0; j < matrix.cols(); ++j) {
-      matrix(i, j) = dist(rng);
-    }
-  }
-}
-
-template <typename _Scalar, int _Rows, int _Cols>
-void gaussian_fill(Eigen::Matrix<_Scalar, _Rows, _Cols> &matrix) {
-  std::default_random_engine rng;
-  gaussian_fill(matrix, 0., 1., rng);
-}
-
-template <typename _Scalar, int _Rows, int _Cols,
-          typename RandomNumberGenerator>
-void gaussian_fill(Eigen::Matrix<_Scalar, _Rows, _Cols> &matrix,
-                   RandomNumberGenerator &rng) {
-  gaussian_fill(matrix, 0., 1., rng);
-}
-
 } // namespace albatross
 
 #endif

--- a/include/albatross/utils/RandomUtils
+++ b/include/albatross/utils/RandomUtils
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_UTILS_RANDOM_UTILS_H
+#define ALBATROSS_UTILS_RANDOM_UTILS_H
+
+#include <random>
+
+#include <albatross/Indexing>
+
+#include "../src/utils/random_utils.hpp"
+
+#endif

--- a/tests/test_block_utils.cc
+++ b/tests/test_block_utils.cc
@@ -15,6 +15,7 @@
 #include <Eigen/Cholesky>
 
 #include <albatross/GP>
+#include <albatross/utils/RandomUtils>
 
 #include "test_utils.h"
 
@@ -115,7 +116,8 @@ TEST(test_block_utils, test_matrix_l) {
 
 TEST(test_block_utils, test_block_symmetric) {
 
-  const auto X = random_covariance_matrix(5);
+  std::default_random_engine gen(2012);
+  const auto X = random_covariance_matrix(5, gen);
 
   const Eigen::MatrixXd rhs = Eigen::MatrixXd::Random(X.cols(), 3);
   const Eigen::MatrixXd expected = X.ldlt().solve(rhs);

--- a/tests/test_random_utils.cc
+++ b/tests/test_random_utils.cc
@@ -11,9 +11,8 @@
  */
 #include <gtest/gtest.h>
 
-#include <albatross/Core>
-#include <albatross/Indexing>
-#include <albatross/src/utils/random_utils.hpp>
+#include <albatross/Evaluation>
+#include <albatross/utils/RandomUtils>
 
 namespace albatross {
 
@@ -41,6 +40,66 @@ TEST(test_random_utils, randint_without_replacement_full_set) {
   EXPECT_EQ(inds.size(), 10);
   std::set<std::size_t> unique_inds(inds.begin(), inds.end());
   EXPECT_EQ(unique_inds.size(), inds.size());
+}
+
+TEST(test_random_utils, test_random_multivariate_normal_1d) {
+  std::default_random_engine gen(2012);
+
+  double expected_mean = 5.;
+  Eigen::VectorXd mean(1);
+  mean << expected_mean;
+  double expected_variance = 3.;
+  Eigen::MatrixXd cov(1, 1);
+  cov << expected_variance;
+
+  Eigen::Index k = 10000;
+  Eigen::MatrixXd samples(k, 1);
+  for (Eigen::Index i = 0; i < k; ++i) {
+    samples.row(i) = random_multivariate_normal(mean, cov, gen);
+  }
+
+  EXPECT_NEAR(samples.mean(), expected_mean, 0.1);
+  EXPECT_NEAR(standard_deviation(samples), std::sqrt(expected_variance), 0.1);
+}
+
+TEST(test_random_utils, test_random_covariance_matrix) {
+  std::default_random_engine gen(2012);
+
+  std::uniform_int_distribution<Eigen::Index> size_distribution(1, 20);
+
+  Eigen::Index k = 100;
+  for (Eigen::Index i = 0; i < k; ++i) {
+    Eigen::Index n = size_distribution(gen);
+    const auto cov = random_covariance_matrix(n, gen);
+    EXPECT_GE(cov.eigenvalues().real().maxCoeff(),
+              std::numeric_limits<double>::epsilon());
+
+    EXPECT_LE((cov - cov.transpose()).norm(), 1e-6);
+  }
+}
+
+TEST(test_random_utils, test_random_multivariate_normal) {
+  // Draw a bunch of samples from various sizes of
+  // multivariate normal distributions and make sure the
+  // results follow the expected chi squared distributions.
+  std::default_random_engine gen(2012);
+
+  std::uniform_int_distribution<Eigen::Index> size_distribution(1, 20);
+
+  Eigen::Index k = 1000;
+  std::vector<double> cdfs;
+  for (Eigen::Index i = 0; i < k; ++i) {
+    Eigen::Index n = size_distribution(gen);
+    const auto cov = random_covariance_matrix(n, gen);
+    Eigen::VectorXd mean(n);
+    gaussian_fill(mean, gen);
+
+    const auto sample = random_multivariate_normal(mean, cov, gen);
+
+    cdfs.push_back(chi_squared_cdf(sample - mean, cov));
+  }
+
+  EXPECT_LT(uniform_ks_test(cdfs), 0.05);
 }
 
 } // namespace albatross

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -18,6 +18,7 @@
 #include <albatross/serialize/GP>
 #include <albatross/serialize/LeastSquares>
 #include <albatross/serialize/Ransac>
+#include <albatross/utils/RandomUtils>
 
 #include <gtest/gtest.h>
 
@@ -258,7 +259,8 @@ struct BlockSymmetricMatrix
 
   RepresentationType create() const override {
 
-    const auto X = random_covariance_matrix(5);
+    std::default_random_engine gen(2012);
+    const auto X = random_covariance_matrix(5, gen);
 
     const Eigen::MatrixXd A = X.topLeftCorner(3, 3);
     const Eigen::MatrixXd B = X.topRightCorner(3, 2);

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -163,13 +163,6 @@ inline auto random_spherical_points(std::size_t n = 10, double radius = 1.,
   return points;
 }
 
-inline auto random_covariance_matrix(Eigen::Index k = 5) {
-  Eigen::MatrixXd X = Eigen::MatrixXd::Random(k, k);
-  X = X.transpose() * X;
-  X.diagonal() += 0.1 * Eigen::VectorXd::Ones(k);
-  return X;
-}
-
 template <typename CovarianceFunction, typename FeatureType>
 void expect_state_space_representation_quality(
     const CovarianceFunction &cov_func,


### PR DESCRIPTION
Some utilities for producing random matrices, covariance matrices in particular, already exist in `albatross` but here we put these tools in the same place and add a target `RandomUtils` to make them easier to use.