### PR TITLE
Serialization Improvements

### DIFF
--- a/include/albatross/src/cereal/gp.hpp
+++ b/include/albatross/src/cereal/gp.hpp
@@ -14,6 +14,7 @@
 #define ALBATROSS_SRC_CEREAL_GP_HPP_
 
 using albatross::Fit;
+using albatross::GaussianProcessBase;
 using albatross::GPFit;
 
 namespace cereal {
@@ -26,6 +27,26 @@ inline void serialize(Archive &archive,
   archive(cereal::make_nvp("information", fit.information));
   archive(cereal::make_nvp("train_ldlt", fit.train_covariance));
   archive(cereal::make_nvp("train_features", fit.train_features));
+}
+
+template <typename Archive, typename CovFunc, typename ImplType>
+void save(Archive &archive, const GaussianProcessBase<CovFunc, ImplType> &gp,
+          const std::uint32_t) {
+  archive(cereal::make_nvp("name", gp.get_name()));
+  archive(cereal::make_nvp("params", gp.get_params()));
+  archive(cereal::make_nvp("insights", gp.insights));
+}
+
+template <typename Archive, typename CovFunc, typename ImplType>
+void load(Archive &archive, GaussianProcessBase<CovFunc, ImplType> &gp,
+          const std::uint32_t) {
+  std::string model_name;
+  archive(cereal::make_nvp("name", model_name));
+  gp.set_name(model_name);
+  albatross::ParameterStore params;
+  archive(cereal::make_nvp("params", params));
+  gp.set_params(params);
+  archive(cereal::make_nvp("insights", gp.insights));
 }
 
 } // namespace cereal

--- a/include/albatross/src/cereal/variant.hpp
+++ b/include/albatross/src/cereal/variant.hpp
@@ -63,6 +63,10 @@ inline void save(Archive &archive, const variant<VariantTypes...> &f,
                  const std::uint32_t) {
 
   archive(cereal::make_nvp("which", f.which()));
+  f.match([&](const auto &x) {
+    std::string which_typeid = typeid(x).name();
+    archive(cereal::make_nvp("which_typeid", which_typeid));
+  });
   f.match([&archive](const auto &x) { archive(cereal::make_nvp("data", x)); });
 }
 
@@ -71,6 +75,8 @@ inline void load(Archive &archive, variant<VariantTypes...> &v,
                  const std::uint32_t) {
   int which;
   archive(cereal::make_nvp("which", which));
+  std::string which_typeid;
+  archive(cereal::make_nvp("which_typeid", which_typeid));
   assert(which < static_cast<int>(sizeof...(VariantTypes)));
   mapbox_variant_detail::load_variant<0, variant<VariantTypes...>,
                                       VariantTypes...>(archive, which, v);

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -70,6 +70,8 @@ public:
 
   auto find(const KeyType &key) const { return map_.find(key); }
 
+  std::size_t erase(const KeyType &key) { return map_.erase(key); }
+
   std::vector<KeyType> keys() const { return map_keys(map_); }
 
   std::vector<ValueType> values() const { return map_values(map_); }

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -205,6 +205,8 @@ public:
 
   std::string get_name() const { return model_name_; };
 
+  void set_name(const std::string &model_name) { model_name_ = model_name; };
+
   /*
    * The Gaussian Process Regression model derives its parameters from
    * the covariance functions.

--- a/include/albatross/src/models/patchwork_gp.hpp
+++ b/include/albatross/src/models/patchwork_gp.hpp
@@ -417,6 +417,8 @@ public:
 
   struct PatchworkFunctionsWithMeasurement {
 
+    PatchworkFunctionsWithMeasurement(){};
+
     PatchworkFunctionsWithMeasurement(PatchworkFunctions functions)
         : functions_(functions) {}
 

--- a/include/albatross/src/utils/csv_utils.hpp
+++ b/include/albatross/src/utils/csv_utils.hpp
@@ -176,8 +176,12 @@ template <typename FeatureType, typename DistributionType>
 inline std::vector<std::string>
 get_column_names(const RegressionDataset<FeatureType> &dataset,
                  const DistributionBase<DistributionType> &predictions) {
-  const auto first_row = to_map(dataset, predictions, 0);
-  return map_keys(first_row);
+  std::set<std::string> keys;
+  for (std::size_t i = 0; i < dataset.features.size(); ++i) {
+    const auto next_keys = map_keys(to_map(dataset, predictions, i));
+    keys.insert(next_keys.begin(), next_keys.end());
+  }
+  return std::vector<std::string>(keys.begin(), keys.end());
 }
 
 inline void write_row(std::ostream &stream,

--- a/include/albatross/src/utils/variant_utils.hpp
+++ b/include/albatross/src/utils/variant_utils.hpp
@@ -20,7 +20,7 @@ template <typename X> struct ToVariantIdentity {};
 } // namespace details
 
 /*
- * In this case X is a variant which is compatible so we need to
+ * In this case X is a sub variant which is compatible so we need to
  * convert it.
  */
 template <typename... Ts, typename X>
@@ -37,6 +37,14 @@ inline std::enable_if_t<
     !is_variant<X>::value && is_in_variant<X, variant<Ts...>>::value, void>
 set_variant(const X &x, variant<Ts...> *to_set) {
   *to_set = x;
+}
+
+template <typename... Ts, typename X>
+inline std::enable_if_t<
+    !is_variant<X>::value && !is_in_variant<X, variant<Ts...>>::value, void>
+set_variant(const X &x, variant<Ts...> *to_set) {
+  static_assert(delay_static_assert<X>::value,
+                "Incompatible type. X does not belong to variant.");
 }
 
 /*

--- a/tests/test_csv_utils.cc
+++ b/tests/test_csv_utils.cc
@@ -77,12 +77,14 @@ struct TestFeature {
  * try to reassemble the object we wrote to file.
  */
 void read_test_csv(std::istream &stream) {
-  io::CSVReader<12> reader("garbage", stream);
-  reader.read_header(
-      io::ignore_no_column, "bar", "double_or_feature.cereal_class_version",
-      "double_or_feature.data", "double_or_feature.which", "feature.one",
-      "feature.two", "foo", "has_other", "prediction", "prediction_variance",
-      "target", "target_variance");
+  io::CSVReader<16> reader("garbage", stream);
+  reader.read_header(io::ignore_no_column, "bar",
+                     "double_or_feature.cereal_class_version",
+                     "double_or_feature.data.one", "double_or_feature.data.two",
+                     "double_or_feature.data", "double_or_feature.which",
+                     "double_or_feature.which_typeid", "feature.one",
+                     "feature.two", "foo", "has_other", "other", "prediction",
+                     "prediction_variance", "target", "target_variance");
 
   bool more_to_parse = true;
   while (more_to_parse) {
@@ -93,11 +95,16 @@ void read_test_csv(std::istream &stream) {
     TestFeature f;
     int version, which;
     std::string double_or_feature;
+    std::string double_or_feature_one;
+    std::string double_or_feature_two;
+    std::string double_or_feature_which_typeid;
     std::string has_other;
-    more_to_parse =
-        reader.read_row(f.bar, version, double_or_feature, which, f.feature.one,
-                        f.feature.two, f.foo, has_other, prediction,
-                        prediction_variance_str, target, target_variance_str);
+    std::string other;
+    more_to_parse = reader.read_row(
+        f.bar, version, double_or_feature_one, double_or_feature_two,
+        double_or_feature, which, double_or_feature_which_typeid, f.feature.one,
+        f.feature.two, f.foo, has_other, other, prediction,
+        prediction_variance_str, target, target_variance_str);
   }
 }
 
@@ -149,12 +156,14 @@ TEST(test_csv_utils, test_writes_without_predictions) {
  * the CSV were missing columns or had unparsable data.
  */
 void read_test_csv_with_metadata(std::istream &stream) {
-  io::CSVReader<13> reader("garbage", stream);
+  io::CSVReader<17> reader("garbage", stream);
   reader.read_header(
       io::ignore_no_column, "bar", "double_or_feature.cereal_class_version",
-      "double_or_feature.data", "double_or_feature.which", "feature.one",
-      "feature.two", "foo", "has_other", "prediction", "prediction_variance",
-      "target", "target_variance", "time");
+      "double_or_feature.data.one", "double_or_feature.data.two",
+      "double_or_feature.data", "double_or_feature.which",
+      "double_or_feature.which_typeid", "feature.one", "feature.two", "foo",
+      "has_other", "other", "prediction", "prediction_variance", "target",
+      "target_variance", "time");
 
   bool more_to_parse = true;
   while (more_to_parse) {
@@ -166,11 +175,16 @@ void read_test_csv_with_metadata(std::istream &stream) {
     TestFeature f;
     int version, which;
     std::string double_or_feature;
+    std::string double_or_feature_one;
+    std::string double_or_feature_two;
+    std::string double_or_feature_which_typeid;
     std::string has_other;
+    std::string other;
     more_to_parse = reader.read_row(
-        f.bar, version, double_or_feature, which, f.feature.one, f.feature.two,
-        f.foo, has_other, prediction, prediction_variance_str, target,
-        target_variance_str, time);
+        f.bar, version, double_or_feature_one, double_or_feature_two,
+        double_or_feature, which, double_or_feature_which_typeid, f.feature.one,
+        f.feature.two, f.foo, has_other, other, prediction,
+        prediction_variance_str, target, target_variance_str, time);
   }
 }
 

--- a/tests/test_group_by.cc
+++ b/tests/test_group_by.cc
@@ -458,6 +458,26 @@ TEST(test_groupby, test_group_by_get_group) {
   }
 }
 
+TEST(test_groupby, test_group_by_erase) {
+
+  const auto fib = fibonacci(20);
+
+  const auto groups = group_by(fib, number_of_digits).groups();
+
+  auto modified = group_by(fib, number_of_digits).groups();
+  const long int to_remove = 2;
+  modified.erase(to_remove);
+
+  EXPECT_TRUE(map_contains(groups, to_remove));
+  EXPECT_FALSE(map_contains(modified, to_remove));
+
+  for (const auto &pair : groups) {
+    if (pair.first != to_remove) {
+      EXPECT_EQ(pair.second, modified.at(pair.first));
+    }
+  }
+}
+
 template <typename T> inline double test_sum(const std::vector<T> &ts) {
   double output = 0.;
   for (const auto &t : ts) {


### PR DESCRIPTION
This change includes a few modifications which enable:

- Serialization of the model name in Gaussian process models.
- The ability to write variant types to csv.
- Serialization of the variant typeid along with the variant to make inspection easier.