### PR TITLE
Mean Function

### DIFF
--- a/examples/example_utils.h
+++ b/examples/example_utils.h
@@ -27,6 +27,14 @@
 #define EXAMPLE_CONSTANT_VALUE 3.14159
 #endif
 
+#ifndef EXAMPLE_SCALE_VALUE
+#define EXAMPLE_SCALE_VALUE 10.
+#endif
+
+#ifndef EXAMPLE_TRANSLATION_VALUE
+#define EXAMPLE_TRANSLATION_VALUE 3.
+#endif
+
 /*
  * Randomly samples n points between low and high.
  */
@@ -56,12 +64,14 @@ std::vector<double> uniform_points_on_line(const std::size_t n,
   return xs;
 };
 
+double sinc(double x) { return x == 0 ? 1. : sin(x) / x; }
+
 /*
  * The noise free function we're attempting to estimate.
  */
 double truth(double x) {
-  double sinx_x = x == 0 ? 1. : sin(x) / x;
-  return x * EXAMPLE_SLOPE_VALUE + EXAMPLE_CONSTANT_VALUE + 10. * sinx_x;
+  return x * EXAMPLE_SLOPE_VALUE + EXAMPLE_CONSTANT_VALUE +
+         EXAMPLE_SCALE_VALUE * sinc(x - EXAMPLE_TRANSLATION_VALUE);
 }
 
 /*
@@ -142,7 +152,7 @@ void write_predictions_to_csv(
   output.open(output_path);
 
   const std::size_t k = 161;
-  auto grid_xs = uniform_points_on_line(k, low - 2., high + 2.);
+  auto grid_xs = uniform_points_on_line(k, low - 10., high + 10.);
 
   auto prediction =
       fit_model.predict_with_measurement_noise(grid_xs).marginal();

--- a/examples/sinc_example_utils.h
+++ b/examples/sinc_example_utils.h
@@ -19,21 +19,23 @@
 
 namespace albatross {
 
-class SlopeTerm : public CovarianceFunction<SlopeTerm> {
+class SincFunction : public MeanFunction<SincFunction> {
+
 public:
-  SlopeTerm(double sigma_slope = 0.1) {
-    this->params_["sigma_slope"] = sigma_slope;
-  };
+  ALBATROSS_DECLARE_PARAMS(scale, translation);
 
-  ~SlopeTerm(){};
+  std::string get_name() const { return "sinc"; }
 
-  std::string get_name() const { return "slope_term"; }
+  SincFunction() {
+    scale = {EXAMPLE_SCALE_VALUE, GaussianPrior(1., 1000.)};
+    translation = {EXAMPLE_TRANSLATION_VALUE, GaussianPrior(0., 1000.)};
+  }
 
-  double _call_impl(const double &x, const double &y) const {
-    double sigma_slope = this->params_.at("sigma_slope").value;
-    return sigma_slope * sigma_slope * x * y;
+  double _call_impl(const double &x) const {
+    return scale.value * sinc(x - translation.value);
   }
 };
+
 } // namespace albatross
 
 #endif

--- a/include/albatross/CovarianceFunctions
+++ b/include/albatross/CovarianceFunctions
@@ -24,6 +24,7 @@
 #include <albatross/src/covariance_functions/traits.hpp>
 #include <albatross/src/covariance_functions/callers.hpp>
 #include <albatross/src/covariance_functions/covariance_function.hpp>
+#include <albatross/src/covariance_functions/mean_function.hpp>
 #include <albatross/src/covariance_functions/call_trace.hpp>
 #include <albatross/src/covariance_functions/measurement.hpp>
 #include <albatross/src/covariance_functions/linear_combination.hpp>

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -82,11 +82,28 @@ struct JointDistribution;
 struct MarginalDistribution;
 
 /*
+ * Covariance Functions
+ */
+template <typename X, typename Y> class SumOfCovarianceFunctions;
+
+template <typename X, typename Y> class ProductOfCovarianceFunctions;
+
+template <typename Derived> class CallTrace;
+
+struct ZeroMean;
+
+template <typename X, typename Y> class SumOfMeanFunctions;
+
+template <typename X, typename Y> class ProductOfMeanFunctions;
+
+/*
  * Models
  */
-template <typename CovarianceFunc, typename ImplType> class GaussianProcessBase;
+template <typename CovarianceFunc, typename MeanFunction, typename ImplType>
+class GaussianProcessBase;
 
-template <typename CovarianceFunc> class GaussianProcessRegression;
+template <typename CovarianceFunc, typename MeanFunction = ZeroMean>
+class GaussianProcessRegression;
 
 struct NullLeastSquaresImpl {};
 

--- a/include/albatross/src/core/priors.hpp
+++ b/include/albatross/src/core/priors.hpp
@@ -58,7 +58,9 @@ class PositivePrior : public Prior {
 public:
   double log_pdf(double x) const override { return x > 0. ? 0. : -LARGE_VAL; }
   std::string get_name() const override { return "positive"; };
-  double lower_bound() const override { return 0.; }
+  double lower_bound() const override {
+    return std::numeric_limits<double>::epsilon();
+  }
   double upper_bound() const override { return LARGE_VAL; }
 };
 

--- a/include/albatross/src/covariance_functions/callers.hpp
+++ b/include/albatross/src/covariance_functions/callers.hpp
@@ -43,11 +43,11 @@ inline Eigen::MatrixXd compute_covariance_matrix(CovFuncCaller caller,
                 "caller does not support the required arguments");
   static_assert(is_invocable_with_result<CovFuncCaller, double, X, Y>::value,
                 "caller does not return a double");
-  int m = static_cast<int>(xs.size());
-  int n = static_cast<int>(ys.size());
+  Eigen::Index m = static_cast<Eigen::Index>(xs.size());
+  Eigen::Index n = static_cast<Eigen::Index>(ys.size());
   Eigen::MatrixXd C(m, n);
 
-  int i, j;
+  Eigen::Index i, j;
   std::size_t si, sj;
   for (i = 0; i < m; i++) {
     si = static_cast<std::size_t>(i);
@@ -70,10 +70,10 @@ inline Eigen::MatrixXd compute_covariance_matrix(CovFuncCaller caller,
   static_assert(is_invocable_with_result<CovFuncCaller, double, X, X>::value,
                 "caller does not return a double");
 
-  int n = static_cast<int>(xs.size());
+  Eigen::Index n = static_cast<Eigen::Index>(xs.size());
   Eigen::MatrixXd C(n, n);
 
-  int i, j;
+  Eigen::Index i, j;
   std::size_t si, sj;
   for (i = 0; i < n; i++) {
     si = static_cast<std::size_t>(i);

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -15,12 +15,6 @@
 
 namespace albatross {
 
-template <typename X, typename Y> class SumOfCovarianceFunctions;
-
-template <typename X, typename Y> class ProductOfCovarianceFunctions;
-
-template <typename Derived> class CallTrace;
-
 /*
  * CovarianceFunction is a CRTP base class which can be used in a
  * way similar to a polymorphic abstract class.  For example if

--- a/include/albatross/src/covariance_functions/mean_function.hpp
+++ b/include/albatross/src/covariance_functions/mean_function.hpp
@@ -1,0 +1,303 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_COVARIANCE_FUNCTIONS_MEAN_FUNCTION_H
+#define ALBATROSS_COVARIANCE_FUNCTIONS_MEAN_FUNCTION_H
+
+namespace albatross {
+
+template <typename Derived> class MeanFunction : public ParameterHandlingMixin {
+
+private:
+  // Declaring these private makes it impossible to accidentally do things like:
+  //     class A : public MeanFunction<B> {}
+  // or
+  //     using A = MeanFunction<B>;
+  //
+  // which if unchecked can lead to some very strange behavior.
+  MeanFunction() : ParameterHandlingMixin(){};
+  friend Derived;
+
+public:
+  template <typename X> double call(const X &x) const {
+    return DefaultCaller::call(derived(), x);
+  }
+
+  static_assert(!is_complete<Derived>::value,
+                "\n\nPassing a complete type in as template parameter "
+                "implies you aren't using CRTP.  Implementations "
+                "of a MeanFunction should look something like:\n"
+                "\n\tclass Foo : public MeanFunction<Foo> {"
+                "\n\t\tdouble _call_impl(const X &x, const Y &y) const;"
+                "\n\t\t..."
+                "\n\t}\n");
+
+  template <typename DummyType = Derived,
+            typename std::enable_if<!has_name<DummyType>::value, int>::type = 0>
+  std::string get_name() const {
+    static_assert(std::is_same<DummyType, Derived>::value,
+                  "never do mean_function.get_name<T>()");
+    return typeid(Derived).name();
+  }
+
+  template <typename DummyType = Derived,
+            typename std::enable_if<has_name<DummyType>::value, int>::type = 0>
+  std::string get_name() const {
+    static_assert(std::is_same<DummyType, Derived>::value,
+                  "never do mean_function.get_name<T>()");
+    return derived().name();
+  }
+
+  std::string pretty_string() const {
+    std::ostringstream ss;
+    ss << get_name() << std::endl;
+    ss << ParameterHandlingMixin::pretty_string();
+    return ss.str();
+  }
+
+  template <typename X, typename std::enable_if<
+                            has_valid_caller<Derived, X>::value, int>::type = 0>
+  auto operator()(const X &x) const {
+    return call(x);
+  }
+
+  // Computes the mean vector
+  template <typename X, typename std::enable_if<
+                            has_valid_caller<Derived, X>::value, int>::type = 0>
+  Eigen::VectorXd operator()(const std::vector<X> &xs) const {
+
+    if (std::is_same<Derived, ZeroMean>::value) {
+      Eigen::Index n = static_cast<Eigen::Index>(xs.size());
+      return Eigen::VectorXd::Zero(n);
+    }
+
+    auto caller = [&](const auto &x) { return this->call(x); };
+    return compute_mean_vector(caller, xs);
+  }
+
+  // Adds the mean to a vector
+  template <typename FeatureType>
+  void add_to(const std::vector<FeatureType> &features,
+              Eigen::VectorXd *target) const {
+    if (std::is_same<Derived, ZeroMean>::value) {
+      return;
+    }
+    const Eigen::VectorXd mean = this->operator()(features);
+    assert(mean.size() == target->size());
+    *target += mean;
+  }
+
+  // Removes the mean from a vector.
+  template <typename FeatureType>
+  void remove_from(const std::vector<FeatureType> &features,
+                   Eigen::VectorXd *target) const {
+    if (std::is_same<Derived, ZeroMean>::value) {
+      return;
+    }
+    const Eigen::VectorXd mean = this->operator()(features);
+    assert(mean.size() == target->size());
+    *target -= mean;
+  }
+
+  /*
+   * Stubs to catch the case where a mean function was called
+   * with arguments that aren't supported.
+   */
+  template <typename X, typename std::enable_if<
+                            (!has_valid_caller<Derived, X>::value &&
+                             !has_possible_call_impl<Derived, X>::value),
+                            int>::type = 0>
+  void operator()(const X &x) const
+      ALBATROSS_FAIL(X, "No public method with signature 'double "
+                        "Derived::_call_impl(const X&) const'");
+
+  template <typename X,
+            typename std::enable_if<(!has_valid_caller<Derived, X>::value &&
+                                     has_invalid_call_impl<Derived, X>::value),
+                                    int>::type = 0>
+  void operator()(const X &x) const
+      ALBATROSS_FAIL(X, "Incorrectly defined method 'double "
+                        "Derived::_call_impl(const X&) const'");
+
+  template <typename Other>
+  const SumOfMeanFunctions<Derived, Other>
+  operator+(const MeanFunction<Other> &other) const;
+
+  template <typename Other>
+  const ProductOfMeanFunctions<Derived, Other>
+  operator*(const MeanFunction<Other> &other) const;
+
+  Derived &derived() { return *static_cast<Derived *>(this); }
+
+  const Derived &derived() const { return *static_cast<const Derived *>(this); }
+};
+
+/*
+ * SUM
+ */
+template <class LHS, class RHS>
+class SumOfMeanFunctions : public MeanFunction<SumOfMeanFunctions<LHS, RHS>> {
+public:
+  SumOfMeanFunctions() : lhs_(), rhs_(){};
+
+  SumOfMeanFunctions(const LHS &lhs, const RHS &rhs) : lhs_(lhs), rhs_(rhs){};
+
+  std::string name() const {
+    return "(" + lhs_.get_name() + "+" + rhs_.get_name() + ")";
+  }
+
+  ParameterStore get_params() const {
+    return map_join(lhs_.get_params(), rhs_.get_params());
+  }
+
+  void unchecked_set_param(const ParameterKey &name, const Parameter &param) {
+    if (map_contains(lhs_.get_params(), name)) {
+      lhs_.set_param(name, param);
+    } else {
+      rhs_.set_param(name, param);
+    }
+  }
+
+  /*
+   * If both LHS and RHS have a valid call method for the types X and Y
+   * this will return the sum of the two.
+   */
+  template <typename X,
+            typename std::enable_if<(has_valid_caller<LHS, X>::value &&
+                                     has_valid_caller<RHS, X>::value),
+                                    int>::type = 0>
+  double _call_impl(const X &x) const {
+    return this->lhs_(x) + this->rhs_(x);
+  }
+
+  /*
+   * If only LHS has a valid call method we ignore R.
+   */
+  template <typename X,
+            typename std::enable_if<(has_valid_caller<LHS, X>::value &&
+                                     !has_valid_caller<RHS, X>::value),
+                                    int>::type = 0>
+  double _call_impl(const X &x) const {
+    return this->lhs_(x);
+  }
+
+  /*
+   * If only RHS has a valid call method we ignore L.
+   */
+  template <typename X,
+            typename std::enable_if<(!has_valid_caller<LHS, X>::value &&
+                                     has_valid_caller<RHS, X>::value),
+                                    int>::type = 0>
+  double _call_impl(const X &x) const {
+    return this->rhs_(x);
+  }
+
+protected:
+  LHS lhs_;
+  RHS rhs_;
+};
+
+/*
+ * PRODUCT
+ */
+template <class LHS, class RHS>
+class ProductOfMeanFunctions
+    : public MeanFunction<ProductOfMeanFunctions<LHS, RHS>> {
+public:
+  ProductOfMeanFunctions() : lhs_(), rhs_(){};
+  ProductOfMeanFunctions(const LHS &lhs, const RHS &rhs)
+      : lhs_(lhs), rhs_(rhs) {
+    ProductOfMeanFunctions();
+  };
+
+  std::string name() const {
+    return "(" + lhs_.get_name() + "*" + rhs_.get_name() + ")";
+  }
+
+  ParameterStore get_params() const {
+    return map_join(lhs_.get_params(), rhs_.get_params());
+  }
+
+  void unchecked_set_param(const ParameterKey &name, const Parameter &param) {
+    if (map_contains(lhs_.get_params(), name)) {
+      lhs_.set_param(name, param);
+    } else {
+      rhs_.set_param(name, param);
+    }
+  }
+
+  /*
+   * If both LHS and RHS have a valid call method for the types X and Y
+   * this will return the product of the two.
+   */
+  template <typename X,
+            typename std::enable_if<(has_valid_caller<LHS, X>::value &&
+                                     has_valid_caller<RHS, X>::value),
+                                    int>::type = 0>
+  double _call_impl(const X &x) const {
+    double output = this->lhs_(x);
+    if (output != 0.) {
+      output *= this->rhs_(x);
+    }
+    return output;
+  }
+
+  /*
+   * If only LHS has a valid call method we ignore R.
+   */
+  template <typename X,
+            typename std::enable_if<(has_valid_caller<LHS, X>::value &&
+                                     !has_valid_caller<RHS, X>::value),
+                                    int>::type = 0>
+  double _call_impl(const X &x) const {
+    return this->lhs_(x);
+  }
+
+  /*
+   * If only RHS has a valid call method we ignore L.
+   */
+  template <typename X,
+            typename std::enable_if<(!has_valid_caller<LHS, X>::value &&
+                                     has_valid_caller<RHS, X>::value),
+                                    int>::type = 0>
+  double _call_impl(const X &x) const {
+    return this->rhs_(x);
+  }
+
+protected:
+  LHS lhs_;
+  RHS rhs_;
+  friend class CallTrace<ProductOfMeanFunctions<LHS, RHS>>;
+};
+
+struct ZeroMean : public MeanFunction<ZeroMean> {
+
+  template <typename X> double _call_impl(const X &) const { return 0.; }
+};
+
+template <typename Derived>
+template <typename Other>
+inline const SumOfMeanFunctions<Derived, Other> MeanFunction<Derived>::
+operator+(const MeanFunction<Other> &other) const {
+  return SumOfMeanFunctions<Derived, Other>(derived(), other.derived());
+};
+
+template <typename Derived>
+template <typename Other>
+inline const ProductOfMeanFunctions<Derived, Other> MeanFunction<Derived>::
+operator*(const MeanFunction<Other> &other) const {
+  return ProductOfMeanFunctions<Derived, Other>(derived(), other.derived());
+};
+
+} // namespace albatross
+
+#endif // ALBATROSS_COVARIANCE_FUNCTIONS_MEAN_FUNCTION_H

--- a/include/albatross/src/covariance_functions/noise.hpp
+++ b/include/albatross/src/covariance_functions/noise.hpp
@@ -21,7 +21,7 @@ template <typename Observed>
 class IndependentNoise : public CovarianceFunction<IndependentNoise<Observed>> {
 public:
   IndependentNoise(double sigma_noise = 0.1) {
-    sigma_independent_noise = {sigma_noise, NonNegativePrior()};
+    sigma_independent_noise = {sigma_noise, PositivePrior()};
   };
 
   ALBATROSS_DECLARE_PARAMS(sigma_independent_noise);

--- a/include/albatross/src/covariance_functions/polynomials.hpp
+++ b/include/albatross/src/covariance_functions/polynomials.hpp
@@ -89,6 +89,23 @@ private:
   std::map<int, std::string> param_names_;
 };
 
+class LinearMean : public MeanFunction<LinearMean> {
+
+public:
+  ALBATROSS_DECLARE_PARAMS(slope, offset);
+
+  std::string get_name() const { return "linear"; }
+
+  LinearMean() {
+    slope = {0., GaussianPrior(0., 1000.)};
+    offset = {0., GaussianPrior(0., 1000.)};
+  }
+
+  double _call_impl(const double &x) const {
+    return slope.value * x + offset.value;
+  }
+};
+
 } // namespace albatross
 
 #endif

--- a/include/albatross/src/models/ransac_gp.hpp
+++ b/include/albatross/src/models/ransac_gp.hpp
@@ -154,7 +154,8 @@ template <typename ModelType, typename FeatureType, typename InlierMetric,
           typename GroupKey>
 inline RansacFunctions<FitAndIndices<ModelType, FeatureType>, GroupKey>
 get_gp_ransac_functions(
-    const ModelType &model, const RegressionDataset<FeatureType> &dataset,
+    const ModelType &model,
+    const RegressionDataset<FeatureType> &dataset_with_mean,
     const GroupIndexer<GroupKey> &indexer, const InlierMetric &inlier_metric,
     const ConsensusMetric &consensus_metric,
     const IsValidCandidateMetric &is_valid_candidate_metric) {
@@ -162,6 +163,8 @@ get_gp_ransac_functions(
   static_assert(is_prediction_metric<InlierMetric>::value,
                 "InlierMetric must be an PredictionMetric.");
 
+  RegressionDataset<FeatureType> dataset(dataset_with_mean);
+  model.get_mean().remove_from(dataset.features, &dataset.targets.mean);
   const auto full_cov = model.compute_covariance(dataset.features);
 
   const auto fitter = get_gp_ransac_fitter<ModelType, FeatureType, GroupKey>(

--- a/include/albatross/src/tune/tune.hpp
+++ b/include/albatross/src/tune/tune.hpp
@@ -121,8 +121,8 @@ struct ModelTuner {
     return model.get_params();
   }
 
-  void initialize_optimizer(
-      const nlopt::algorithm &algorithm = nlopt::LN_NELDERMEAD) {
+  void
+  initialize_optimizer(const nlopt::algorithm &algorithm = nlopt::LN_SBPLX) {
     // The various algorithms in nlopt are coded by the first two characters.
     // In this case LN stands for local, gradient free.
     auto tunable_params = model.get_tunable_parameters();

--- a/tests/test_callers.cc
+++ b/tests/test_callers.cc
@@ -23,6 +23,14 @@ template <typename T> using Identity = T;
 template <typename Caller, template <typename T> class XWrapper = Identity,
           template <typename T> class YWrapper = Identity>
 inline void expect_direct_calls_true() {
+
+  EXPECT_TRUE(
+      bool(caller_has_valid_call<Caller, HasMultipleMean, XWrapper<X>>::value));
+  EXPECT_TRUE(
+      bool(caller_has_valid_call<Caller, HasMultipleMean, XWrapper<Y>>::value));
+  EXPECT_TRUE(
+      bool(caller_has_valid_call<Caller, HasMultipleMean, XWrapper<W>>::value));
+
   EXPECT_TRUE(bool(caller_has_valid_call<Caller, HasMultiple, XWrapper<X>,
                                          YWrapper<X>>::value));
   EXPECT_TRUE(bool(caller_has_valid_call<Caller, HasMultiple, XWrapper<X>,
@@ -44,6 +52,13 @@ inline void expect_symmetric_calls_true() {
 template <typename Caller, template <typename T> class XWrapper = Identity,
           template <typename T> class YWrapper = Identity>
 inline void expect_all_calls_false() {
+
+  EXPECT_FALSE(
+      bool(caller_has_valid_call<Caller, HasMultipleMean, XWrapper<Z>>::value));
+
+  EXPECT_FALSE(
+      bool(caller_has_valid_call<Caller, HasMultipleMean, XWrapper<V>>::value));
+
   EXPECT_FALSE(bool(caller_has_valid_call<Caller, HasMultiple, XWrapper<X>,
                                           YWrapper<W>>::value));
   EXPECT_FALSE(bool(caller_has_valid_call<Caller, HasMultiple, XWrapper<Y>,

--- a/tests/test_covariance_utils.h
+++ b/tests/test_covariance_utils.h
@@ -61,6 +61,20 @@ public:
   std::string name_ = "has_multiple";
 };
 
+class HasMultipleMean : public MeanFunction<HasMultiple> {
+public:
+  double _call_impl(const X &) const { return 1.; };
+
+  double _call_impl(const Y &) const { return 3.; };
+
+  double _call_impl(const W &) const { return 7.; };
+
+  // These are all invalid:
+  double _call_impl(const Z &) { return 1.; };
+
+  double _call_impl(V &) const { return 11.; };
+};
+
 class HasPublicCallImpl {
 public:
   double _call_impl(const X &, const Y &) const { return 1.; };

--- a/tests/test_model_adapter.cc
+++ b/tests/test_model_adapter.cc
@@ -17,9 +17,10 @@ namespace albatross {
 
 template <typename CovFunc>
 class TestAdaptedModel
-    : public GaussianProcessBase<CovFunc, TestAdaptedModel<CovFunc>> {
+    : public GaussianProcessBase<CovFunc, ZeroMean, TestAdaptedModel<CovFunc>> {
 public:
-  using Base = GaussianProcessBase<CovFunc, TestAdaptedModel<CovFunc>>;
+  using Base =
+      GaussianProcessBase<CovFunc, ZeroMean, TestAdaptedModel<CovFunc>>;
 
   template <typename FeatureType>
   using FitType = typename Base::template CholeskyFit<FeatureType>;

--- a/tests/test_models.cc
+++ b/tests/test_models.cc
@@ -47,7 +47,7 @@ TYPED_TEST_P(RegressionModelTester, test_predict_variants) {
   expect_predict_variants_consistent(pred);
 }
 
-TYPED_TEST_P(RegressionModelTester, test_currect_derived_type) {
+TYPED_TEST_P(RegressionModelTester, test_correct_derived_type) {
   const auto model = this->test_case.get_model();
   const auto derived = model.derived();
   bool same = std::is_same<decltype(model), decltype(derived)>::value;
@@ -56,7 +56,7 @@ TYPED_TEST_P(RegressionModelTester, test_currect_derived_type) {
 
 REGISTER_TYPED_TEST_CASE_P(RegressionModelTester,
                            test_performs_reasonably_on_linear_data,
-                           test_predict_variants, test_currect_derived_type);
+                           test_predict_variants, test_correct_derived_type);
 
 INSTANTIATE_TYPED_TEST_CASE_P(test_models, RegressionModelTester,
                               ExampleModels);

--- a/tests/test_traits_covariance_functions.cc
+++ b/tests/test_traits_covariance_functions.cc
@@ -126,72 +126,86 @@ TEST(test_traits_covariance_function, test_vector_operator_inspection) {
       has_call_operator<HasMultiple, std::vector<Z>, std::vector<Z>>::value));
 }
 
-TEST(test_traits_covariance_function, test_has_valid_caller_for_all_variants) {
+TEST(test_traits_covariance_function,
+     test_has_valid_cov_caller_for_all_variants) {
 
   // With one type
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<W>>::value));
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<X>>::value));
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<Y>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<W>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<X>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<Y>>::value));
 
   EXPECT_FALSE(
-      bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                             variant<Z>>::value));
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<Z>>::value));
 
   // With two types
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<X, W>>::value));
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<W, X>>::value));
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<X, Y>>::value));
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<Y, X>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<X, W>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<W, X>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<X, Y>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<Y, X>>::value));
 
   EXPECT_FALSE(
-      bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                             variant<X, Z>>::value));
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<X, Z>>::value));
   EXPECT_FALSE(
-      bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                             variant<Z, X>>::value));
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<Z, X>>::value));
   EXPECT_FALSE(
-      bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                             variant<W, Z>>::value));
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<W, Z>>::value));
 
   // With three types
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<W, X, Y>>::value));
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<W, Y, X>>::value));
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<X, W, Y>>::value));
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<X, Y, W>>::value));
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<Y, X, W>>::value));
-  EXPECT_TRUE(bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                                     variant<Y, W, X>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<W, X, Y>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<W, Y, X>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<X, W, Y>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<X, Y, W>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<Y, X, W>>::value));
+  EXPECT_TRUE(
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<Y, W, X>>::value));
 
   EXPECT_FALSE(
-      bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                             variant<X, Y, Z>>::value));
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<X, Y, Z>>::value));
   EXPECT_FALSE(
-      bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                             variant<X, Z, Y>>::value));
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<X, Z, Y>>::value));
   EXPECT_FALSE(
-      bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                             variant<Y, X, Z>>::value));
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<Y, X, Z>>::value));
   EXPECT_FALSE(
-      bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                             variant<Y, Z, X>>::value));
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<Y, Z, X>>::value));
   EXPECT_FALSE(
-      bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                             variant<Z, X, Y>>::value));
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<Z, X, Y>>::value));
   EXPECT_FALSE(
-      bool(has_valid_caller_for_all_variants<HasMultiple, DefaultCaller,
-                                             variant<Z, Y, X>>::value));
+      bool(has_valid_cov_caller_for_all_variants<HasMultiple, DefaultCaller,
+                                                 variant<Z, Y, X>>::value));
 }
 
 TEST(test_traits_covariance_function,


### PR DESCRIPTION
This adds the ability to specify a mean function as well as a covariance function when defining a Gaussian process.

TLDR; using a mean function may be valuable if you want to capture a well observed a priori process as part of the model itself.  For example if you "know" that your data contains a linear trend and are most interested in capturing phenomena which are deviations from that linear trend then using a linear mean could be a good choice.

In most literature Gaussian processes are considered to be zero mean.  To the best of my knowledge this is done because 1) most (all?) mean functions can be turned into an equivalent covariance function 2) most of the computational burden of a GP is in inverting the covariance matrix so the mean function isn't usually the primary concern in literature. 3) you can remove any non-zero mean from the data before fitting a GP.

In practice however there are situations where directly using a mean function is useful.  Take a quadratic function as an example.  A GP with quadratic mean  and arbitrary covariance function, `k`, could be written:
```
gp_with ~ GP(a + b*x + c * x * x, k);
```
This model will have parameters which consist of `a`, `b`, `c` and any params from `k`.  Each of `a`, `b` and `c` can have priors which could also gaussian with associated variances `var_a`, `var_b` and `var_c`.  To determine `a`, `b`, and `c` we would have to use numerical optimization to find the maximum likelihood estimates (or a similar approach)

We could alternatively write a new covariance function and build a new GP:
```
k_quad(x, y) = var_a + var_b * x * y + var_c * x * x * y * y
gp_with_out ~ GP(0, k + k_quad);
```
which should result in very similar predictions, but also has the advantage of having closed form estimates of the quadratic terms along with their uncertainty (which is NOT captured when using the quadratic mean).

So why use the mean directly?  What I've experienced recently is that while packing the quadratic term into a covariance function is much more elegant, it can also lead to some serious numerical round off issues.  Notice the covariance function has terms which are double the order of the equivalent mean function and that the `k_quad` is added to `k`.  If the domain of `x` and `y` get large you can quickly find yourself dealing with extremely large floating point values.