### PR TITLE
Grouped Eigen Type Safety

### DIFF
--- a/include/albatross/src/core/traits.hpp
+++ b/include/albatross/src/core/traits.hpp
@@ -43,6 +43,8 @@ struct is_valid_fit_type : public std::false_type {};
 template <typename FitParameter>
 struct is_valid_fit_type<Fit<FitParameter>> : public std::true_type {};
 
+DEFINE_CLASS_METHOD_TRAITS(_fit_impl);
+
 /*
  * This determines whether or not a class (T) has a method defined for,
  *   `Fit<U, FeatureType> _fit_impl(const std::vector<FeatureType>&,
@@ -51,17 +53,15 @@ struct is_valid_fit_type<Fit<FitParameter>> : public std::true_type {};
  */
 template <typename T, typename FeatureType> class has_valid_fit {
   template <typename C,
-            typename FitType = decltype(std::declval<const C>()._fit_impl(
-                std::declval<const std::vector<FeatureType> &>(),
-                std::declval<const MarginalDistribution &>()))>
+            typename FitType = typename class_method__fit_impl_traits<
+                C, const std::vector<FeatureType> &,
+                const MarginalDistribution &>::return_type>
   static typename is_valid_fit_type<FitType>::type test(C *);
   template <typename> static std::false_type test(...);
 
 public:
   static constexpr bool value = decltype(test<T>(0))::value;
 };
-
-DEFINE_CLASS_METHOD_TRAITS(_fit_impl);
 
 template <typename T, typename FeatureType>
 class has_possible_fit : public has__fit_impl<T, std::vector<FeatureType> &,

--- a/include/albatross/src/core/traits.hpp
+++ b/include/albatross/src/core/traits.hpp
@@ -43,8 +43,6 @@ struct is_valid_fit_type : public std::false_type {};
 template <typename FitParameter>
 struct is_valid_fit_type<Fit<FitParameter>> : public std::true_type {};
 
-DEFINE_CLASS_METHOD_TRAITS(_fit_impl);
-
 /*
  * This determines whether or not a class (T) has a method defined for,
  *   `Fit<U, FeatureType> _fit_impl(const std::vector<FeatureType>&,
@@ -53,15 +51,17 @@ DEFINE_CLASS_METHOD_TRAITS(_fit_impl);
  */
 template <typename T, typename FeatureType> class has_valid_fit {
   template <typename C,
-            typename FitType = typename class_method__fit_impl_traits<
-                C, const std::vector<FeatureType> &,
-                const MarginalDistribution &>::return_type>
+            typename FitType = decltype(std::declval<const C>()._fit_impl(
+                std::declval<const std::vector<FeatureType> &>(),
+                std::declval<const MarginalDistribution &>()))>
   static typename is_valid_fit_type<FitType>::type test(C *);
   template <typename> static std::false_type test(...);
 
 public:
   static constexpr bool value = decltype(test<T>(0))::value;
 };
+
+DEFINE_CLASS_METHOD_TRAITS(_fit_impl);
 
 template <typename T, typename FeatureType>
 class has_possible_fit : public has__fit_impl<T, std::vector<FeatureType> &,

--- a/include/albatross/src/details/traits.hpp
+++ b/include/albatross/src/details/traits.hpp
@@ -162,6 +162,35 @@ struct variant_size<variant<Ts...>>
     : public std::tuple_size<std::tuple<Ts...>> {};
 
 /*
+ * Eigen helpers
+ */
+template <typename T> class is_eigen_plain_object {
+  template <typename C>
+  static typename std::enable_if<
+      std::is_base_of<Eigen::PlainObjectBase<C>, C>::value,
+      std::true_type>::type
+  test(int);
+
+  template <typename C> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+template <typename T> class is_eigen_xpr {
+  template <
+      typename C,
+      typename BaseType = typename Eigen::internal::dense_xpr_base<C>::type,
+      std::enable_if_t<!is_eigen_plain_object<C>::value, int> = 0>
+  static std::true_type test(int);
+
+  template <typename C> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+/*
  * invocable and invoke result
  *
  * both copied from the possible implementation provided here:

--- a/include/albatross/src/details/traits.hpp
+++ b/include/albatross/src/details/traits.hpp
@@ -178,10 +178,13 @@ public:
 };
 
 template <typename T> class is_eigen_xpr {
-  template <
-      typename C,
-      typename BaseType = typename Eigen::internal::dense_xpr_base<C>::type,
-      std::enable_if_t<!is_eigen_plain_object<C>::value, int> = 0>
+  // Here we check if T is a generic eigen expression, but we then
+  // want to rule out cases where T is a plain_object such as
+  // an Eigen::MatrixXd.
+  template <typename C,
+            typename IsGenericXpr =
+                typename Eigen::internal::generic_xpr_base<C>::type,
+            std::enable_if_t<!is_eigen_plain_object<C>::value, int> = 0>
   static std::true_type test(int);
 
   template <typename C> static std::false_type test(...);

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -78,6 +78,8 @@ public:
 
   std::pair<KeyType, ValueType> first_group() const { return *map_.begin(); }
 
+  ValueType first_value() const { return map_.begin()->first; }
+
   auto min_value() const {
     const auto value_compare = [](const auto &x, const auto &y) {
       return x.second < y.second;
@@ -244,6 +246,17 @@ public:
     }
     return output;
   }
+};
+
+template <typename KeyType, typename EigenXpr>
+class Grouped<KeyType, EigenXpr,
+              std::enable_if_t<is_eigen_xpr<EigenXpr>::value>>
+    : public GroupedBase<KeyType, EigenXpr> {
+  static_assert(
+      delay_static_assert<EigenXpr>::value,
+      "Storing the result of Eigen operations is dangerous since they often "
+      "contain references which can easily lose scope, consider explicitly "
+      "forming an Eigen::MatrixXd (or similar) as the value type");
 };
 
 template <typename KeyType>

--- a/include/albatross/src/indexing/traits.hpp
+++ b/include/albatross/src/indexing/traits.hpp
@@ -61,27 +61,26 @@ struct grouper_result
     : public invoke_result<GrouperFunction,
                            typename const_ref<ValueType>::type> {};
 
-template <typename GrouperFunction, typename ValueType>
-class group_key_is_valid {
+template <typename GroupKey> class group_key_is_valid {
 
-  template <
-      typename C,
-      typename std::enable_if_t<
-          is_valid_map_key<typename grouper_result<C, ValueType>::type>::value,
-          int> = 0>
+  template <typename C, std::enable_if_t<is_valid_map_key<C>::value, int> = 0>
   static std::true_type test(C *);
   template <typename> static std::false_type test(...);
 
 public:
-  static constexpr bool value = decltype(test<GrouperFunction>(0))::value;
+  static constexpr bool value = decltype(test<GroupKey>(0))::value;
 };
 
 template <typename GrouperFunction, typename ValueType>
 struct is_valid_grouper {
 
+private:
+  using GroupKey = typename grouper_result<GrouperFunction, ValueType>::type;
+
+public:
   static constexpr bool value =
       is_invocable_const_ref<GrouperFunction, ValueType>::value &&
-      group_key_is_valid<GrouperFunction, ValueType>::value;
+      group_key_is_valid<GroupKey>::value;
 };
 
 /*

--- a/include/albatross/src/indexing/traits.hpp
+++ b/include/albatross/src/indexing/traits.hpp
@@ -71,16 +71,20 @@ public:
   static constexpr bool value = decltype(test<GroupKey>(0))::value;
 };
 
-template <typename GrouperFunction, typename ValueType>
-struct is_valid_grouper {
+template <typename GrouperFunction, typename ValueType> class is_valid_grouper {
 
-private:
-  using GroupKey = typename grouper_result<GrouperFunction, ValueType>::type;
+  template <
+      typename C,
+      typename GroupKey = typename grouper_result<C, ValueType>::type,
+      typename std::enable_if<is_invocable_const_ref<C, ValueType>::value &&
+                                  group_key_is_valid<GroupKey>::value,
+                              int>::type = 0>
+  static std::true_type test(C *);
+  template <typename> static std::false_type test(...);
 
 public:
-  static constexpr bool value =
-      is_invocable_const_ref<GrouperFunction, ValueType>::value &&
-      group_key_is_valid<GroupKey>::value;
+  static constexpr bool value = decltype(test<GrouperFunction>(0))::value;
+  ;
 };
 
 /*

--- a/tests/test_traits_core.cc
+++ b/tests/test_traits_core.cc
@@ -308,9 +308,33 @@ public:
 
 class HasNoName {};
 
-TEST(test_traits_covariance, test_has_name) {
+TEST(test_traits_core, test_has_name) {
   EXPECT_TRUE(bool(has_name<HasName>::value));
   EXPECT_FALSE(bool(has_name<HasNoName>::value));
+}
+
+TEST(test_traits_core, test_eigen_plain_objects) {
+  EXPECT_TRUE(bool(is_eigen_plain_object<Eigen::MatrixXd>::value));
+  EXPECT_FALSE(bool(is_eigen_xpr<Eigen::MatrixXd>::value));
+
+  EXPECT_TRUE(bool(is_eigen_plain_object<Eigen::VectorXd>::value));
+  EXPECT_FALSE(bool(is_eigen_xpr<Eigen::VectorXd>::value));
+
+  EXPECT_TRUE(bool(is_eigen_plain_object<Eigen::Matrix<int, 3, 4>>::value));
+  EXPECT_FALSE(bool(is_eigen_xpr<Eigen::Matrix<int, 3, 4>>::value));
+}
+
+TEST(test_traits_core, test_eigen_expressions) {
+  Eigen::MatrixXd a;
+  Eigen::MatrixXd b;
+
+  using ProductType = decltype(a * b);
+  EXPECT_FALSE(bool(is_eigen_plain_object<ProductType>::value));
+  EXPECT_TRUE(bool(is_eigen_xpr<ProductType>::value));
+
+  using LDLTType = Eigen::LDLT<Eigen::MatrixXd>;
+  EXPECT_FALSE(bool(is_eigen_plain_object<LDLTType>::value));
+  EXPECT_FALSE(bool(is_eigen_xpr<LDLTType>::value));
 }
 
 } // namespace albatross


### PR DESCRIPTION
This change puts in a safety check to make sure you don't accidentally put an `Eigen` expression into a map.  Doing so can lead to unexpected behavior as things lose scope.

For example, we don't want to do something like:
```
Eigen::MatrixXd lhs = Eigen::MatrixXd::Random(3, 4);
auto product_eval = [&](const Eigen::MatrixXd &rhs) {
    return lhs * rhs;
};

auto product = group_of_matrices.apply(product_eval);
```
The reason is that you may expect the result (`product`) would also contain matrices ... but they'll actually hold something like `Eigen::Product<Eigen::MatrixXd>` objects which hold reference to the objects involved.  As a result if (for example) `lhs` were to lose scope you may get memory access crashes.

To play it safe in these situations you'll need to add `.eval()` to the end of the expression.