### PR TITLE
Patchwork Gaussian Process

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -72,9 +72,24 @@ target_link_libraries(sparse_example
 add_custom_target(run_sparse_example
   DEPENDS sparse_example
   COMMAND sparse_example -input ${PROJECT_SOURCE_DIR}/examples/sinc_input.csv -output ./sinc_predictions.csv
-  COMMENT "Running inspection_example"
+  COMMENT "Running sparse_example"
   )
 
+
+add_executable(patchwork_example
+  patchwork_example.cc
+  )
+target_link_libraries(patchwork_example
+  albatross
+  gflags
+  pthread
+  nlopt
+  )
+add_custom_target(run_patchwork_example
+  DEPENDS patchwork_example
+  COMMAND patchwork_example -input ${PROJECT_SOURCE_DIR}/examples/sinc_input.csv -output ./sinc_predictions.csv
+  COMMENT "Running patchwork_example"
+  )
 
 set(albatross_example_BINARIES
   sinc_example

--- a/examples/patchwork_example.cc
+++ b/examples/patchwork_example.cc
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/Tune>
+
+#include <albatross/PatchworkGP>
+
+#include <csv.h>
+#include <fstream>
+#include <gflags/gflags.h>
+#include <iostream>
+
+#define EXAMPLE_SLOPE_VALUE 0.
+#define EXAMPLE_CONSTANT_VALUE 0.
+
+#include "sinc_example_utils.h"
+
+DEFINE_string(input, "", "path to csv containing input data.");
+DEFINE_string(output, "", "path where predictions will be written in csv.");
+DEFINE_int32(n, 10, "number of training points to use.");
+DEFINE_int32(k, 5, "number of training points to use.");
+DEFINE_bool(tune, false, "a flag indication parameters should be tuned first.");
+
+using albatross::get_tuner;
+using albatross::ParameterStore;
+using albatross::RegressionDataset;
+
+struct PatchworkFunctions {
+
+  double width = 2.;
+
+  long int grouper(const double &x) const { return lround(x / width); }
+
+  std::vector<double> boundary(long int x, long int y) const {
+    if (fabs(x - y) == 1) {
+      double center = width * 0.5 * (x + y);
+      std::vector<double> boundary = {center - 1., center, center + 1.};
+      return boundary;
+    }
+    return {};
+  }
+
+  long int nearest_group(const std::vector<long int> &groups,
+                         const long int &query) const {
+    long int nearest = query;
+    long int nearest_distance = std::numeric_limits<long int>::max();
+    for (const auto &group : groups) {
+      const auto distance = abs(query - group);
+      if (distance < nearest_distance) {
+        nearest = group;
+        nearest_distance = distance;
+      }
+    }
+    return nearest;
+  }
+};
+
+int main(int argc, char *argv[]) {
+
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  int n = FLAGS_n;
+  const double low = -3.;
+  const double high = 13.;
+  const double meas_noise = 0.1;
+
+  if (FLAGS_input == "") {
+    FLAGS_input = "input.csv";
+  }
+  maybe_create_training_data(FLAGS_input, n, low, high, meas_noise);
+
+  using namespace albatross;
+
+  std::cout << "Reading the input data." << std::endl;
+  RegressionDataset<double> data = read_csv_input(FLAGS_input);
+
+  std::cout << "Defining the model." << std::endl;
+  using Noise = IndependentNoise<double>;
+  using SquaredExp = SquaredExponential<EuclideanDistance>;
+
+  Noise noise(meas_noise);
+  SquaredExp squared_exponential(3.5, 5.7);
+  auto cov_func = noise + squared_exponential;
+
+  std::cout << cov_func.pretty_string() << std::endl;
+
+  const auto m = gp_from_covariance(cov_func, "example_model");
+
+  auto fit_to_interval = [&](const auto &dataset) { return m.fit(dataset); };
+
+  PatchworkFunctions patchwork_functions;
+
+  auto grouper = [&](const auto &f) { return patchwork_functions.grouper(f); };
+
+  const auto fit_models = data.group_by(grouper).apply(fit_to_interval);
+
+  const auto patchwork =
+      patchwork_gp_from_covariance(cov_func, patchwork_functions);
+
+  const auto patchwork_fit = patchwork.from_fit_models(fit_models);
+
+  const std::size_t k = 161;
+  auto grid_xs = uniform_points_on_line(k, low - 2., high + 2.);
+  Eigen::VectorXd truth_mean(k);
+  for (Eigen::Index i = 0; i < truth_mean.size(); ++i) {
+    truth_mean[i] = truth(grid_xs[i]);
+  }
+  MarginalDistribution targets(truth_mean);
+  RegressionDataset<double> dataset(grid_xs, targets);
+
+  auto prediction = patchwork_fit.predict(dataset.features).marginal();
+
+  std::ofstream output;
+  output.open(FLAGS_output);
+
+  albatross::write_to_csv(output, dataset, prediction);
+}

--- a/examples/sparse_example.cc
+++ b/examples/sparse_example.cc
@@ -77,7 +77,7 @@ int main(int argc, char *argv[]) {
 
   std::cout << cov.pretty_string() << std::endl;
 
-  LeaveOneOut loo;
+  LeaveOneOutGrouper loo;
   UniformlySpacedInducingPoints strategy(FLAGS_k);
   auto model = sparse_gp_from_covariance(cov, loo, strategy, "example");
   //  auto model = gp_from_covariance(cov, "example");

--- a/include/albatross/PatchworkGP
+++ b/include/albatross/PatchworkGP
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_PATCHWORK_GP_H
+#define ALBATROSS_PATCHWORK_GP_H
+
+#include "GP"
+
+#include <albatross/src/utils/block_utils.hpp>
+#include <albatross/src/utils/eigen_utils.hpp>
+#include <albatross/src/models/patchwork_gp.hpp>
+
+#endif

--- a/include/albatross/PatchworkGP
+++ b/include/albatross/PatchworkGP
@@ -17,6 +17,7 @@
 
 #include <albatross/src/utils/block_utils.hpp>
 #include <albatross/src/utils/eigen_utils.hpp>
+#include <albatross/src/models/patchwork_gp_details.hpp>
 #include <albatross/src/models/patchwork_gp.hpp>
 
 #endif

--- a/include/albatross/src/core/prediction.hpp
+++ b/include/albatross/src/core/prediction.hpp
@@ -192,6 +192,10 @@ public:
 
   std::size_t size() const { return features_.size(); }
 
+  explicit operator JointDistribution() const { return this->joint(); };
+
+  explicit operator MarginalDistribution() const { return this->marginal(); };
+
 private:
   template <typename T> struct get_type {};
 

--- a/include/albatross/src/models/patchwork_gp.hpp
+++ b/include/albatross/src/models/patchwork_gp.hpp
@@ -82,12 +82,17 @@ class patchwork_functions_are_valid {
   static constexpr bool has_valid_boundary =
       is_vector<BoundaryReturnType>::value;
 
-  using NearestGroupReturnType = typename class_method_nearest_group_traits<
-      T, typename const_ref<std::vector<GroupKey>>::type,
-      ConstRefGroupKey>::return_type;
+  template <typename Key, std::enable_if_t<!std::is_void<Key>::value, int> = 0,
+            typename NearestGroupReturnType =
+                typename class_method_nearest_group_traits<
+                    T, typename const_ref<std::vector<Key>>::type,
+                    ConstRefGroupKey>::return_type>
+  static NearestGroupReturnType nearest_group_test(int);
+
+  template <typename C> static void nearest_group_test(...);
 
   static constexpr bool has_valid_nearest_group =
-      std::is_same<NearestGroupReturnType, GroupKey>::value;
+      std::is_same<decltype(nearest_group_test<GroupKey>(0)), GroupKey>::value;
 
 public:
   static constexpr bool value =
@@ -482,7 +487,6 @@ public:
 
     auto group_features = as_group_features(features, predict_grouper);
 
-    std::cout << "C_fb" << std::endl;
     const Eigen::MatrixXd C_fb =
         patchwork_covariance_matrix(group_features, boundary_features);
     const Eigen::MatrixXd C_fb_bb_inv =

--- a/include/albatross/src/models/patchwork_gp.hpp
+++ b/include/albatross/src/models/patchwork_gp.hpp
@@ -234,7 +234,12 @@ public:
     assert(boundary_features.size() > 0);
 
     // The following variable names are meant to approximately match the
-    // notatoin used in Equation 5 (and the following matrices).
+    // notation used in Equation 5 (and the following matrices).  The
+    // subscripts had to be changed.  In particular we've used:
+    //
+    //   d - the data, this is script D in the paper.
+    //   b - the boundaries, this is \del in the paper.
+    //   f - the prediction locations, this is * in the paper.
 
     // C_bb is the covariance matrix between all boundaries, it will
     // have a lot of zeros, so it could be decomposed more efficiently,
@@ -297,15 +302,6 @@ public:
     // information = (C_dd - Cdb C_bb^-1 C_bd)^-1 ys
     const auto information = patchwork_solver_from_v(C_dd, C_db, S_bb_ldlt, vs);
 
-    Eigen::VectorXd C_bb_inv_C_bd_information =
-        Eigen::VectorXd::Zero(C_bb.rows());
-    auto accumulate_C_bb_inv_C_bd_information = [&](const auto &key,
-                                                    const auto &C_bd_i) {
-      C_bb_inv_C_bd_information +=
-          C_bb_ldlt.solve(C_bd_i.transpose() * information.at(key));
-    };
-    C_db.apply(accumulate_C_bb_inv_C_bd_information);
-
     return ReturnType(*this, PatchworkFitType(fit_models, information,
                                               boundary_features, C_dd, C_db,
                                               C_bb_ldlt, S_bb_ldlt));
@@ -351,7 +347,7 @@ public:
     //
     //   prediction = N(m, P - E)
     //
-    // where P is the prior covariance and E the explained covariance.
+    // Where P is the prior covariance and E the explained covariance
     const Eigen::MatrixXd C_fb = patchwork_covariance_matrix(
         group_features, patchwork_fit.boundary_features);
 
@@ -383,6 +379,7 @@ public:
     const Eigen::VectorXd mean =
         block_inner_product(cross_transpose, patchwork_fit.information);
 
+    // This is Equation 7 but split into a few steps.
     const auto patchwork_solve_cross_transpose =
         patchwork_solver(patchwork_fit.C_dd, patchwork_fit.C_db,
                          patchwork_fit.S_bb_ldlt, cross_transpose);

--- a/include/albatross/src/models/patchwork_gp.hpp
+++ b/include/albatross/src/models/patchwork_gp.hpp
@@ -1,0 +1,555 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef INCLUDE_ALBATROSS_MODELS_PATCHWORK_GP_H_
+#define INCLUDE_ALBATROSS_MODELS_PATCHWORK_GP_H_
+
+/*
+ * Patchwork Gaussian Process is based off the paper:
+ *
+ *   Chiwoo Park and Daniel Apley. 2018. Patchwork Kriging for large-scale
+ * Gaussian process regression. J. Mach. Learn. Res. 19, 1 (January 2018),
+ * 269-311.
+ *
+ *   http://www.jmlr.org/papers/volume19/17-042/17-042.pdf
+ *
+ * The implementation requires that you define a class which contains three
+ * methods:
+ *
+ * grouper :
+ *
+ *     GroupKey grouper(const FeatureType &f) const
+ *
+ *   This method should take a FeatureType and return which group it belongs to.
+ *
+ * boundary:
+ *
+ *     std::vector<BoundaryFeature> boundary(const GroupKey &x, const
+ * GroupKey&y) const
+ *
+ *   This method should take two groups and return the features which represent
+ * the boundary between two groups that will be constrained to be equal.
+ *
+ * nearest_group:
+ *
+ *   GroupKey nearest_group(const std::vector<GroupKey> &groups, const GroupKey
+ * &query) const
+ *
+ *   This method is used during prediction and takes a vector of all the
+ * available groups and a query group.  If the query exists it should simply
+ * return the query.  But if the query group doesn't exist is should return the
+ * nearest group.
+ *
+ */
+
+namespace albatross {
+
+namespace details {
+
+DEFINE_CLASS_METHOD_TRAITS(boundary);
+
+DEFINE_CLASS_METHOD_TRAITS(nearest_group);
+
+DEFINE_CLASS_METHOD_TRAITS(grouper);
+
+template <typename T, typename FeatureType>
+class patchwork_functions_are_valid {
+
+  using GroupKey = typename class_method_grouper_traits<
+      T, typename const_ref<FeatureType>::type>::return_type;
+
+  static constexpr bool has_valid_grouper = group_key_is_valid<GroupKey>::value;
+
+  using ConstRefGroupKey = typename const_ref<GroupKey>::type;
+
+  using BoundaryReturnType =
+      typename class_method_boundary_traits<T, ConstRefGroupKey,
+                                            ConstRefGroupKey>::return_type;
+
+  static constexpr bool has_valid_boundary =
+      is_vector<BoundaryReturnType>::value;
+
+  using NearestGroupReturnType = typename class_method_nearest_group_traits<
+      T, typename const_ref<std::vector<GroupKey>>::type,
+      ConstRefGroupKey>::return_type;
+
+  static constexpr bool has_valid_nearest_group =
+      std::is_same<NearestGroupReturnType, GroupKey>::value;
+
+public:
+  static constexpr bool value =
+      has_valid_grouper && has_valid_boundary && has_valid_nearest_group;
+};
+
+} // namespace details
+
+/*
+ * A BoundaryFeature represents a pseudo observation of the difference
+ * between predictions from two different models.  In other words,
+ *
+ *   BoundaryFeature(key_i, key_j, feature)
+ *
+ * represents the quantity
+ *
+ *   model_i.predict(feature) - model_j.predict(feature)
+ *
+ * Patchwork Krigging uses these to force equivalence between two
+ * otherwise independent models.
+ */
+template <typename GroupKey, typename FeatureType> struct BoundaryFeature {
+
+  BoundaryFeature(const GroupKey &lhs_, const GroupKey &rhs_,
+                  const FeatureType &feature_)
+      : lhs(lhs_), rhs(rhs_), feature(feature_){};
+
+  BoundaryFeature(GroupKey &&lhs_, GroupKey &&rhs_, FeatureType &&feature_)
+      : lhs(std::move(lhs_)), rhs(std::move(rhs_)),
+        feature(std::move(feature_)){};
+
+  GroupKey lhs;
+  GroupKey rhs;
+  FeatureType feature;
+};
+
+template <typename GroupKey, typename FeatureType>
+auto as_boundary_feature(GroupKey &&lhs, GroupKey &&rhs,
+                         FeatureType &&feature) {
+  using BoundaryFeatureType =
+      BoundaryFeature<typename std::decay<GroupKey>::type,
+                      typename std::decay<FeatureType>::type>;
+  return BoundaryFeatureType(std::forward<GroupKey>(lhs),
+                             std::forward<GroupKey>(rhs),
+                             std::forward<FeatureType>(feature));
+}
+
+template <typename GroupKey, typename FeatureType>
+auto as_boundary_features(GroupKey &&lhs, GroupKey &&rhs,
+                          const std::vector<FeatureType> &features) {
+  using BoundaryFeatureType =
+      BoundaryFeature<typename std::decay<GroupKey>::type,
+                      typename std::decay<FeatureType>::type>;
+
+  std::vector<BoundaryFeatureType> boundary_features;
+  for (const auto &f : features) {
+    boundary_features.emplace_back(as_boundary_feature(lhs, rhs, f));
+  }
+  return boundary_features;
+}
+
+/*
+ * GroupFeature
+ */
+
+template <typename GroupKey, typename FeatureType> struct GroupFeature {
+
+  GroupFeature(const GroupKey &key_, const FeatureType &feature_)
+      : key(key_), feature(feature_){};
+
+  GroupFeature(GroupKey &&key_, FeatureType &&feature_)
+      : key(std::move(key_)), feature(std::move(feature_)){};
+
+  GroupKey key;
+  FeatureType feature;
+};
+
+template <typename GroupKey, typename FeatureType>
+auto as_group_feature(GroupKey &&key, FeatureType &&feature) {
+  using GroupFeatureType = GroupFeature<typename std::decay<GroupKey>::type,
+                                        typename std::decay<FeatureType>::type>;
+  return GroupFeatureType(std::forward<GroupKey>(key),
+                          std::forward<FeatureType>(feature));
+}
+
+template <typename GrouperFunction, typename FeatureType>
+auto as_group_features(const GroupBy<std::vector<FeatureType>, GrouperFunction>
+                           &grouped_features) {
+
+  using GroupKey =
+      typename GroupBy<std::vector<FeatureType>, GrouperFunction>::KeyType;
+  using GroupFeatureType =
+      GroupFeature<GroupKey, typename std::decay<FeatureType>::type>;
+
+  std::vector<GroupFeatureType> group_features;
+
+  auto emplace_in_output = [&](const auto &key, const auto &features) {
+    for (const auto &f : features) {
+      group_features.emplace_back(as_group_feature(key, f));
+    }
+  };
+  grouped_features.apply(emplace_in_output);
+
+  return group_features;
+}
+
+template <typename GroupKey, typename FeatureType>
+auto as_group_features(const GroupKey &key,
+                       const std::vector<FeatureType> &features) {
+  using GroupFeatureType =
+      GroupFeature<GroupKey, typename std::decay<FeatureType>::type>;
+
+  std::vector<GroupFeatureType> group_features;
+  for (const auto &f : features) {
+    group_features.emplace_back(as_group_feature(key, f));
+  }
+  return group_features;
+}
+
+template <typename SubCaller> struct PatchworkCallerBase {
+  template <
+      typename CovFunc, typename X, typename Y,
+      typename std::enable_if<
+          has_valid_cov_caller<CovFunc, SubCaller, X, Y>::value, int>::type = 0>
+  static double call(const CovFunc &cov_func, const X &x, const Y &y) {
+    return SubCaller::call(cov_func, x, y);
+  }
+
+  template <typename CovFunc, typename GroupKey, typename FeatureTypeX,
+            typename FeatureTypeY>
+  static double call(const CovFunc &cov_func,
+                     const GroupFeature<GroupKey, FeatureTypeX> &x,
+                     const GroupFeature<GroupKey, FeatureTypeY> &y) {
+    if (x.key == y.key) {
+      return SubCaller::call(cov_func, x.feature, y.feature);
+    } else {
+      return 0.;
+    }
+  }
+
+  template <typename CovFunc, typename GroupKey, typename FeatureTypeX,
+            typename FeatureTypeY>
+  static double call(const CovFunc &cov_func,
+                     const GroupFeature<GroupKey, FeatureTypeX> &x,
+                     const BoundaryFeature<GroupKey, FeatureTypeY> &y) {
+    if (x.key == y.lhs) {
+      return SubCaller::call(cov_func, x.feature, y.feature);
+    } else if (x.key == y.rhs) {
+      return -SubCaller::call(cov_func, x.feature, y.feature);
+    } else {
+      return 0.;
+    }
+  }
+
+  template <typename CovFunc, typename GroupKey, typename FeatureTypeX,
+            typename FeatureTypeY>
+  static double call(const CovFunc &cov_func,
+                     const BoundaryFeature<GroupKey, FeatureTypeX> &x,
+                     const BoundaryFeature<GroupKey, FeatureTypeY> &y) {
+
+    if (x.lhs == y.lhs && x.rhs == y.rhs) {
+      return 2 * SubCaller::call(cov_func, x.feature, y.feature);
+    } else if (x.lhs == y.lhs && x.rhs != y.rhs) {
+      return SubCaller::call(cov_func, x.feature, y.feature);
+    } else if (x.lhs != y.lhs && x.rhs == y.rhs) {
+      return SubCaller::call(cov_func, x.feature, y.feature);
+    } else if (x.lhs == y.rhs && x.rhs != y.lhs) {
+      return -SubCaller::call(cov_func, x.feature, y.feature);
+    } else if (x.lhs != y.rhs && x.rhs == y.lhs) {
+      return -SubCaller::call(cov_func, x.feature, y.feature);
+    } else {
+      return 0.;
+    }
+  }
+};
+
+// The PatchworkCaller tries symmetric versions of the PatchworkCallerBase
+// and otherwise resorts to the DefaultCaller
+using PatchworkCaller =
+    internal::SymmetricCaller<PatchworkCallerBase<DefaultCaller>>;
+
+template <typename FitModelType, typename GroupKey> struct PatchworkGPFit {};
+
+template <typename ModelType, typename FitType, typename GroupKey>
+struct Fit<PatchworkGPFit<FitModel<ModelType, FitType>, GroupKey>> {
+
+  using FeatureType = typename FitType::Feature;
+
+  Grouped<GroupKey, FitModel<ModelType, FitType>> fit_models;
+
+  //  Eigen::MatrixXd C_bb_inv_C_bd;
+  //  Grouped<GroupKey, Eigen::VectorXd> information;
+  //  PatchworkFunctions patchwork_functions;
+  //  using GroupKey = typename
+  //  details::grouper_result<PatchworkFunctions::GrouperFunction,
+  //                                                    FeatureType>::type;
+
+  Fit(){};
+
+  Fit(const Grouped<GroupKey, FitModel<ModelType, FitType>> &fit_models_)
+      : fit_models(fit_models_){};
+
+  Fit(const Grouped<GroupKey, FitModel<ModelType, FitType>> &&fit_models_)
+      : fit_models(std::move(fit_models_)){};
+};
+
+template <typename BoundaryFunction, typename GroupKey>
+auto build_boundary_features(const BoundaryFunction &boundary_function,
+                             const std::vector<GroupKey> &groups) {
+  using BoundarySubFeatureType =
+      typename invoke_result<BoundaryFunction, GroupKey,
+                             GroupKey>::type::value_type;
+  using BoundaryFeatureType = BoundaryFeature<GroupKey, BoundarySubFeatureType>;
+
+  std::vector<BoundaryFeatureType> boundary_features;
+  for (std::size_t i = 0; i < groups.size(); ++i) {
+    for (std::size_t j = i + 1; j < groups.size(); ++j) {
+      const auto next_boundary_features = as_boundary_features(
+          groups[i], groups[j], boundary_function(groups[i], groups[j]));
+      if (next_boundary_features.size() > 0) {
+        boundary_features.insert(boundary_features.end(),
+                                 next_boundary_features.begin(),
+                                 next_boundary_features.end());
+      }
+    }
+  }
+  assert(boundary_features.size() > 0);
+  return boundary_features;
+}
+
+template <typename CovFunc, typename PatchworkFunctions>
+class PatchworkGaussianProcess
+    : public GaussianProcessBase<
+          CovFunc, PatchworkGaussianProcess<CovFunc, PatchworkFunctions>> {
+
+public:
+  using Base = GaussianProcessBase<
+      CovFunc, PatchworkGaussianProcess<CovFunc, PatchworkFunctions>>;
+
+  PatchworkGaussianProcess() : Base(){};
+  PatchworkGaussianProcess(CovFunc &covariance_function)
+      : Base(covariance_function){};
+  PatchworkGaussianProcess(CovFunc &covariance_function,
+                           PatchworkFunctions patchwork_functions)
+      : Base(covariance_function), patchwork_functions_(patchwork_functions){};
+
+  template <typename FitModelType, typename GroupKey>
+  auto
+  from_fit_models(const Grouped<GroupKey, FitModelType> &fit_models) const {
+    using PatchworkFitType = Fit<PatchworkGPFit<FitModelType, GroupKey>>;
+    return FitModel<PatchworkGaussianProcess, PatchworkFitType>(
+        *this, PatchworkFitType(fit_models));
+  };
+
+  template <typename FeatureType, typename FitModelType, typename GroupKey>
+  JointDistribution _predict_impl(
+      const std::vector<FeatureType> &features,
+      const Fit<PatchworkGPFit<FitModelType, GroupKey>> &patchwork_fit,
+      PredictTypeIdentity<JointDistribution> &&) const {
+
+    const auto fit_models = patchwork_fit.fit_models;
+
+    if (fit_models.size() == 1) {
+      return fit_models.values()[0].predict(features).joint();
+    }
+
+    auto get_obs_vector = [](const auto &fit_model) {
+      // TOOD: should these be converted to Measurement<> types?
+      return fit_model.predict(fit_model.get_fit().train_features).mean();
+    };
+    const auto obs_vectors = patchwork_fit.fit_models.apply(get_obs_vector);
+
+    auto boundary_function = [&](const GroupKey &x, const GroupKey &y) {
+      return patchwork_functions_.boundary(x, y);
+    };
+
+    const auto boundary_features =
+        build_boundary_features(boundary_function, fit_models.keys());
+
+    auto patchwork_caller = [&](const auto &x, const auto &y) {
+      return PatchworkCaller::call(this->covariance_function_, x, y);
+    };
+
+    auto patchwork_covariance_matrix = [&](const auto &xs, const auto &ys) {
+      return compute_covariance_matrix(patchwork_caller, xs, ys);
+    };
+
+    // C_bb is the covariance matrix between all boundaries, it will
+    // have a lot of zeros so could be decomposed more efficiently
+    const Eigen::MatrixXd C_bb =
+        patchwork_covariance_matrix(boundary_features, boundary_features);
+    const auto C_bb_ldlt = C_bb.ldlt();
+
+    // C_dd is the large block diagonal matrix, with one block for each model
+    // or which we already have an efficient way of computing the inverse.
+    auto get_train_covariance = [](const auto &fit_model) {
+      return fit_model.get_fit().train_covariance;
+    };
+    const auto C_dd = fit_models.apply(get_train_covariance);
+
+    auto get_features = [](const auto &fit_model) {
+      return fit_model.get_fit().train_features;
+    };
+
+    // C_db holds the covariance between each model and all boundaries.
+    // The actual storage is effectively a map with values which correspond
+    // to the covariance between that model's features and the boundaries.
+    auto C_db_one_group = [&](const auto &key, const auto &fit_model) {
+      const auto group_features =
+          as_group_features(key, get_features(fit_model));
+      return patchwork_covariance_matrix(group_features, boundary_features);
+    };
+    const auto C_db = fit_models.apply(C_db_one_group);
+    const auto C_dd_inv_C_db = block_diag_solve(C_dd, C_db);
+
+    //    S_bb = C_bb - C_db * C_dd^-1 * C_db
+    const Eigen::MatrixXd S_bb =
+        C_bb - block_inner_product(C_db, C_dd_inv_C_db);
+    const auto S_bb_ldlt = S_bb.ldlt();
+
+    auto solver = [&](const auto &rhs) {
+      // A^-1 rhs + A^-1 C (B - C^T A^-1 C)^-1 C^T A^-1 rhs
+      // A^-1 rhs + A^-1 C S^-1 C^T A^-1 rhs
+
+      // A = C_dd
+      // B = C_bb
+      // C = C_db
+      // S = S_bb = (B - C^T A^-1 C)
+      const auto Ai_rhs = block_diag_solve(C_dd, rhs);
+
+      // S_bb^-1 C^T A^-1 rhs
+      auto SiCtAi_rhs_block = [&](const Eigen::MatrixXd &C_db_i,
+                                  const auto &Ai_rhs_i) {
+        return Eigen::MatrixXd(S_bb_ldlt.solve(C_db_i.transpose() * Ai_rhs_i));
+      };
+      const Eigen::MatrixXd SiCtAi_rhs =
+          block_accumulate(C_db, Ai_rhs, SiCtAi_rhs_block);
+
+      auto product_with_SiCtAi_rhs = [&](const auto &key, const auto &C_db_i) {
+        return Eigen::MatrixXd(C_db_i * SiCtAi_rhs);
+      };
+      const auto CSiCtAi_rhs = C_db.apply(product_with_SiCtAi_rhs);
+
+      auto output = block_diag_solve(C_dd, CSiCtAi_rhs);
+      // Adds A^-1 rhs to A^-1 C S^-1 C^T A^-1 rhs
+      auto add_Ai_rhs = [&](const auto &key, const auto &group) {
+        return (group + Ai_rhs.at(key)).eval();
+      };
+      return output.apply(add_Ai_rhs);
+    };
+
+    const auto ys = fit_models.apply(get_obs_vector);
+    const auto information = solver(ys);
+
+    Eigen::VectorXd C_bb_inv_C_bd_information =
+        Eigen::VectorXd::Zero(C_bb.rows());
+    auto accumulate_C_bb_inv_C_bd_information = [&](const auto &key,
+                                                    const auto &C_bd_i) {
+      C_bb_inv_C_bd_information +=
+          C_bb_ldlt.solve(C_bd_i.transpose() * information.at(key));
+    };
+    C_db.apply(accumulate_C_bb_inv_C_bd_information);
+
+    /*
+     * PREDICT
+     */
+
+    auto predict_grouper = [&](const auto &f) {
+      return patchwork_functions_.nearest_group(
+          C_db.keys(), patchwork_functions_.grouper(f));
+    };
+
+    const auto grouped = group_by(features, predict_grouper);
+    const auto group_features = as_group_features(grouped);
+
+    const Eigen::MatrixXd C_fb =
+        patchwork_covariance_matrix(group_features, boundary_features);
+    const auto C_fb_bb_inv = C_bb_ldlt.solve(C_fb.transpose()).transpose();
+
+    auto compute_cross_block_transpose = [&](const auto &key,
+                                             const auto &fit_model) {
+      const auto train_features =
+          as_group_features(key, get_features(fit_model));
+      Eigen::MatrixXd block =
+          patchwork_covariance_matrix(train_features, group_features);
+      block -= C_db.at(key) * C_fb_bb_inv.transpose();
+      return block;
+    };
+
+    const auto cross_transpose =
+        fit_models.apply(compute_cross_block_transpose);
+    const auto C_dd_inv_cross = solver(cross_transpose);
+
+    const Eigen::VectorXd mean =
+        block_inner_product(cross_transpose, information);
+    const Eigen::MatrixXd explained =
+        block_inner_product(cross_transpose, C_dd_inv_cross);
+
+    const Eigen::MatrixXd cov =
+        patchwork_covariance_matrix(group_features, group_features) -
+        C_fb_bb_inv * C_fb.transpose() - explained;
+
+    return JointDistribution(mean, cov);
+  }
+
+  template <typename FeatureType>
+  auto _fit_impl(const std::vector<FeatureType> &features,
+                 const MarginalDistribution &targets) const {
+
+    static_assert(details::patchwork_functions_are_valid<PatchworkFunctions,
+                                                         FeatureType>::value,
+                  "Invalid PatchworkFunctions for this FeatureType");
+
+    const auto m = gp_from_covariance(this->covariance_function_, "internal");
+
+    auto create_fit_model = [&](const auto &dataset) { return m.fit(dataset); };
+
+    const RegressionDataset<FeatureType> dataset(features, targets);
+
+    auto grouper = [&](const auto &f) {
+      return patchwork_functions_.grouper(f);
+    };
+
+    const auto fit_models = dataset.group_by(grouper).apply(create_fit_model);
+
+    return from_fit_models(fit_models).get_fit();
+  }
+
+  struct PatchworkFunctionsWithMeasurement {
+
+    PatchworkFunctionsWithMeasurement(PatchworkFunctions functions)
+        : functions_(functions) {}
+
+    template <typename X> auto grouper(const X &x) const {
+      return functions_.grouper(x);
+    }
+
+    template <typename X> auto grouper(const Measurement<X> &x) const {
+      return functions_.grouper(x.value);
+    }
+
+    template <typename GroupKey>
+    auto boundary(const GroupKey &x, const GroupKey &y) const {
+      return functions_.boundary(x, y);
+    }
+
+    template <typename GroupKey>
+    auto nearest_group(const std::vector<GroupKey> &groups,
+                       const GroupKey &query) const {
+      return functions_.nearest_group(groups, query);
+    }
+
+    PatchworkFunctions functions_;
+  };
+
+  PatchworkFunctionsWithMeasurement patchwork_functions_;
+};
+
+template <typename CovFunc, typename PatchworkFunctions>
+inline PatchworkGaussianProcess<CovFunc, PatchworkFunctions>
+patchwork_gp_from_covariance(CovFunc covariance_function,
+                             PatchworkFunctions patchwork_functions) {
+  return PatchworkGaussianProcess<CovFunc, PatchworkFunctions>(
+      covariance_function, patchwork_functions);
+};
+
+} // namespace albatross
+
+#endif /* INCLUDE_ALBATROSS_MODELS_SPARSE_GP_H_ */

--- a/include/albatross/src/models/patchwork_gp.hpp
+++ b/include/albatross/src/models/patchwork_gp.hpp
@@ -22,6 +22,10 @@
  *
  *   http://www.jmlr.org/papers/volume19/17-042/17-042.pdf
  *
+ * This technique works by splitting a problem (which may contain too much
+ * data for a single GP) into tractible sized domains which are then stitched
+ * together by forcing their predictions to be equal along boundaries.
+ *
  * The implementation requires that you define a class which contains three
  * methods:
  *
@@ -53,252 +57,6 @@
 
 namespace albatross {
 
-namespace details {
-
-DEFINE_CLASS_METHOD_TRAITS(boundary);
-
-DEFINE_CLASS_METHOD_TRAITS(nearest_group);
-
-DEFINE_CLASS_METHOD_TRAITS(grouper);
-
-/*
- * Here we make sure that a given class T contains all the required methods
- * to be PatchworkFunctions and that the types involved are consistent.
- */
-template <typename T, typename FeatureType>
-class patchwork_functions_are_valid {
-
-  using GroupKey = typename class_method_grouper_traits<
-      T, typename const_ref<FeatureType>::type>::return_type;
-
-  static constexpr bool has_valid_grouper = group_key_is_valid<GroupKey>::value;
-
-  using ConstRefGroupKey = typename const_ref<GroupKey>::type;
-
-  using BoundaryReturnType =
-      typename class_method_boundary_traits<T, ConstRefGroupKey,
-                                            ConstRefGroupKey>::return_type;
-
-  static constexpr bool has_valid_boundary =
-      is_vector<BoundaryReturnType>::value;
-
-  template <typename Key, std::enable_if_t<!std::is_void<Key>::value, int> = 0,
-            typename NearestGroupReturnType =
-                typename class_method_nearest_group_traits<
-                    T, typename const_ref<std::vector<Key>>::type,
-                    ConstRefGroupKey>::return_type>
-  static NearestGroupReturnType nearest_group_test(int);
-
-  template <typename C> static void nearest_group_test(...);
-
-  static constexpr bool has_valid_nearest_group =
-      std::is_same<decltype(nearest_group_test<GroupKey>(0)), GroupKey>::value;
-
-public:
-  static constexpr bool value =
-      has_valid_grouper && has_valid_boundary && has_valid_nearest_group;
-};
-
-} // namespace details
-
-/*
- * A BoundaryFeature represents a pseudo observation of the difference
- * between predictions from two different models.  In other words,
- *
- *   BoundaryFeature(key_i, key_j, feature)
- *
- * represents the quantity
- *
- *   model_i.predict(feature) - model_j.predict(feature)
- *
- * Patchwork Krigging uses these to force equivalence between two
- * otherwise independent models.  These are the \delta_{k,l} variables
- * in Equation 2 from the paper referenced above.
- */
-template <typename GroupKey, typename FeatureType> struct BoundaryFeature {
-
-  BoundaryFeature(const GroupKey &left_key_, const GroupKey &right_key_,
-                  const FeatureType &feature_)
-      : left_key(left_key_), right_key(right_key_), feature(feature_){};
-
-  BoundaryFeature(GroupKey &&left_key_, GroupKey &&right_key_,
-                  FeatureType &&feature_)
-      : left_key(std::move(left_key_)), right_key(std::move(right_key_)),
-        feature(std::move(feature_)){};
-
-  GroupKey left_key;
-  GroupKey right_key;
-  FeatureType feature;
-};
-
-template <typename GroupKey, typename FeatureType>
-inline auto as_boundary_feature(GroupKey &&left_key, GroupKey &&right_key,
-                                FeatureType &&feature) {
-  using BoundaryFeatureType =
-      BoundaryFeature<typename std::decay<GroupKey>::type,
-                      typename std::decay<FeatureType>::type>;
-  return BoundaryFeatureType(std::forward<GroupKey>(left_key),
-                             std::forward<GroupKey>(right_key),
-                             std::forward<FeatureType>(feature));
-}
-
-template <typename GroupKey, typename FeatureType>
-inline auto as_boundary_features(GroupKey &&left_key, GroupKey &&right_key,
-                                 const std::vector<FeatureType> &features) {
-  using BoundaryFeatureType =
-      BoundaryFeature<typename std::decay<GroupKey>::type,
-                      typename std::decay<FeatureType>::type>;
-
-  std::vector<BoundaryFeatureType> boundary_features;
-  for (const auto &f : features) {
-    boundary_features.emplace_back(as_boundary_feature(left_key, right_key, f));
-  }
-  return boundary_features;
-}
-
-/*
- * GroupFeature
- *
- * This is used to indicate which model a particular Feature corresponds
- * to.  It corresponds (loosely) to the f_i in Equations 3 and 4 from
- * the paper referenced above.
- */
-
-template <typename GroupKey, typename FeatureType> struct GroupFeature {
-
-  GroupFeature() : key(), feature(){};
-
-  GroupFeature(const GroupKey &key_, const FeatureType &feature_)
-      : key(key_), feature(feature_){};
-
-  GroupFeature(GroupKey &&key_, FeatureType &&feature_)
-      : key(std::move(key_)), feature(std::move(feature_)){};
-
-  GroupKey key;
-  FeatureType feature;
-};
-
-template <typename GroupKey, typename FeatureType>
-inline auto as_group_feature(GroupKey &&key, FeatureType &&feature) {
-  using GroupFeatureType = GroupFeature<typename std::decay<GroupKey>::type,
-                                        typename std::decay<FeatureType>::type>;
-  return GroupFeatureType(std::forward<GroupKey>(key),
-                          std::forward<FeatureType>(feature));
-}
-
-template <typename GroupKey, typename FeatureType>
-inline auto as_group_feature(GroupKey &&key,
-                             GroupFeature<GroupKey, FeatureType> &feature) {
-  return feature;
-}
-
-template <typename GrouperFunction, typename FeatureType>
-inline auto as_group_features(const std::vector<FeatureType> &features,
-                              const GrouperFunction &grouper_function) {
-
-  using GroupKey =
-      typename GroupBy<std::vector<FeatureType>, GrouperFunction>::KeyType;
-  using GroupFeatureType =
-      GroupFeature<GroupKey, typename std::decay<FeatureType>::type>;
-
-  std::vector<GroupFeatureType> group_features(features.size());
-
-  auto emplace_in_output = [&](const auto &key, const auto &idx) {
-    for (const auto &i : idx) {
-      group_features[i] = as_group_feature(key, features[i]);
-    }
-  };
-  group_by(features, grouper_function).index_apply(emplace_in_output);
-
-  return group_features;
-}
-
-template <typename GroupKey, typename FeatureType>
-inline auto as_group_features(const GroupKey &key,
-                              const std::vector<FeatureType> &features) {
-  using GroupFeatureType =
-      GroupFeature<GroupKey, typename std::decay<FeatureType>::type>;
-
-  std::vector<GroupFeatureType> group_features;
-  for (const auto &f : features) {
-    group_features.emplace_back(as_group_feature(key, f));
-  }
-  return group_features;
-}
-
-/*
- * Here we define the rules laid out in Equations 3 and 4 of the referenced
- * paper.  The rules consist of defining the covariance between boundary
- * features, group features and in the trivial case two normal features.
- */
-template <typename SubCaller> struct PatchworkCallerBase {
-  template <
-      typename CovFunc, typename X, typename Y,
-      typename std::enable_if<
-          has_valid_cov_caller<CovFunc, SubCaller, X, Y>::value, int>::type = 0>
-  static double call(const CovFunc &cov_func, const X &x, const Y &y) {
-    // The trivial case, forward on to the underlying covariance.
-    return SubCaller::call(cov_func, x, y);
-  }
-
-  template <typename CovFunc, typename GroupKey, typename FeatureTypeX,
-            typename FeatureTypeY>
-  static double call(const CovFunc &cov_func,
-                     const GroupFeature<GroupKey, FeatureTypeX> &x,
-                     const GroupFeature<GroupKey, FeatureTypeY> &y) {
-    // The covariance between any two group features is only defined if
-    // the two are in the same group.
-    if (x.key == y.key) {
-      return SubCaller::call(cov_func, x.feature, y.feature);
-    } else {
-      return 0.;
-    }
-  }
-
-  template <typename CovFunc, typename GroupKey, typename FeatureTypeX,
-            typename FeatureTypeY>
-  static double call(const CovFunc &cov_func,
-                     const GroupFeature<GroupKey, FeatureTypeX> &x,
-                     const BoundaryFeature<GroupKey, FeatureTypeY> &y) {
-    // This is Equation 3 in the referenced paper.
-    if (x.key == y.left_key) {
-      return SubCaller::call(cov_func, x.feature, y.feature);
-    } else if (x.key == y.right_key) {
-      return -SubCaller::call(cov_func, x.feature, y.feature);
-    } else {
-      return 0.;
-    }
-  }
-
-  template <typename CovFunc, typename GroupKey, typename FeatureTypeX,
-            typename FeatureTypeY>
-  static double call(const CovFunc &cov_func,
-                     const BoundaryFeature<GroupKey, FeatureTypeX> &x,
-                     const BoundaryFeature<GroupKey, FeatureTypeY> &y) {
-    // This is Equation 4 in the referenced paper.
-    if (x.left_key == y.left_key && x.right_key == y.right_key) {
-      return 2 * SubCaller::call(cov_func, x.feature, y.feature);
-    } else if (x.left_key == y.right_key && x.right_key == y.left_key) {
-      return -2 * SubCaller::call(cov_func, x.feature, y.feature);
-    } else if (x.left_key == y.left_key && x.right_key != y.right_key) {
-      return SubCaller::call(cov_func, x.feature, y.feature);
-    } else if (x.left_key != y.left_key && x.right_key == y.right_key) {
-      return SubCaller::call(cov_func, x.feature, y.feature);
-    } else if (x.left_key == y.right_key && x.right_key != y.left_key) {
-      return -SubCaller::call(cov_func, x.feature, y.feature);
-    } else if (x.left_key != y.right_key && x.right_key == y.left_key) {
-      return -SubCaller::call(cov_func, x.feature, y.feature);
-    } else {
-      return 0.;
-    }
-  }
-};
-
-// The PatchworkCaller tries symmetric versions of the PatchworkCallerBase
-// and otherwise resorts to the DefaultCaller
-using PatchworkCaller =
-    internal::SymmetricCaller<PatchworkCallerBase<DefaultCaller>>;
-
 template <typename FitModelType, typename GroupKey,
           typename BoundaryFeatureType>
 struct PatchworkGPFit {};
@@ -313,12 +71,16 @@ struct Fit<PatchworkGPFit<FitModel<ModelType, FitType>, GroupKey,
   Grouped<GroupKey, FitModel<ModelType, FitType>> fit_models;
   Grouped<GroupKey, Eigen::MatrixXd> information;
   std::vector<BoundaryFeatureType> boundary_features;
+  // These matrices make up the block elements in Equation 5
   Grouped<GroupKey, CovarianceRepresentation> C_dd;
   Grouped<GroupKey, Eigen::MatrixXd> C_db;
   Eigen::SerializableLDLT C_bb_ldlt;
   Eigen::SerializableLDLT S_bb_ldlt;
 
   Fit(){};
+
+  Fit(const Grouped<GroupKey, FitModel<ModelType, FitType>> &fit_models_)
+      : fit_models(fit_models_){};
 
   Fit(const Grouped<GroupKey, FitModel<ModelType, FitType>> &fit_models_,
       const Grouped<GroupKey, Eigen::MatrixXd> &information_,
@@ -356,12 +118,11 @@ auto build_boundary_features(const BoundaryFunction &boundary_function,
       }
     }
   }
-  assert(boundary_features.size() > 0);
   return boundary_features;
 }
 
 template <typename GroupKey, typename Solver, int Rows, int Cols>
-auto block_solver(
+auto patchwork_solver(
     const Grouped<GroupKey, Solver> &A,
     const Grouped<GroupKey, Eigen::MatrixXd> &C,
     const Eigen::SerializableLDLT &S,
@@ -422,17 +183,24 @@ public:
   auto
   from_fit_models(const Grouped<GroupKey, FitModelType> &fit_models) const {
 
-    auto get_obs_vector = [](const auto &fit_model) {
-      return fit_model.predict(fit_model.get_fit().train_features).mean();
-    };
-    const auto obs_vectors = fit_models.apply(get_obs_vector);
-
     auto boundary_function = [&](const GroupKey &x, const GroupKey &y) {
       return patchwork_functions_.boundary(x, y);
     };
 
     const auto boundary_features =
         build_boundary_features(boundary_function, fit_models.keys());
+
+    using BoundaryFeatureType = typename std::decay<typename decltype(
+        boundary_features)::value_type>::type;
+    using PatchworkFitType =
+        Fit<PatchworkGPFit<FitModelType, GroupKey, BoundaryFeatureType>>;
+    using ReturnType = FitModel<PatchworkGaussianProcess, PatchworkFitType>;
+
+    if (fit_models.size() == 1) {
+      return ReturnType(*this, PatchworkFitType(fit_models));
+    }
+
+    assert(boundary_features.size() > 0);
 
     // C_bb is the covariance matrix between all boundaries, it will
     // have a lot of zeros so it could be decomposed more efficiently
@@ -453,7 +221,8 @@ public:
     auto C_db_one_group = [&](const auto &key, const auto &fit_model) {
       const auto group_features =
           as_group_features(key, fit_model.get_fit().train_features);
-      return patchwork_covariance_matrix(group_features, boundary_features);
+      return this->patchwork_covariance_matrix(group_features,
+                                               boundary_features);
     };
     const auto C_db = fit_models.apply(C_db_one_group);
     const auto C_dd_inv_C_db = block_diag_solve(C_dd, C_db);
@@ -463,8 +232,12 @@ public:
         C_bb - block_inner_product(C_db, C_dd_inv_C_db);
     const auto S_bb_ldlt = S_bb.ldlt();
 
+    auto get_obs_vector = [](const auto &fit_model) {
+      return fit_model.predict(fit_model.get_fit().train_features).mean();
+    };
+
     const auto ys = fit_models.apply(get_obs_vector);
-    const auto information = block_solver(C_dd, C_db, S_bb_ldlt, ys);
+    const auto information = patchwork_solver(C_dd, C_db, S_bb_ldlt, ys);
 
     Eigen::VectorXd C_bb_inv_C_bd_information =
         Eigen::VectorXd::Zero(C_bb.rows());
@@ -475,14 +248,9 @@ public:
     };
     C_db.apply(accumulate_C_bb_inv_C_bd_information);
 
-    using BoundaryFeatureType = typename std::decay<typename decltype(
-        boundary_features)::value_type>::type;
-
-    using PatchworkFitType =
-        Fit<PatchworkGPFit<FitModelType, GroupKey, BoundaryFeatureType>>;
-    return FitModel<PatchworkGaussianProcess, PatchworkFitType>(
-        *this, PatchworkFitType(fit_models, information, boundary_features,
-                                C_dd, C_db, C_bb_ldlt, S_bb_ldlt));
+    return ReturnType(*this, PatchworkFitType(fit_models, information,
+                                              boundary_features, C_dd, C_db,
+                                              C_bb_ldlt, S_bb_ldlt));
   };
 
   template <typename FeatureType, typename FitModelType, typename GroupKey,
@@ -514,7 +282,7 @@ public:
       const auto train_features =
           as_group_features(key, fit_model.get_fit().train_features);
       Eigen::MatrixXd block =
-          patchwork_covariance_matrix(train_features, group_features);
+          this->patchwork_covariance_matrix(train_features, group_features);
       block -= patchwork_fit.C_db.at(key) * C_fb_bb_inv.transpose();
       return block;
     };
@@ -522,8 +290,8 @@ public:
     const auto cross_transpose =
         patchwork_fit.fit_models.apply(compute_cross_block_transpose);
     const auto C_dd_inv_cross =
-        block_solver(patchwork_fit.C_dd, patchwork_fit.C_db,
-                     patchwork_fit.S_bb_ldlt, cross_transpose);
+        patchwork_solver(patchwork_fit.C_dd, patchwork_fit.C_db,
+                         patchwork_fit.S_bb_ldlt, cross_transpose);
 
     const Eigen::VectorXd mean =
         block_inner_product(cross_transpose, patchwork_fit.information);

--- a/include/albatross/src/models/patchwork_gp.hpp
+++ b/include/albatross/src/models/patchwork_gp.hpp
@@ -386,8 +386,8 @@ public:
     const Eigen::MatrixXd explained =
         block_inner_product(cross_transpose, patchwork_solve_cross_transpose);
     const Eigen::MatrixXd cov =
-        patchwork_covariance_matrix(group_features, group_features) -
-        Q.transpose() * C_fb.transpose() - explained;
+        patchwork_covariance_matrix(group_features, group_features) - C_fb * Q -
+        explained;
 
     return JointDistribution(mean, cov);
   }

--- a/include/albatross/src/models/patchwork_gp_details.hpp
+++ b/include/albatross/src/models/patchwork_gp_details.hpp
@@ -133,15 +133,15 @@ inline auto as_boundary_features(GroupKey &&left_group_key,
 
 template <typename GroupKey, typename FeatureType> struct GroupFeature {
 
-  GroupFeature() : key(), feature(){};
+  GroupFeature() : group_key(), feature(){};
 
   GroupFeature(const GroupKey &key_, const FeatureType &feature_)
-      : key(key_), feature(feature_){};
+      : group_key(key_), feature(feature_){};
 
   GroupFeature(GroupKey &&key_, FeatureType &&feature_)
-      : key(std::move(key_)), feature(std::move(feature_)){};
+      : group_key(std::move(key_)), feature(std::move(feature_)){};
 
-  GroupKey key;
+  GroupKey group_key;
   FeatureType feature;
 };
 
@@ -217,7 +217,7 @@ template <typename SubCaller> struct PatchworkCallerBase {
                      const GroupFeature<GroupKey, FeatureTypeY> &y) {
     // The covariance between any two group features is only defined if
     // the two are in the same group.
-    if (x.key == y.key) {
+    if (x.group_key == y.group_key) {
       return SubCaller::call(cov_func, x.feature, y.feature);
     } else {
       return 0.;
@@ -230,9 +230,9 @@ template <typename SubCaller> struct PatchworkCallerBase {
                      const GroupFeature<GroupKey, FeatureTypeX> &x,
                      const BoundaryFeature<GroupKey, FeatureTypeY> &y) {
     // This is Equation 3 in the referenced paper.
-    if (x.key == y.left_group_key) {
+    if (x.group_key == y.left_group_key) {
       return SubCaller::call(cov_func, x.feature, y.feature);
-    } else if (x.key == y.right_group_key) {
+    } else if (x.group_key == y.right_group_key) {
       return -SubCaller::call(cov_func, x.feature, y.feature);
     } else {
       return 0.;

--- a/include/albatross/src/models/patchwork_gp_details.hpp
+++ b/include/albatross/src/models/patchwork_gp_details.hpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_MODELS_PATCHWORK_GP_DETAILS_HPP_
+#define ALBATROSS_MODELS_PATCHWORK_GP_DETAILS_HPP_
+
+namespace albatross {
+
+namespace details {
+
+DEFINE_CLASS_METHOD_TRAITS(boundary);
+
+DEFINE_CLASS_METHOD_TRAITS(nearest_group);
+
+DEFINE_CLASS_METHOD_TRAITS(grouper);
+
+/*
+ * Here we make sure that a given class T contains all the required methods
+ * to be PatchworkFunctions and that the types involved are consistent.
+ */
+template <typename T, typename FeatureType>
+class patchwork_functions_are_valid {
+
+  using GroupKey = typename class_method_grouper_traits<
+      T, typename const_ref<FeatureType>::type>::return_type;
+
+  static constexpr bool has_valid_grouper = group_key_is_valid<GroupKey>::value;
+
+  using ConstRefGroupKey = typename const_ref<GroupKey>::type;
+
+  using BoundaryReturnType =
+      typename class_method_boundary_traits<T, ConstRefGroupKey,
+                                            ConstRefGroupKey>::return_type;
+
+  static constexpr bool has_valid_boundary =
+      is_vector<BoundaryReturnType>::value;
+
+  template <typename Key, std::enable_if_t<!std::is_void<Key>::value, int> = 0,
+            typename NearestGroupReturnType =
+                typename class_method_nearest_group_traits<
+                    T, typename const_ref<std::vector<Key>>::type,
+                    ConstRefGroupKey>::return_type>
+  static NearestGroupReturnType nearest_group_test(int);
+
+  template <typename C> static void nearest_group_test(...);
+
+  static constexpr bool has_valid_nearest_group =
+      std::is_same<decltype(nearest_group_test<GroupKey>(0)), GroupKey>::value;
+
+public:
+  static constexpr bool value =
+      has_valid_grouper && has_valid_boundary && has_valid_nearest_group;
+};
+
+} // namespace details
+
+/*
+ * A BoundaryFeature represents a pseudo observation of the difference
+ * between predictions from two different models.  In other words,
+ *
+ *   BoundaryFeature(key_i, key_j, feature)
+ *
+ * represents the quantity
+ *
+ *   model_i.predict(feature) - model_j.predict(feature)
+ *
+ * Patchwork Krigging uses these to force equivalence between two
+ * otherwise independent models.  These are the \delta_{k,l} variables
+ * in Equation 2 from the paper referenced above.
+ */
+template <typename GroupKey, typename FeatureType> struct BoundaryFeature {
+
+  BoundaryFeature(const GroupKey &left_key_, const GroupKey &right_key_,
+                  const FeatureType &feature_)
+      : left_key(left_key_), right_key(right_key_), feature(feature_){};
+
+  BoundaryFeature(GroupKey &&left_key_, GroupKey &&right_key_,
+                  FeatureType &&feature_)
+      : left_key(std::move(left_key_)), right_key(std::move(right_key_)),
+        feature(std::move(feature_)){};
+
+  GroupKey left_key;
+  GroupKey right_key;
+  FeatureType feature;
+};
+
+template <typename GroupKey, typename FeatureType>
+inline auto as_boundary_feature(GroupKey &&left_key, GroupKey &&right_key,
+                                FeatureType &&feature) {
+  using BoundaryFeatureType =
+      BoundaryFeature<typename std::decay<GroupKey>::type,
+                      typename std::decay<FeatureType>::type>;
+  return BoundaryFeatureType(std::forward<GroupKey>(left_key),
+                             std::forward<GroupKey>(right_key),
+                             std::forward<FeatureType>(feature));
+}
+
+template <typename GroupKey, typename FeatureType>
+inline auto as_boundary_features(GroupKey &&left_key, GroupKey &&right_key,
+                                 const std::vector<FeatureType> &features) {
+  using BoundaryFeatureType =
+      BoundaryFeature<typename std::decay<GroupKey>::type,
+                      typename std::decay<FeatureType>::type>;
+
+  std::vector<BoundaryFeatureType> boundary_features;
+  for (const auto &f : features) {
+    boundary_features.emplace_back(as_boundary_feature(left_key, right_key, f));
+  }
+  return boundary_features;
+}
+
+/*
+ * GroupFeature
+ *
+ * This is used to indicate which model a particular Feature corresponds
+ * to.  It corresponds (loosely) to the f_i in Equations 3 and 4 from
+ * the paper referenced above.
+ */
+
+template <typename GroupKey, typename FeatureType> struct GroupFeature {
+
+  GroupFeature() : key(), feature(){};
+
+  GroupFeature(const GroupKey &key_, const FeatureType &feature_)
+      : key(key_), feature(feature_){};
+
+  GroupFeature(GroupKey &&key_, FeatureType &&feature_)
+      : key(std::move(key_)), feature(std::move(feature_)){};
+
+  GroupKey key;
+  FeatureType feature;
+};
+
+template <typename GroupKey, typename FeatureType>
+inline auto as_group_feature(GroupKey &&key, FeatureType &&feature) {
+  using GroupFeatureType = GroupFeature<typename std::decay<GroupKey>::type,
+                                        typename std::decay<FeatureType>::type>;
+  return GroupFeatureType(std::forward<GroupKey>(key),
+                          std::forward<FeatureType>(feature));
+}
+
+template <typename GroupKey, typename FeatureType>
+inline auto as_group_feature(GroupKey &&key,
+                             GroupFeature<GroupKey, FeatureType> &feature) {
+  return feature;
+}
+
+template <typename GrouperFunction, typename FeatureType>
+inline auto as_group_features(const std::vector<FeatureType> &features,
+                              const GrouperFunction &grouper_function) {
+
+  using GroupKey =
+      typename GroupBy<std::vector<FeatureType>, GrouperFunction>::KeyType;
+  using GroupFeatureType =
+      GroupFeature<GroupKey, typename std::decay<FeatureType>::type>;
+
+  std::vector<GroupFeatureType> group_features(features.size());
+
+  auto emplace_in_output = [&](const auto &key, const auto &idx) {
+    for (const auto &i : idx) {
+      group_features[i] = as_group_feature(key, features[i]);
+    }
+  };
+  group_by(features, grouper_function).index_apply(emplace_in_output);
+
+  return group_features;
+}
+
+template <typename GroupKey, typename FeatureType>
+inline auto as_group_features(const GroupKey &key,
+                              const std::vector<FeatureType> &features) {
+  using GroupFeatureType =
+      GroupFeature<GroupKey, typename std::decay<FeatureType>::type>;
+
+  std::vector<GroupFeatureType> group_features;
+  for (const auto &f : features) {
+    group_features.emplace_back(as_group_feature(key, f));
+  }
+  return group_features;
+}
+
+namespace internal {
+
+/*
+ * Here we define the rules laid out in Equations 3 and 4 of the referenced
+ * paper.  The rules consist of defining the covariance between boundary
+ * features, group features and in the trivial case two normal features.
+ */
+template <typename SubCaller> struct PatchworkCallerBase {
+  template <
+      typename CovFunc, typename X, typename Y,
+      typename std::enable_if<
+          has_valid_cov_caller<CovFunc, SubCaller, X, Y>::value, int>::type = 0>
+  static double call(const CovFunc &cov_func, const X &x, const Y &y) {
+    // The trivial case, forward on to the underlying covariance.
+    return SubCaller::call(cov_func, x, y);
+  }
+
+  template <typename CovFunc, typename GroupKey, typename FeatureTypeX,
+            typename FeatureTypeY>
+  static double call(const CovFunc &cov_func,
+                     const GroupFeature<GroupKey, FeatureTypeX> &x,
+                     const GroupFeature<GroupKey, FeatureTypeY> &y) {
+    // The covariance between any two group features is only defined if
+    // the two are in the same group.
+    if (x.key == y.key) {
+      return SubCaller::call(cov_func, x.feature, y.feature);
+    } else {
+      return 0.;
+    }
+  }
+
+  template <typename CovFunc, typename GroupKey, typename FeatureTypeX,
+            typename FeatureTypeY>
+  static double call(const CovFunc &cov_func,
+                     const GroupFeature<GroupKey, FeatureTypeX> &x,
+                     const BoundaryFeature<GroupKey, FeatureTypeY> &y) {
+    // This is Equation 3 in the referenced paper.
+    if (x.key == y.left_key) {
+      return SubCaller::call(cov_func, x.feature, y.feature);
+    } else if (x.key == y.right_key) {
+      return -SubCaller::call(cov_func, x.feature, y.feature);
+    } else {
+      return 0.;
+    }
+  }
+
+  template <typename CovFunc, typename GroupKey, typename FeatureTypeX,
+            typename FeatureTypeY>
+  static double call(const CovFunc &cov_func,
+                     const BoundaryFeature<GroupKey, FeatureTypeX> &x,
+                     const BoundaryFeature<GroupKey, FeatureTypeY> &y) {
+    // This is Equation 4 in the referenced paper.
+    if (x.left_key == y.left_key && x.right_key == y.right_key) {
+      return 2 * SubCaller::call(cov_func, x.feature, y.feature);
+    } else if (x.left_key == y.right_key && x.right_key == y.left_key) {
+      return -2 * SubCaller::call(cov_func, x.feature, y.feature);
+    } else if (x.left_key == y.left_key && x.right_key != y.right_key) {
+      return SubCaller::call(cov_func, x.feature, y.feature);
+    } else if (x.left_key != y.left_key && x.right_key == y.right_key) {
+      return SubCaller::call(cov_func, x.feature, y.feature);
+    } else if (x.left_key == y.right_key && x.right_key != y.left_key) {
+      return -SubCaller::call(cov_func, x.feature, y.feature);
+    } else if (x.left_key != y.right_key && x.right_key == y.left_key) {
+      return -SubCaller::call(cov_func, x.feature, y.feature);
+    } else {
+      return 0.;
+    }
+  }
+};
+
+} // namespace internal
+
+// The PatchworkCaller tries symmetric versions of the PatchworkCallerBase
+// and otherwise resorts to the DefaultCaller
+using PatchworkCaller =
+    internal::SymmetricCaller<internal::PatchworkCallerBase<DefaultCaller>>;
+
+} // namespace albatross
+
+#endif /* ALBATROSS_MODELS_PATCHWORK_GP_DETAILS_HPP_ */

--- a/include/albatross/src/stats/chi_squared.hpp
+++ b/include/albatross/src/stats/chi_squared.hpp
@@ -30,7 +30,7 @@ inline double chi_squared_cdf_unsafe(double x, std::size_t degrees_of_freedom) {
   return incomplete_gamma(0.5 * degrees_of_freedom, 0.5 * x);
 }
 
-inline double chi_squared_cdf_safe(double x, std::size_t degrees_of_freedom) {
+inline double chi_squared_cdf_safe(double x, double degrees_of_freedom) {
 
   if (std::isnan(x) || x < 0.) {
     return NAN;
@@ -48,12 +48,16 @@ inline double chi_squared_cdf_safe(double x, std::size_t degrees_of_freedom) {
     return 1.;
   }
 
+  if (std::isinf(degrees_of_freedom)) {
+    return 0.;
+  }
+
   return chi_squared_cdf_unsafe(x, degrees_of_freedom);
 }
 
 } // namespace details
 
-inline double chi_squared_cdf(double x, std::size_t degrees_of_freedom) {
+inline double chi_squared_cdf(double x, double degrees_of_freedom) {
   return details::chi_squared_cdf_safe(x, degrees_of_freedom);
 }
 

--- a/include/albatross/src/utils/block_utils.hpp
+++ b/include/albatross/src/utils/block_utils.hpp
@@ -15,6 +15,143 @@
 
 namespace albatross {
 
+/*
+ * One approach to dealing with block linear algebra is to cluster everything
+ * into groups these subsequent methods make those representations easier to
+ * work with.
+ */
+template <typename MatrixType>
+inline Eigen::MatrixXd block_sum(const std::vector<MatrixType> &xs) {
+  MatrixType output = xs[0];
+  for (std::size_t i = 1; i < xs.size(); ++i) {
+    // Eigen internally asserts that the results are the same size.
+    output += xs[i];
+  }
+  return output;
+}
+
+template <typename GroupKey, typename MatrixType>
+inline MatrixType block_sum(const Grouped<GroupKey, MatrixType> &xs) {
+  return block_sum(xs.values());
+}
+
+/*
+ * Patchwork GP works by clustering all the data into groups which
+ * results in several Grouped objects containing block matrix representations.
+ *
+ * These subsequent methods make those representations easier to work with.
+ */
+template <typename GroupKey, typename X, typename Y, typename ApplyFunction>
+inline Eigen::MatrixXd block_accumulate(const Grouped<GroupKey, X> &lhs,
+                                        const Grouped<GroupKey, Y> &rhs,
+                                        const ApplyFunction &apply_function) {
+  // block_accumulate takes two different grouped objects and returns
+  // the sum of that function applied to each pair of values.  Another
+  // way of writing this could be something like:
+  //
+  //   sum_i ( apply_function(lhs.at(key_i), rhs.at(key_i)) )
+  //
+  // The result of apply_function is expected to be an Eigen::MatrixXd
+  static_assert(
+      std::is_same<Eigen::MatrixXd,
+                   typename invoke_result<ApplyFunction, X, Y>::type>::value,
+      "apply_function needs to return an Eigen::MatrixXd type");
+
+  assert(lhs.size() == rhs.size());
+  assert(lhs.size() > 0);
+
+  auto one_group = [&](const auto &key) {
+    assert(map_contains(lhs, key) && map_contains(rhs, key));
+    return apply_function(lhs.at(key), rhs.at(key));
+  };
+
+  return block_sum(apply(lhs.keys(), one_group));
+}
+
+template <typename GroupKey, typename ApplyFunction>
+inline Eigen::MatrixXd
+block_product(const Grouped<GroupKey, Eigen::MatrixXd> &lhs,
+              const Grouped<GroupKey, Eigen::MatrixXd> &rhs) {
+  // This performs a block matrix product operation where if you aligned the
+  // lhs into horizontal blocks and the right into vertical blocks by ordering
+  // their keys:
+  //
+  //   lhs = [x_0, ..., x_n]
+  //   rhs = [y_0, ..., y_n]
+  //
+  // the output corresponds to:
+  //
+  //   lhs * rhs = [x_0, ..., x_2] * [y_0
+  //                                  ...
+  //                                  y_2]
+  //
+  auto matrix_product = [&](const auto &x, const auto &y) {
+    return (x * y).eval();
+  };
+
+  return block_accumulate(lhs, rhs, matrix_product);
+}
+
+template <typename GroupKey>
+inline Eigen::MatrixXd
+block_inner_product(const Grouped<GroupKey, Eigen::MatrixXd> &lhs,
+                    const Grouped<GroupKey, Eigen::MatrixXd> &rhs) {
+  // This performs a block matrix inner product operation where if you aligned
+  // the lhs into horizontal blocks and the right into vertical blocks by
+  // ordering their keys:
+  //
+  //   lhs = [x_0, ..., x_n]
+  //   rhs = [y_0, ..., y_n]
+  //
+  // the output corresponds to:
+  //
+  //   lhs.T * rhs = [x_0.T, ..., x_n.T] * [y_0
+  //                                        ...
+  //                                        y_n]
+  //
+  auto matrix_inner_product = [&](const auto &x, const auto &y) {
+    return (x.transpose() * y).eval();
+  };
+
+  return block_accumulate(lhs, rhs, matrix_inner_product);
+}
+
+template <typename GroupKey, typename Solver, typename Rhs>
+inline auto block_diag_solve(const Grouped<GroupKey, Solver> &lhs,
+                             const Grouped<GroupKey, Rhs> &rhs) {
+  // Here we have the equivalent to a block diagonal matrix solve
+  // in which the inverse of each group in the lhs is applied to
+  // the corresponding group in rhs.
+  //
+  //   lhs = [x_0, ..., x_n]
+  //   rhs = [y_0, ..., y_n]
+  //
+  // the output corresponds to:
+  //
+  //   lhs.T * rhs = [x_0^-1, ..., x_n^-1] * [y_0
+  //                                          ...
+  //                                          y_n]
+  //
+  auto solve_one_block = [&](const auto &key, const auto &x) {
+    return Eigen::MatrixXd(lhs.at(key).solve(x));
+  };
+
+  return rhs.apply(solve_one_block);
+};
+
+template <typename GroupKey>
+inline Grouped<GroupKey, Eigen::MatrixXd>
+block_subtract(const Grouped<GroupKey, Eigen::MatrixXd> &lhs,
+               const Grouped<GroupKey, Eigen::MatrixXd> &rhs) {
+
+  assert(lhs.size() == rhs.size());
+  auto matrix_subtract = [&](const auto &key_i, const auto &rhs_i) {
+    return (lhs.at(key_i) - rhs_i).eval();
+  };
+
+  return rhs.apply(matrix_subtract);
+}
+
 template <typename MatrixType, unsigned int Mode = Eigen::Lower>
 struct BlockTriangularView;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(albatross_unit_tests
   test_model_metrics.cc  
   test_models.cc
   test_parameter_handling_mixin.cc
+  test_patchwork_gp.cc
   test_prediction.cc
   test_radial.cc
   test_random_utils.cc

--- a/tests/test_patchwork_gp.cc
+++ b/tests/test_patchwork_gp.cc
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <gtest/gtest.h>
+
+#include "test_models.h"
+#include <chrono>
+#include <fstream>
+
+#include <albatross/PatchworkGP>
+#include <albatross/utils/CsvUtils>
+
+namespace albatross {
+
+struct ExamplePatchworkFunctions {
+
+  double width = 5.;
+
+  long int grouper(const double &x) const { return lround(floor(x / width)); }
+
+  std::vector<double> boundary(long int x, long int y) const {
+    if (fabs(x - y) == 1) {
+      double center = width * 0.5 * (x + y);
+      std::vector<double> boundary = {center - 1., center, center + 1.};
+      return boundary;
+    }
+    return {};
+  }
+
+  long int nearest_group(const std::vector<long int> &groups,
+                         const long int &query) const {
+    long int nearest = query;
+    long int nearest_distance = std::numeric_limits<long int>::max();
+    for (const auto &group : groups) {
+      const auto distance = abs(query - group);
+      if (distance < nearest_distance) {
+        nearest = group;
+        nearest_distance = distance;
+      }
+    }
+    return nearest;
+  }
+};
+
+template <typename CovFunc>
+void expect_patchwork_gp_performance(const CovFunc &covariance,
+                                     double mean_threshold,
+                                     double cov_threshold) {
+
+  auto dataset = make_toy_linear_data();
+  auto direct = gp_from_covariance(covariance, "direct");
+
+  ExamplePatchworkFunctions patchwork_functions;
+  const auto patchwork =
+      patchwork_gp_from_covariance(covariance, patchwork_functions);
+
+  auto direct_fit = direct.fit(dataset);
+  auto patchwork_fit = patchwork.fit(dataset);
+
+  auto test_features = linspace(0.01, 9.9, 11);
+
+  auto direct_pred = direct_fit.predict(test_features).joint();
+  auto patchwork_pred = patchwork_fit.predict(test_features).joint();
+
+  std::ofstream ofs("test.csv");
+  RegressionDataset<double> direct_dataset(test_features,
+                                           direct_pred.marginal());
+  write_to_csv(ofs, direct_dataset, patchwork_pred.marginal());
+
+  double patchwork_error =
+      root_mean_square_error(patchwork_pred.mean, direct_pred.mean);
+
+  EXPECT_LT(patchwork_error, mean_threshold);
+
+  double patchwork_cov_diff =
+      (patchwork_pred.covariance - direct_pred.covariance).norm();
+
+  EXPECT_LT(patchwork_cov_diff, cov_threshold);
+}
+
+TEST(test_patchwork_gp, test_traits) {
+
+  struct PatchworkTestType {};
+
+  EXPECT_TRUE(
+      bool(details::patchwork_functions_are_valid<ExamplePatchworkFunctions,
+                                                  double>::value));
+  EXPECT_FALSE(
+      bool(details::patchwork_functions_are_valid<ExamplePatchworkFunctions,
+                                                  PatchworkTestType>::value));
+}
+
+TEST(test_patchwork_gp, test_sanity) {
+
+  auto covariance = make_simple_covariance_function();
+
+  covariance.set_param("squared_exponential_length_scale", 1000.);
+  expect_patchwork_gp_performance(covariance, 0.1, 0.3);
+
+  covariance.set_param("squared_exponential_length_scale", 100.);
+  expect_patchwork_gp_performance(covariance, 1e-2, 0.3);
+
+  covariance.set_param("squared_exponential_length_scale", 10.);
+  expect_patchwork_gp_performance(covariance, 5e-2, 0.3);
+}
+
+} // namespace albatross

--- a/tests/test_patchwork_gp.cc
+++ b/tests/test_patchwork_gp.cc
@@ -28,7 +28,7 @@ struct ExamplePatchworkFunctions {
   long int grouper(const double &x) const { return lround(floor(x / width)); }
 
   std::vector<double> boundary(long int x, long int y) const {
-    if (fabs(x - y) == 1) {
+    if (std::abs(x - y) == 1) {
       double center = width * 0.5 * (x + y);
       std::vector<double> boundary = {center - 1., center, center + 1.};
       return boundary;
@@ -41,7 +41,7 @@ struct ExamplePatchworkFunctions {
     long int nearest = query;
     long int nearest_distance = std::numeric_limits<long int>::max();
     for (const auto &group : groups) {
-      const auto distance = abs(query - group);
+      const auto distance = std::abs(query - group);
       if (distance < nearest_distance) {
         nearest = group;
         nearest_distance = distance;


### PR DESCRIPTION
This change adds a new approximation to a Gaussian process in which groups Gaussian processes are "stitched" together using:

>  Chiwoo Park and Daniel Apley. 2018. Patchwork Kriging for large-scale
>  Gaussian process regression. J. Mach. Learn. Res. 19, 1 (January 2018),
>  269-311.
> 
>    http://www.jmlr.org/papers/volume19/17-042/17-042.pdf

Very generally this is done by grouping the input data into smaller domains.  A full GP is fit to each of those domains and predictions from each of those models are forced to agree with each other along boundaries.

As a user you're required to create a `struct` which contains three methods:

 * grouper `GroupKey grouper(const FeatureType &f) const`
This method should take a FeatureType and return which group it belongs to.
 * boundary: `std::vector<BoundaryFeature> boundary(const GroupKey &x, const GroupKey&y) const`
This method should take two groups and return the features which represent the boundary between two groups that will be constrained to be equal.
 * nearest_group `GroupKey nearest_group(const std::vector<GroupKey> &groups, const GroupKey &query) const`
    This method is used during prediction and takes a vector of all the available groups and a query group.  If the query exists it should simply return the query.  But if the query group doesn't exist is should return the nearest group.
