### PR TITLE
MCMC Ensemble Sampling

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -6,7 +6,7 @@ run_tests() {
     # Run the long integration tests in release mode so they're fast.
     cmake -DENABLE_AUTOLINT=ON \
       -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="$C_COMPILER" -DCMAKE_CXX_COMPILER="$CXX_COMPILER" ../
-    make run_albatross_unit_tests run_inspection_example run_sinc_example run_temperature_example -j2
+    make run_albatross_unit_tests run_inspection_example run_sinc_example run_temperature_example run_sampler_example -j2
     cd ..
 }
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,6 +13,21 @@ add_custom_target(run_sinc_example
   COMMENT "Running sinc_example"
   )
 
+add_executable(sampler_example
+  sampler_example.cc
+  )
+target_link_libraries(sampler_example
+  albatross
+  gflags
+  pthread
+  nlopt
+  )
+add_custom_target(run_sampler_example
+  DEPENDS sampler_example
+  COMMAND sampler_example -input ${PROJECT_SOURCE_DIR}/examples/sinc_input.csv -output ./sinc_predictions.csv -tune
+  COMMENT "Running sampler_example"
+  )
+
 
 add_executable(inspection_example
   inspection.cc

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(sampler_example
   )
 add_custom_target(run_sampler_example
   DEPENDS sampler_example
-  COMMAND sampler_example -input ${PROJECT_SOURCE_DIR}/examples/sinc_input.csv -output ./sinc_predictions.csv -tune
+  COMMAND sampler_example -input ${PROJECT_SOURCE_DIR}/examples/sinc_input.csv -output ./sinc_predictions.csv --maxiter 100
   COMMENT "Running sampler_example"
   )
 

--- a/examples/plot_sampler_output.py
+++ b/examples/plot_sampler_output.py
@@ -1,0 +1,101 @@
+import sys
+import argparse
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import corner
+
+from scipy import stats
+
+sns.set_style('darkgrid')
+
+
+def create_parser():
+    p = argparse.ArgumentParser()
+    p.add_argument("input")
+    p.add_argument("--thin", type=int, default=10)
+    p.add_argument("--burn-in", type=int, default=100)
+    return p
+
+
+
+
+
+if __name__ == "__main__":
+
+    p = create_parser()
+    args = p.parse_args()
+
+    df = pd.read_csv(args.input);
+    for k in df.columns:
+        df[k] = df[k].astype('f')
+    df = df.iloc[np.all(np.isfinite(df.values), axis=1)]
+
+    samples = [v for k, v in df.groupby('iteration')]
+    samples = samples[args.burn_in:]
+    samples = samples[::args.thin]
+
+    columns = np.setdiff1d(samples[0].columns, ['iteration', 'log_probability', 'ensemble_index'])
+
+    data = np.vstack([s[columns].values.astype('f') for s in samples])
+    log_p = np.concatenate([s["log_probability"].values for s in samples])
+    log_p = np.ma.masked_array(log_p, mask=~np.isfinite(log_p))
+
+    iteration = np.concatenate([s["iteration"].values for s in samples])
+    good = log_p >= stats.mstats.mquantiles(log_p, [0.1])
+    limits = stats.mstats.mquantiles(data[good], [0.05, 0.95], axis=0).data.T
+
+    def rescale(lim):
+        d = 0.05 * (lim[1] - lim[0])
+        if d == 0.:
+            d = 1e-4
+        return (lim[0] - d, lim[1] + d)
+
+    limits = [rescale(lim) for lim in limits]
+
+    bins = [np.linspace(lim[0], lim[1], 40) for lim in limits]
+
+    k = data.shape[1]
+    fig = plt.figure(figsize=(16, 16))
+
+    if k > 1:
+        grid = plt.GridSpec(k, k, hspace=0.2, wspace=0.2)
+    else:
+        grid = plt.GridSpec(1, 2, hspace=0.2, wspace=0.2)
+
+    for i in range(len(columns)):
+        for j in range(i + 1):
+            ax = fig.add_subplot(grid[i, j], xticklabels=[])
+
+            if i == j:
+                ax.hist(data[:, i], bins=40, color='steelblue')
+            else:
+                ax.hist2d(data[:, j], data[:, i], bins=[bins[j], bins[i]], norm=mcolors.PowerNorm(0.5))
+                ax.set_ylim(limits[i])
+                ax.set_xlim(limits[j])
+            if i == k - 1:
+                ax.set_xlabel(columns[j])
+            if j == 0:
+                ax.set_ylabel(columns[i])
+
+    if k > 1:
+        mid = int(np.ceil(k / 3))
+        ax = fig.add_subplot(grid[:mid, (mid + 1):], xticklabels=[])
+    else:
+        ax = fig.add_subplot(grid[0, 1], xticklabels=[])
+
+    ax.plot(iteration, log_p, '.')
+    ylim = stats.mstats.mquantiles(log_p, [0.01, 1.])
+    ylim_buffer = 0.05 * (ylim[1] - ylim[0])
+    ylim[0] -= ylim_buffer
+    ylim[1] += ylim_buffer
+    ax.set_ylim(ylim)  
+    ax.set_ylabel("log probability")
+    ax.set_xlabel("iterations")  
+    x_ticks = np.linspace(np.min(iteration), np.max(iteration), 11)
+    ax.set_xticks(x_ticks)
+    ax.set_xticklabels(map(lambda x : str(int(x)), x_ticks))
+    plt.show()
+

--- a/examples/sampler_example.cc
+++ b/examples/sampler_example.cc
@@ -104,9 +104,6 @@ int main(int argc, char *argv[]) {
     const SincFunction sinc;
     auto model = gp_from_covariance_and_mean(indep_noise, linear + sinc);
 
-    std::cout << pretty_params(model.get_params()) << std::endl;
-    //    model.set_param_values({});
-
     run_sampler(model, data);
   } else if (FLAGS_mode == "test_gp") {
     /*

--- a/examples/sampler_example.cc
+++ b/examples/sampler_example.cc
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2018 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/Tune>
+#include <csv.h>
+#include <fstream>
+#include <gflags/gflags.h>
+#include <iostream>
+
+#include "sinc_example_utils.h"
+
+#include <albatross/Core>
+#include <albatross/Samplers>
+
+DEFINE_string(input, "", "path to csv containing input data.");
+DEFINE_string(output, "", "path where samples will be written in csv.");
+DEFINE_int32(n, 10, "number of training points to use.");
+DEFINE_int32(maxiter, 1000, "number of iterations.");
+DEFINE_string(mode, "radial", "which modelling approach to use.");
+
+using albatross::ParameterStore;
+using albatross::RegressionDataset;
+
+namespace albatross {
+
+template <typename ModelType, typename FeatureType>
+void run_sampler(const ModelType &model_,
+                 const RegressionDataset<FeatureType> &data) {
+
+  ModelType model(model_);
+
+  albatross::GaussianProcessNegativeLogLikelihood nll;
+  auto tuner = get_tuner(model, nll, data);
+  tuner.optimizer.set_ftol_abs(1e-3);
+  tuner.optimizer.set_ftol_rel(1e-3);
+  tuner.optimizer.set_maxeval(200);
+  model.set_params(tuner.tune());
+
+  std::default_random_engine gen(2012);
+
+  std::size_t max_iterations = static_cast<std::size_t>(FLAGS_maxiter);
+  std::shared_ptr<std::ostream> ostream =
+      std::make_shared<std::ofstream>(FLAGS_output);
+  auto callback = get_csv_writing_callback(model, ostream);
+
+  const std::size_t walkers = 3 * model.get_params().size();
+
+  ensemble_sampler(model, data, walkers, max_iterations, gen, callback);
+}
+
+} // namespace albatross
+
+int main(int argc, char *argv[]) {
+
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  int n = FLAGS_n;
+  const double low = -10.;
+  const double high = 23.;
+  const double meas_noise_sd = 0.1;
+
+  if (FLAGS_input == "") {
+    FLAGS_input = "input.csv";
+  }
+  maybe_create_training_data(FLAGS_input, n, low, high, meas_noise_sd);
+
+  using namespace albatross;
+
+  std::cout << "Reading the input data." << std::endl;
+  RegressionDataset<double> data = read_csv_input(FLAGS_input);
+
+  std::cout << "Defining the model." << std::endl;
+
+  using Noise = IndependentNoise<double>;
+  Noise indep_noise(meas_noise_sd);
+  indep_noise.sigma_independent_noise.prior =
+      PositivePrior(); // LogScaleUniformPrior(1e-3, 1e2);
+
+  if (FLAGS_mode == "radial") {
+    // this approach uses a squared exponential radial function to capture
+    // the function we're estimating using non-parametric techniques
+    //    const Polynomial<1> polynomial(100.);
+    using SquaredExp = SquaredExponential<EuclideanDistance>;
+    const SquaredExp squared_exponential(3.5, 5.7);
+    auto cov = squared_exponential + measurement_only(indep_noise);
+    const LinearMean linear;
+    auto model = gp_from_covariance_and_mean(cov, linear);
+
+    run_sampler(model, data);
+  } else if (FLAGS_mode == "parametric") {
+    // Here we assume we know the "truth" is made up of a linear trend and
+    // a scaled and translated sinc function with added noise and capture
+    // this all through the use of a mean function.
+    const LinearMean linear;
+    const SincFunction sinc;
+    auto model = gp_from_covariance_and_mean(indep_noise, linear + sinc);
+
+    std::cout << pretty_params(model.get_params()) << std::endl;
+    //    model.set_param_values({});
+
+    run_sampler(model, data);
+  } else if (FLAGS_mode == "test_gp") {
+    /*
+     * Create random noisy observations to use as train data.
+     */
+    std::default_random_engine generator;
+    std::normal_distribution<double> noise_distribution(0., meas_noise_sd);
+    std::vector<int> xs(n);
+    Eigen::VectorXd ys(n);
+    for (int i = 0; i < n; i++) {
+      xs[i] = i;
+      double noise = noise_distribution(generator);
+      ys[i] = noise;
+    }
+    const albatross::RegressionDataset<int> data(xs, ys);
+    const auto cov = indep_noise;
+    auto model = gp_from_covariance(cov);
+    run_sampler(model, data);
+  }
+}

--- a/include/albatross/Samplers
+++ b/include/albatross/Samplers
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_SAMPLERS_H
+#define ALBATROSS_SAMPLERS_H
+
+#include <albatross/Indexing>
+#include <albatross/utils/CsvUtils>
+#include <albatross/utils/RandomUtils>
+
+#include <albatross/src/samplers/state.hpp>
+#include <albatross/src/samplers/callbacks.hpp>
+#include <albatross/src/samplers/ensemble.hpp>
+#include <albatross/src/models/mcmc.hpp>
+
+#endif

--- a/include/albatross/Samplers
+++ b/include/albatross/Samplers
@@ -20,6 +20,5 @@
 #include <albatross/src/samplers/state.hpp>
 #include <albatross/src/samplers/callbacks.hpp>
 #include <albatross/src/samplers/ensemble.hpp>
-#include <albatross/src/models/mcmc.hpp>
 
 #endif

--- a/include/albatross/src/cereal/gp.hpp
+++ b/include/albatross/src/cereal/gp.hpp
@@ -29,16 +29,20 @@ inline void serialize(Archive &archive,
   archive(cereal::make_nvp("train_features", fit.train_features));
 }
 
-template <typename Archive, typename CovFunc, typename ImplType>
-void save(Archive &archive, const GaussianProcessBase<CovFunc, ImplType> &gp,
+template <typename Archive, typename CovFunc, typename MeanFunc,
+          typename ImplType>
+void save(Archive &archive,
+          const GaussianProcessBase<CovFunc, MeanFunc, ImplType> &gp,
           const std::uint32_t) {
   archive(cereal::make_nvp("name", gp.get_name()));
   archive(cereal::make_nvp("params", gp.get_params()));
   archive(cereal::make_nvp("insights", gp.insights));
 }
 
-template <typename Archive, typename CovFunc, typename ImplType>
-void load(Archive &archive, GaussianProcessBase<CovFunc, ImplType> &gp,
+template <typename Archive, typename CovFunc, typename MeanFunc,
+          typename ImplType>
+void load(Archive &archive,
+          GaussianProcessBase<CovFunc, MeanFunc, ImplType> &gp,
           const std::uint32_t) {
   std::string model_name;
   archive(cereal::make_nvp("name", model_name));

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -153,6 +153,16 @@ template <typename InlierMetric, typename ConsensusMetric,
 struct GaussianProcessRansacStrategy;
 
 /*
+ * Samplers
+ */
+
+struct SamplerState;
+
+struct NullCallback;
+
+using EnsembleSamplerState = std::vector<SamplerState>;
+
+/*
  * Traits
  */
 

--- a/include/albatross/src/core/priors.hpp
+++ b/include/albatross/src/core/priors.hpp
@@ -88,7 +88,13 @@ public:
   double lower_bound() const override { return lower_; }
   double upper_bound() const override { return upper_; }
 
-  double log_pdf(double) const override { return -log(upper_ - lower_); }
+  double log_pdf(double x) const override {
+    if (x >= lower_ && x <= upper_) {
+      return -log(upper_ - lower_);
+    } else {
+      return -LARGE_VAL;
+    }
+  }
 
   double lower_;
   double upper_;

--- a/include/albatross/src/covariance_functions/noise.hpp
+++ b/include/albatross/src/covariance_functions/noise.hpp
@@ -24,6 +24,9 @@ public:
     sigma_independent_noise = {sigma_noise, PositivePrior()};
   };
 
+  IndependentNoise(const IndependentNoise &other)
+      : sigma_independent_noise(other.sigma_independent_noise){};
+
   ALBATROSS_DECLARE_PARAMS(sigma_independent_noise);
 
   ~IndependentNoise(){};

--- a/include/albatross/src/samplers/callbacks.hpp
+++ b/include/albatross/src/samplers/callbacks.hpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_SAMPLERS_CALLBACKS_HPP_
+#define ALBATROSS_SAMPLERS_CALLBACKS_HPP_
+
+namespace albatross {
+
+struct NullCallback {
+  void operator()(std::size_t, const EnsembleSamplerState &){};
+};
+
+inline std::vector<std::string> get_columns(const ParameterStore &example) {
+  std::vector<std::string> columns;
+  columns.push_back("iteration");
+  columns.push_back("log_probability");
+  columns.push_back("ensemble_index");
+  const auto param_names = map_keys(example);
+  columns.insert(columns.end(), param_names.begin(), param_names.end());
+  return columns;
+}
+
+template <typename ModelType>
+inline void
+write_ensemble_sampler_state(std::ostream &stream, const ModelType &model,
+                             const EnsembleSamplerState &ensemble,
+                             std::size_t iteration,
+                             const std::vector<std::string> &columns) {
+
+  ModelType m;
+  for (std::size_t i = 0; i < ensemble.size(); ++i) {
+    std::map<std::string, std::string> row;
+
+    m.set_tunable_params_values(ensemble[i].params);
+    for (const auto &param : m.get_params()) {
+      row[param.first] = std::to_string(param.second.value);
+    }
+    row["iteration"] = std::to_string(iteration);
+    row["log_probability"] = std::to_string(ensemble[i].log_prob);
+    row["ensemble_index"] = std::to_string(i);
+    write_row(stream, row, columns);
+  }
+}
+
+template <typename ModelType> struct CsvWritingCallback {
+
+  CsvWritingCallback(std::shared_ptr<std::ostream> &stream_)
+      : stream(stream_){};
+
+  CsvWritingCallback(std::shared_ptr<std::ostream> &&stream_)
+      : stream(std::move(stream_)){};
+
+  void operator()(std::size_t iteration,
+                  const EnsembleSamplerState &ensembles) {
+    if (iteration == 0) {
+      columns = get_columns(model.get_params());
+      write_header(*stream, columns);
+    }
+    write_ensemble_sampler_state(*stream, model, ensembles, iteration, columns);
+  }
+
+  ModelType model;
+  std::shared_ptr<std::ostream> stream;
+  std::vector<std::string> columns;
+};
+
+template <typename ModelType>
+CsvWritingCallback<ModelType> get_csv_writing_callback(const ModelType &model,
+                                                       std::string path) {
+  return CsvWritingCallback<ModelType>(std::make_shared<std::ofstream>(path));
+}
+
+template <typename ModelType>
+CsvWritingCallback<ModelType>
+get_csv_writing_callback(const ModelType &model,
+                         std::shared_ptr<std::ostream> &stream) {
+  return CsvWritingCallback<ModelType>(stream);
+}
+
+} // namespace albatross
+
+#endif /* ALBATROSS_SAMPLERS_CALLBACKS_HPP_ */

--- a/include/albatross/src/samplers/ensemble.hpp
+++ b/include/albatross/src/samplers/ensemble.hpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_SRC_SAMPLERS_ENSEMBLE_HPP_
+#define ALBATROSS_SRC_SAMPLERS_ENSEMBLE_HPP_
+
+namespace albatross {
+
+inline auto split_indices(std::size_t n, std::size_t k) {
+  std::vector<std::size_t> inds(n);
+  std::iota(inds.begin(), inds.end(), 0);
+  return group_by(inds, KFoldGrouper(k)).indexers().values();
+}
+
+inline std::size_t random_complement(std::size_t n, std::size_t i,
+                                     std::default_random_engine &gen) {
+  // Draws a random integer between 0 and n - 1 excluding i.
+  assert(n > 1);
+  std::uniform_int_distribution<std::size_t> uniform_int(0, n - 1);
+  std::size_t output;
+  while (true) {
+    output = uniform_int(gen);
+    if (output != i) {
+      return output;
+    }
+  }
+}
+
+template <typename JitterDistribution>
+std::vector<std::vector<double>> initial_params_from_jitter(
+    const ParameterStore &params, JitterDistribution &jitter_distribution,
+    std::default_random_engine &gen, std::size_t n = -1) {
+
+  n = std::max(n, 2 * params.size() + 1);
+
+  std::vector<std::vector<double>> output;
+  std::vector<double> double_params = get_tunable_parameters(params).values;
+  output.push_back(double_params);
+  for (std::size_t i = 0; i < n - 1; ++i) {
+
+    std::vector<double> perturbed(double_params);
+    for (auto &d : perturbed) {
+      d += jitter_distribution(gen);
+    };
+
+    output.push_back(perturbed);
+  }
+  return output;
+}
+
+void assert_valid_states(const EnsembleSamplerState &ensembles) {
+  for (std::size_t i = 0; i < ensembles.size(); ++i) {
+    assert(std::isfinite(ensembles[i].log_prob));
+  }
+}
+
+template <typename ComputeLogProb>
+EnsembleSamplerState stretch_move_step(const EnsembleSamplerState &ensembles,
+                                       ComputeLogProb compute_log_prob,
+                                       std::default_random_engine &gen,
+                                       std::size_t n_splits = 2,
+                                       double a = 2.) {
+
+  const std::size_t n_ensembles = ensembles.size();
+  const std::size_t n_dim = ensembles[0].params.size();
+
+  assert_valid_states(ensembles);
+
+  std::vector<ParameterStore> proposed(n_ensembles);
+  std::vector<double> log_prob_z(n_ensembles);
+
+  std::uniform_real_distribution<double> uniform_real(0.0, 1.0);
+  std::uniform_int_distribution<std::size_t> uniform_int(0, n_ensembles - 1);
+
+  const auto splits = split_indices(n_ensembles, n_splits);
+
+  EnsembleSamplerState next_ensembles(ensembles);
+
+  for (const auto &split : splits) {
+
+    const auto complement = indices_complement(split, n_ensembles);
+    std::uniform_int_distribution<std::size_t> random_complement_idx(
+        0, complement.size() - 1);
+
+    for (const std::size_t &k : split) {
+
+      SamplerState current(next_ensembles[k]);
+      SamplerState proposed(current);
+      proposed.accepted = false;
+
+      // Choose X_j from the complementary ensembles.
+      std::size_t j = complement[random_complement_idx(gen)];
+      // It's possible the sampler will get initialized with non-finite
+      // probabilities, if that happens we want to only pick from the
+      // set which are finite.
+      while (!std::isfinite(next_ensembles[j].log_prob)) {
+        j = complement[random_complement_idx(gen)];
+      }
+
+      // Draw a random z
+      double p = uniform_real(gen);
+      double z = pow((a - 1.0) * p + 1, 2.0) / a;
+      log_prob_z[k] = (n_dim - 1.0) * log(z);
+
+      // proposed = x_j + z * (x_k - x_j)
+      for (std::size_t i = 0; i < n_dim; ++i) {
+        double v_j = next_ensembles[j].params[i];
+        proposed.params[i] = v_j + z * (proposed.params[i] - v_j);
+      }
+
+      proposed.log_prob = compute_log_prob(proposed.params);
+      const double log_diff =
+          log_prob_z[k] + proposed.log_prob - current.log_prob;
+
+      const double random = uniform_real(gen);
+      const bool accepted = log_diff > log(random);
+      const bool is_finite = std::isfinite(proposed.log_prob);
+      if (accepted && is_finite) {
+        proposed.accepted = true;
+        next_ensembles[k] = proposed;
+      } else {
+        next_ensembles[k].accepted = false;
+      }
+    }
+  }
+
+  return next_ensembles;
+}
+
+template <typename ComputeLogProb>
+inline EnsembleSamplerState
+ensure_finite_initial_state(ComputeLogProb &&compute_log_prob,
+                            const EnsembleSamplerState &ensembles,
+                            std::default_random_engine &gen) {
+
+  EnsembleSamplerState output;
+  for (const auto &state : ensembles) {
+    if (std::isfinite(state.log_prob)) {
+      output.push_back(state);
+    }
+  }
+  assert(output.size() > 2 && "Need at least two finite initial states");
+
+  std::uniform_real_distribution<double> uniform_real(0.0, 1.0);
+
+  while (output.size() < ensembles.size()) {
+    const auto random_pair = random_without_replacement(output, 2, gen);
+
+    SamplerState attempt(random_pair[0]);
+    for (std::size_t i = 0; i < attempt.params.size(); ++i) {
+      const auto a = uniform_real(gen);
+      attempt.params[i] += a * (random_pair[1].params[i] - attempt.params[i]);
+    }
+
+    attempt.log_prob = compute_log_prob(attempt.params);
+    if (std::isfinite(attempt.log_prob)) {
+      output.push_back(attempt);
+    }
+  }
+  return output;
+}
+
+template <typename ComputeLogProb, typename CallbackFunc = NullCallback>
+std::vector<EnsembleSamplerState>
+ensemble_sampler(ComputeLogProb &&compute_log_prob,
+                 const EnsembleSamplerState &initial_state,
+                 std::size_t max_iterations, std::default_random_engine &gen,
+                 CallbackFunc &&callback = NullCallback()) {
+
+  EnsembleSamplerState state = ensure_finite_initial_state(
+      std::forward<ComputeLogProb>(compute_log_prob), initial_state, gen);
+
+  std::vector<EnsembleSamplerState> output;
+  output.push_back(state);
+  callback(0, state);
+
+  for (std::size_t iter = 1; iter <= max_iterations; ++iter) {
+    const auto next_state = stretch_move_step<ComputeLogProb>(
+        state, std::forward<ComputeLogProb>(compute_log_prob), gen);
+    output.push_back(next_state);
+    callback(iter, next_state);
+    state = next_state;
+  }
+  return output;
+}
+
+template <typename ComputeLogProb, typename CallbackFunc = NullCallback>
+std::vector<EnsembleSamplerState>
+ensemble_sampler(ComputeLogProb &&compute_log_prob,
+                 const std::vector<std::vector<double>> &params,
+                 std::size_t max_iterations, std::default_random_engine &gen,
+                 CallbackFunc &&callback = NullCallback()) {
+
+  EnsembleSamplerState ensembles;
+  for (const auto &p : params) {
+    SamplerState state = {p, compute_log_prob(p), true};
+    ensembles.push_back(state);
+  }
+
+  return ensemble_sampler(std::forward<ComputeLogProb>(compute_log_prob),
+                          ensembles, max_iterations, gen,
+                          std::forward<CallbackFunc>(callback));
+}
+
+template <typename ModelType, typename FeatureType,
+          typename CallbackFunc = NullCallback>
+std::vector<EnsembleSamplerState> ensemble_sampler(
+    const ModelType &model, const RegressionDataset<FeatureType> &dataset,
+    std::size_t n_walkers, std::size_t max_iterations,
+    std::default_random_engine &gen, CallbackFunc &&callback = NullCallback()) {
+
+  std::normal_distribution<double> jitter(0., 0.1);
+  const auto initial_params =
+      initial_params_from_jitter(model.get_params(), jitter, gen, n_walkers);
+
+  auto compute_ll = [&](const std::vector<double> &param_values) {
+    ModelType m(model);
+    m.set_tunable_params_values(param_values);
+    return m.log_likelihood(dataset);
+  };
+
+  return ensemble_sampler(compute_ll, initial_params, max_iterations, gen,
+                          std::forward<CallbackFunc>(callback));
+}
+
+} // namespace albatross
+
+#endif /* INCLUDE_ALBATROSS_SRC_SAMPLERS_ENSEMBLE_HPP_ */

--- a/include/albatross/src/samplers/state.hpp
+++ b/include/albatross/src/samplers/state.hpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_SAMPLERS_STATE_HPP_
+#define ALBATROSS_SAMPLERS_STATE_HPP_
+
+namespace albatross {
+
+struct SamplerState {
+  std::vector<double> params;
+  double log_prob;
+  bool accepted;
+};
+
+} // namespace albatross
+
+#endif /* ALBATROSS_SAMPLERS_STATE_HPP_ */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(albatross_unit_tests
   test_radial.cc
   test_random_utils.cc
   test_ransac.cc
+  test_samplers.cc
   test_scaling_function.cc
   test_serializable_ldlt.cc
   test_serialize.cc

--- a/tests/test_model_adapter.cc
+++ b/tests/test_model_adapter.cc
@@ -29,11 +29,15 @@ public:
     this->params_["center"] = {1., UniformPrior(-10., 10.)};
   }
 
+  TestAdaptedModel(const TestAdaptedModel &other) : Base(other) {
+    this->params_["center"] = other.get_params()["center"];
+  };
+
   std::vector<double>
   convert(const std::vector<AdaptedFeature> &features) const {
     std::vector<double> converted;
     for (const auto &f : features) {
-      converted.push_back(f.value - this->get_param_value("center"));
+      converted.push_back(f.value - this->params_.at("center").value);
     }
     return converted;
   }

--- a/tests/test_model_metrics.cc
+++ b/tests/test_model_metrics.cc
@@ -28,7 +28,7 @@ public:
  */
 typedef ::testing::Types<LeaveOneOutLikelihood<JointDistribution>,
                          LeaveOneOutLikelihood<MarginalDistribution>,
-                         LeaveOneOutRMSE, GaussianProcessLikelihood>
+                         LeaveOneOutRMSE, GaussianProcessNegativeLogLikelihood>
     MetricsToTest;
 
 TYPED_TEST_CASE(ModelMetricTester, MetricsToTest);

--- a/tests/test_samplers.cc
+++ b/tests/test_samplers.cc
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2019 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <albatross/Core>
+#include <albatross/Samplers>
+
+#include <fstream>
+
+#include "test_models.h"
+
+namespace albatross {
+
+TEST(test_samplers, test_samplers_from_normal_distribution) {
+
+  const double sd = M_PI;
+
+  auto gaussian_ll = [&](const std::vector<double> &xs) {
+    assert(xs.size() == 1);
+    return -0.5 * std::pow(xs[0] / sd, 2.);
+  };
+
+  std::default_random_engine gen(2012);
+  std::size_t walkers = 10;
+
+  std::normal_distribution<double> jitter_distribution(0., 0.1 * sd);
+  std::vector<std::vector<double>> initial_params;
+  for (std::size_t i = 0; i < walkers; ++i) {
+    initial_params.push_back({jitter_distribution(gen)});
+  }
+
+  std::size_t burn_in = 100;
+  std::size_t thin = 10;
+  std::size_t max_iterations = 2000;
+  const auto ensemble_samples =
+      ensemble_sampler(gaussian_ll, initial_params, max_iterations, gen);
+
+  std::vector<double> cdfs;
+  for (std::size_t i = burn_in; i < ensemble_samples.size(); i += thin) {
+    for (const auto &sample : ensemble_samples[i]) {
+      const double value = sample.params[0];
+      const double chi_squared_sample = std::pow(value / sd, 2.);
+      cdfs.push_back(chi_squared_cdf(chi_squared_sample, 1));
+    }
+  }
+
+  EXPECT_LT(*std::min_element(cdfs.begin(), cdfs.end()), 0.1);
+  EXPECT_GT(*std::max_element(cdfs.begin(), cdfs.end()), 0.9);
+  double ks = uniform_ks_test(cdfs);
+  EXPECT_LT(ks, 0.05);
+}
+
+TEST(test_samplers, test_samplers_from_uniform_distribution) {
+
+  auto uniform_ll = [&](const std::vector<double> &xs) {
+    assert(xs.size() == 1);
+    if (xs[0] >= 0. && xs[0] <= 1.) {
+      return 0.;
+    } else {
+      return -LARGE_VAL;
+    }
+  };
+
+  std::default_random_engine gen(2012);
+  std::size_t walkers = 10;
+
+  std::uniform_real_distribution<double> jitter_distribution(0., 1.);
+  std::vector<std::vector<double>> initial_params;
+  for (std::size_t i = 0; i < walkers; ++i) {
+    initial_params.push_back({jitter_distribution(gen)});
+  }
+
+  // Insert some invalid initial parameters to make sure
+  // we properly initialize the sampler.
+  initial_params[0][0] = -1.;
+  initial_params[initial_params.size() - 1][0] = 10.;
+
+  std::size_t burn_in = 100;
+  std::size_t thin = 10;
+  std::size_t max_iterations = 2000;
+  const auto ensemble_samples =
+      ensemble_sampler(uniform_ll, initial_params, max_iterations, gen);
+
+  std::vector<double> cdfs;
+  for (std::size_t i = burn_in; i < ensemble_samples.size(); i += thin) {
+    for (const auto &sample : ensemble_samples[i]) {
+      const double value = sample.params[0];
+      cdfs.push_back(value);
+    }
+  }
+
+  EXPECT_LT(*std::min_element(cdfs.begin(), cdfs.end()), 0.1);
+  EXPECT_GT(*std::max_element(cdfs.begin(), cdfs.end()), 0.9);
+  double ks = uniform_ks_test(cdfs);
+  EXPECT_LT(ks, 0.05);
+}
+
+TEST(test_samplers, test_samplers_gp) {
+  const double a = 3.14;
+  const double b = sqrt(2.);
+  const double meas_noise_sd = 1.;
+  const auto dataset = make_toy_linear_data(a, b, meas_noise_sd, 10);
+
+  std::default_random_engine gen(2012);
+  const std::size_t walkers = 10;
+
+  using Noise = IndependentNoise<double>;
+  Noise indep_noise(meas_noise_sd);
+  indep_noise.sigma_independent_noise.prior = LogScaleUniformPrior(1e-3, 1e2);
+  LinearMean linear;
+
+  auto model = gp_from_covariance_and_mean(indep_noise, linear);
+
+  std::size_t max_iterations = 100;
+
+  std::shared_ptr<std::ostringstream> oss =
+      std::make_shared<std::ostringstream>();
+  std::shared_ptr<std::ostream> ostream =
+      static_cast<std::shared_ptr<std::ostream>>(oss);
+
+  auto callback = get_csv_writing_callback(model, ostream);
+
+  const auto ensemble_samples =
+      ensemble_sampler(model, dataset, walkers, max_iterations, gen, callback);
+
+  assert(oss->str().size() > 1);
+}
+
+} // namespace albatross


### PR DESCRIPTION
This PR adds an Affine invariant Bayesian sampler to allow for full Bayesian inference of model parameters using Monte Carlo Markov Chains.

It's heavily based on the original paper [Ensemble samplers with affine invariance. Jonathan Goodman and Jonathan Weare](https://msp.org/camcos/2010/5-1/p04.xhtml) and the python implementation in [emcee](https://arxiv.org/abs/1202.3665).

Why use this instead of tuning?
- Tuning will find you the maximum likelihood parameters but doesn't give you information about correlation between parameters which may be valuable for understanding how a model works.  If, for example, you found that two parameters were very heavily correlated you might want to reformulate the parameterization, or may realize that some part of the model isn't even adding much value.
- While Gaussian processes are capable of capturing uncertainty, that is rarely the whole picture.  To get a more complete picture of a model's uncertainty it's best to integrate over the parameters.

Here's an example made by running:
```
make sampler_example && ./examples/sampler_example -input ./input.csv -output ./output.csv -n 50 -maxiter 5000 && python ../examples/plot_sampler_output.py ./output.csv
```
![mcmc](https://user-images.githubusercontent.com/514053/71755825-66c28f00-2e41-11ea-93e7-8b15f911ec66.png)
This shows the distribution of parameters from 5000 iterations of MCMC.  The plotting utility could use a little more love, but by looking at the off diagonal blocks you can see the clear presence of correlations between some of the parameters in the model.