### PR TITLE
Variant Serialization Backward Compatibility

### DIFF
--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -382,4 +382,29 @@ REGISTER_TYPED_TEST_CASE_P(RegressionModelTester, test_model_serializes,
 INSTANTIATE_TYPED_TEST_CASE_P(test_serialize, RegressionModelTester,
                               ExampleModels);
 
+TEST(test_serialize, test_variant_version_1_backward_compatibility) {
+
+  int one = 1;
+  variant<int, double> foo = one;
+
+  // Serialize it using version 0
+  std::ostringstream os;
+  {
+    cereal::JSONOutputArchive oarchive(os);
+    save(oarchive, foo, 0);
+  }
+  std::cout << os.str() << std::endl;
+
+  // Deserialize it.
+  std::istringstream is(os.str());
+  variant<int, double> deserialized;
+  {
+    cereal::JSONInputArchive iarchive(is);
+    load(iarchive, deserialized, 0);
+  }
+  // Make sure the original and deserialized representations are
+  // equivalent.
+  EXPECT_TRUE(foo == deserialized);
+}
+
 } // namespace albatross

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -382,8 +382,7 @@ REGISTER_TYPED_TEST_CASE_P(RegressionModelTester, test_model_serializes,
 INSTANTIATE_TYPED_TEST_CASE_P(test_serialize, RegressionModelTester,
                               ExampleModels);
 
-TEST(test_serialize, test_variant_version_1_backward_compatibility) {
-
+TEST(test_serialize, test_variant_version_0) {
   int one = 1;
   variant<int, double> foo = one;
 


### PR DESCRIPTION
Make sure we can deserialize old GP models where `name` wasn't serialized as well as old variant versions where `which_typeid` wasn't included.