### PR TITLE
Sparse GP Likelihood

### DIFF
--- a/examples/plot_sampler_output.py
+++ b/examples/plot_sampler_output.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
 
     limits = [rescale(lim) for lim in limits]
 
-    bins = [np.linspace(lim[0], lim[1], 40) for lim in limits]
+    bins = [np.linspace(lim[0], lim[1], 20) for lim in limits]
 
     k = data.shape[1]
     fig = plt.figure(figsize=(16, 16))
@@ -67,7 +67,12 @@ if __name__ == "__main__":
 
     for i in range(len(columns)):
         for j in range(i + 1):
-            ax = fig.add_subplot(grid[i, j], xticklabels=[])
+            if i == j or i == len(columns) - 1:
+                ax_kwdargs = {}
+            else:
+                ax_kwdargs = {"xticks": []}
+
+            ax = fig.add_subplot(grid[i, j], **ax_kwdargs)
 
             if i == j:
                 ax.hist(data[:, i], bins=40, color='steelblue')

--- a/include/albatross/src/eigen/serializable_ldlt.hpp
+++ b/include/albatross/src/eigen/serializable_ldlt.hpp
@@ -52,6 +52,15 @@ public:
 
   bool is_initialized() const { return this->m_isInitialized; }
 
+  template <class _Scalar, int _Rows, int _Cols>
+  Eigen::Matrix<_Scalar, _Rows, _Cols>
+  sqrt_solve(const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
+    Eigen::Matrix<_Scalar, _Rows, _Cols> output = this->transpositionsP() * rhs;
+    output = this->matrixL().solve(output);
+    const auto sqrt_diag = this->vectorD().array().sqrt().matrix().asDiagonal();
+    return sqrt_diag.inverse() * output;
+  }
+
   std::vector<Eigen::MatrixXd>
   inverse_blocks(const std::vector<std::vector<std::size_t>> &blocks) const {
 

--- a/include/albatross/src/eigen/serializable_ldlt.hpp
+++ b/include/albatross/src/eigen/serializable_ldlt.hpp
@@ -61,6 +61,15 @@ public:
     return sqrt_diag.inverse() * output;
   }
 
+  double log_determinant() const {
+    // The log determinant can be found by starting with the full decomposition
+    //   log(|A|) = log(|P| |L| |D| |L| |P^T|)
+    // then realizing that P and L are both unit matrices so we get:
+    //   log(|A|) = log(|D|)
+    //            = sum(log(diag(D)))
+    return this->vectorD().array().log().sum();
+  }
+
   std::vector<Eigen::MatrixXd>
   inverse_blocks(const std::vector<std::vector<std::size_t>> &blocks) const {
 

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -368,8 +368,11 @@ public:
     //
     //   L = 1/2 (n log(2 pi) + log(|K|) + y^T K^-1 y)
     //
-    // where in our case we have K = A + Q_ff
-
+    // where in our case we have
+    //   K = A + Q_ff
+    // and
+    //   Q_ff = K_fu K_uu^-1 K_uf
+    //
     // First we get the determinant, |K|:
     //
     //   |K| = |A + Q_ff|
@@ -380,8 +383,9 @@ public:
     //       = |I + P A^-1 P^T| |A|
     //       = |B| |A|
     //
-    // which is derived here (though there are errors in their derivation):
+    // which is derived here:
     //   https://bwengals.github.io/pymc3-fitcvfe-implementation-notes.html
+    // though as of Jan 2020 there are typos in the derivation.
 
     const double log_det_a = sc.A_llt.log_determinant();
     const double log_det_b = sc.B_ldlt.vectorD().array().log().sum();
@@ -393,6 +397,7 @@ public:
     //   d = y^T K^-1 y
     //     = y^T (A + Q_ff)^-1 y
     //     = y^T (A^-1 + A^-1 K_fu S^-1 K_uf A^-1) y
+    //         with S = K_uu + K_uf A^-1 K_fu  (woodbury identity)
     //     = y^T (A^-1 + A^-1 P^T B^-1 P A^-1) y
     //     = y^T A^-1 y + y^T A^-1 P^T B^-1 P A^-1 y
     //     = y^T (A^-1 y) + (B^{-1/2} P A^-1 y)^T (B^{-1/2} P A^-1 y)

--- a/include/albatross/src/samplers/callbacks.hpp
+++ b/include/albatross/src/samplers/callbacks.hpp
@@ -36,7 +36,7 @@ write_ensemble_sampler_state(std::ostream &stream, const ModelType &model,
                              std::size_t iteration,
                              const std::vector<std::string> &columns) {
 
-  ModelType m;
+  ModelType m(model);
   for (std::size_t i = 0; i < ensemble.size(); ++i) {
     std::map<std::string, std::string> row;
 
@@ -53,11 +53,13 @@ write_ensemble_sampler_state(std::ostream &stream, const ModelType &model,
 
 template <typename ModelType> struct CsvWritingCallback {
 
-  CsvWritingCallback(std::shared_ptr<std::ostream> &stream_)
-      : stream(stream_){};
+  CsvWritingCallback(const ModelType &model_,
+                     std::shared_ptr<std::ostream> &stream_)
+      : model(model_), stream(stream_){};
 
-  CsvWritingCallback(std::shared_ptr<std::ostream> &&stream_)
-      : stream(std::move(stream_)){};
+  CsvWritingCallback(const ModelType &model_,
+                     std::shared_ptr<std::ostream> &&stream_)
+      : model(model_), stream(std::move(stream_)){};
 
   void operator()(std::size_t iteration,
                   const EnsembleSamplerState &ensembles) {
@@ -76,14 +78,15 @@ template <typename ModelType> struct CsvWritingCallback {
 template <typename ModelType>
 CsvWritingCallback<ModelType> get_csv_writing_callback(const ModelType &model,
                                                        std::string path) {
-  return CsvWritingCallback<ModelType>(std::make_shared<std::ofstream>(path));
+  return CsvWritingCallback<ModelType>(model,
+                                       std::make_shared<std::ofstream>(path));
 }
 
 template <typename ModelType>
 CsvWritingCallback<ModelType>
 get_csv_writing_callback(const ModelType &model,
                          std::shared_ptr<std::ostream> &stream) {
-  return CsvWritingCallback<ModelType>(stream);
+  return CsvWritingCallback<ModelType>(model, stream);
 }
 
 } // namespace albatross

--- a/include/albatross/src/utils/block_utils.hpp
+++ b/include/albatross/src/utils/block_utils.hpp
@@ -167,6 +167,8 @@ struct BlockDiagonalLLT {
 
   BlockTriangularView<const Eigen::MatrixXd> matrixL() const;
 
+  double log_determinant() const;
+
   Eigen::Index rows() const;
 
   Eigen::Index cols() const;
@@ -290,6 +292,14 @@ BlockDiagonalLLT::matrixL() const {
   for (const auto &b : blocks) {
     Eigen::TriangularView<const Eigen::MatrixXd, Eigen::Lower> L = b.matrixL();
     output.blocks.push_back(L);
+  }
+  return output;
+}
+
+inline double BlockDiagonalLLT::log_determinant() const {
+  double output = 0.;
+  for (const auto &b : blocks) {
+    output += 2. * log(b.matrixL().determinant());
   }
   return output;
 }

--- a/tests/test_block_utils.cc
+++ b/tests/test_block_utils.cc
@@ -52,6 +52,19 @@ TEST(test_block_utils, test_to_dense) {
   EXPECT_LE((block_result - dense).norm(), 1e-6);
 }
 
+TEST(test_block_utils, test_block_llt) {
+  const auto example = block_example();
+  const BlockDiagonalLLT llt = example.block.llt();
+
+  const Eigen::MatrixXd expect_identity = llt.solve(example.dense);
+  const Eigen::MatrixXd identity =
+      Eigen::MatrixXd::Identity(example.dense.rows(), example.dense.cols());
+  EXPECT_LT((expect_identity - identity).norm(), 1e-8);
+
+  EXPECT_NEAR(example.dense.determinant(),
+              exp(example.block.llt().log_determinant()), 1e-8);
+}
+
 TEST(test_block_utils, test_diagonal) {
 
   auto example = block_example();

--- a/tests/test_samplers.cc
+++ b/tests/test_samplers.cc
@@ -137,7 +137,9 @@ TEST(test_samplers, test_samplers_gp) {
   EXPECT_GT(oss->str().size(), 1);
 }
 
-inline long int get_group(const double &f) { return lround(floor(f / 5.)); }
+inline long int get_group(const double &f) {
+  return static_cast<double>(floor(f / 5.));
+}
 
 struct LeaveOneIntervalOut {
   long int operator()(const double &f) const { return get_group(f); }

--- a/tests/test_samplers.cc
+++ b/tests/test_samplers.cc
@@ -14,6 +14,7 @@
 
 #include <albatross/Core>
 #include <albatross/Samplers>
+#include <albatross/SparseGP>
 
 #include <fstream>
 
@@ -133,7 +134,54 @@ TEST(test_samplers, test_samplers_gp) {
   const auto ensemble_samples =
       ensemble_sampler(model, dataset, walkers, max_iterations, gen, callback);
 
-  assert(oss->str().size() > 1);
+  EXPECT_GT(oss->str().size(), 1);
+}
+
+inline long int get_group(const double &f) { return lround(floor(f / 5.)); }
+
+struct LeaveOneIntervalOut {
+  long int operator()(const double &f) const { return get_group(f); }
+};
+
+TEST(test_samplers, test_samplers_sparse_gp) {
+  const double a = 3.14;
+  const double b = sqrt(2.);
+  const double meas_noise_sd = 1.;
+  const auto dataset = make_toy_linear_data(a, b, meas_noise_sd, 50);
+
+  std::default_random_engine gen(2012);
+  const std::size_t walkers = 32;
+
+  using Noise = IndependentNoise<double>;
+  Noise indep_noise(meas_noise_sd);
+  indep_noise.sigma_independent_noise.value = 1.;
+  indep_noise.sigma_independent_noise.prior = LogScaleUniformPrior(1e-3, 1e2);
+  auto meas_noise = measurement_only(indep_noise);
+  LinearMean linear;
+  linear.offset.value = a;
+  linear.slope.value = b;
+
+  LeaveOneIntervalOut grouper;
+  UniformlySpacedInducingPoints strategy(5);
+
+  auto model = sparse_gp_from_covariance_and_mean(meas_noise, linear, grouper,
+                                                  strategy, "test");
+  model.set_prior("inducing_nugget", FixedPrior());
+  model.set_prior("measurement_nugget", FixedPrior());
+
+  std::size_t max_iterations = 100;
+
+  std::shared_ptr<std::ostringstream> oss =
+      std::make_shared<std::ostringstream>();
+  std::shared_ptr<std::ostream> ostream =
+      static_cast<std::shared_ptr<std::ostream>>(oss);
+
+  auto callback = get_csv_writing_callback(model, ostream);
+
+  const auto ensemble_samples =
+      ensemble_sampler(model, dataset, walkers, max_iterations, gen, callback);
+
+  EXPECT_GT(oss->str().size(), 1);
 }
 
 } // namespace albatross

--- a/tests/test_serializable_ldlt.cc
+++ b/tests/test_serializable_ldlt.cc
@@ -45,6 +45,16 @@ TEST_F(SerializableLDLTTest, test_inverse_diagonal) {
   EXPECT_LE(fabs((Eigen::VectorXd(inverse.diagonal()) - diag).norm()), 1e-8);
 }
 
+TEST_F(SerializableLDLTTest, test_log_det) {
+  auto ldlt = cov.ldlt();
+  const auto serializable_ldlt = Eigen::SerializableLDLT(ldlt);
+  const double expected = log(cov.determinant());
+  const double actual = serializable_ldlt.log_determinant();
+
+  // The sqrt solves aren't unique, but we can check the outer product
+  EXPECT_NEAR(expected, actual, 1e-8);
+}
+
 TEST_F(SerializableLDLTTest, test_sqrt_solve) {
   auto ldlt = cov.ldlt();
   const auto serializable_ldlt = Eigen::SerializableLDLT(ldlt);

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -19,7 +19,9 @@
 
 namespace albatross {
 
-long int get_group(const double &f) { return lround(floor(f / 5.)); }
+inline long int get_group(const double &f) {
+  return static_cast<double>(floor(f / 5.));
+}
 
 struct LeaveOneIntervalOut {
 

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -19,13 +19,11 @@
 
 namespace albatross {
 
-std::string get_group(const double &f) {
-  return std::to_string(static_cast<int>(f) / 10);
-}
+long int get_group(const double &f) { return lround(floor(f / 5.)); }
 
 struct LeaveOneIntervalOut {
 
-  std::string operator()(const double &f) const { return get_group(f); }
+  long int operator()(const double &f) const { return get_group(f); }
 };
 
 template <typename GrouperFunction>
@@ -34,8 +32,7 @@ public:
   GrouperFunction grouper;
 };
 
-typedef ::testing::Types<LeaveOneOutGrouper, LeaveOneIntervalOut>
-    IndependenceAssumptions;
+typedef ::testing::Types<LeaveOneIntervalOut> IndependenceAssumptions;
 TYPED_TEST_CASE(SparseGaussianProcessTest, IndependenceAssumptions);
 
 template <typename CovFunc, typename GrouperFunction>
@@ -131,6 +128,11 @@ TYPED_TEST(SparseGaussianProcessTest, test_scales) {
   auto covariance = make_simple_covariance_function();
 
   auto direct = gp_from_covariance(covariance, "direct");
+  // We need to make sure the priors on the parameters don't enter
+  // into the log_likelihood computation.
+  for (const auto &p : direct.get_params()) {
+    direct.set_prior(p.first, FixedPrior());
+  }
 
   using namespace std::chrono;
   high_resolution_clock::time_point start = high_resolution_clock::now();
@@ -149,6 +151,53 @@ TYPED_TEST(SparseGaussianProcessTest, test_scales) {
 
   // Make sure the sparse version is a lot faster.
   EXPECT_LT(sparse_duration, 0.3 * direct_duration);
+}
+
+TYPED_TEST(SparseGaussianProcessTest, test_likelihood) {
+
+  auto grouper = this->grouper;
+  auto dataset = make_toy_sine_data(5., 10., 0.1, 12);
+  auto covariance = make_simple_covariance_function();
+
+  UniformlySpacedInducingPoints strategy(2);
+  auto sparse =
+      sparse_gp_from_covariance(covariance, grouper, strategy, "sparse");
+  const auto inducing_points = strategy(covariance, dataset.features);
+  // We need to make sure the priors on the parameters don't enter
+  // into the log_likelihood computation.
+  for (const auto &p : sparse.get_params()) {
+    sparse.set_prior(p.first, FixedPrior());
+  }
+
+  // Here we build up the dense equivalent to the sparse GP covariance matrix
+  // which we can then use to sanity check the likelihood computation
+  const auto measurements = as_measurements(dataset.features);
+  Eigen::MatrixXd K_uu = covariance(inducing_points);
+
+  const double inducing_nugget = sparse.get_params()["inducing_nugget"].value;
+  const double measurement_nugget =
+      sparse.get_params()["measurement_nugget_"].value;
+  K_uu.diagonal() += inducing_nugget * Eigen::VectorXd::Ones(K_uu.rows());
+
+  const Eigen::MatrixXd K_fu = covariance(measurements, inducing_points);
+  const Eigen::MatrixXd Q_ff = K_fu * (K_uu.ldlt().solve(K_fu.transpose()));
+
+  Eigen::MatrixXd K = Q_ff;
+  const auto indexers = group_by(dataset.features, grouper).indexers();
+  for (const auto &idx_pair : indexers) {
+    for (const Eigen::Index i : idx_pair.second) {
+      for (const Eigen::Index j : idx_pair.second) {
+        K(i, j) = covariance(measurements[i], measurements[j]);
+      }
+    }
+  }
+  K += dataset.targets.covariance;
+  K.diagonal() += measurement_nugget * Eigen::VectorXd::Ones(K.rows());
+
+  const double expected = -negative_log_likelihood(dataset.targets.mean, K);
+  const double actual = sparse.log_likelihood(dataset);
+
+  EXPECT_NEAR(expected, actual, 1e-6);
 }
 
 } // namespace albatross


### PR DESCRIPTION
Add a log likelihood method for sparse Gaussian processes in order to allow us to perform Bayesian inference on the parameters of sparse models.