### PR TITLE
Alternate Method for Setting Serialization Version

### DIFF
--- a/include/albatross/src/cereal/gp.hpp
+++ b/include/albatross/src/cereal/gp.hpp
@@ -59,30 +59,6 @@ void load(Archive &archive,
   archive(cereal::make_nvp("insights", gp.insights));
 }
 
-// Here we define the version for variant serialization following the
-// example given here: https://github.com/USCiLab/cereal/issues/319
-namespace detail {
-template <typename CovFunc, typename MeanFunc, typename ImplType>
-struct Version<GaussianProcessBase<CovFunc, MeanFunc, ImplType>> {
-  static const std::uint32_t version;
-  static std::uint32_t registerVersion() {
-    ::cereal::detail::StaticObject<Versions>::getInstance().mapping.emplace(
-        std::type_index(
-            typeid(GaussianProcessBase<CovFunc, MeanFunc, ImplType>))
-            .hash_code(),
-        GP_SERIALIZATION_VERSION);
-    return GP_SERIALIZATION_VERSION;
-  }
-  static void unused() { (void)version; }
-};
-
-template <typename CovFunc, typename MeanFunc, typename ImplType>
-const std::uint32_t
-    Version<GaussianProcessBase<CovFunc, MeanFunc, ImplType>>::version =
-        Version<GaussianProcessBase<CovFunc, MeanFunc,
-                                    ImplType>>::registerVersion();
-} // namespace detail
-
 } // namespace cereal
 
 #endif /* ALBATROSS_SRC_CEREAL_GP_HPP_ */

--- a/include/albatross/src/cereal/traits.hpp
+++ b/include/albatross/src/cereal/traits.hpp
@@ -55,6 +55,56 @@ template <typename X, typename Archive> class valid_in_out_serializer {
 public:
   static constexpr bool value = decltype(test<X>(0))::value;
 };
+
 } // namespace albatross
+
+namespace cereal {
+namespace detail {
+
+// The Following makes it so you can set a static member in a class
+// in order to define the cereal serialization version that will be used.
+//
+//   struct Foo {
+//     static const std::uint32_t serialization_version = 2;
+//   }
+
+template <typename X> class has_serialization_version {
+  template <typename T>
+  static std::enable_if_t<
+      std::is_same<std::uint32_t, typename std::decay<decltype(
+                                      T::serialization_version)>::type>::value,
+      std::true_type>
+  test(int);
+  template <typename T> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<X>(0))::value;
+};
+
+// This default definition mimics the one in helpers.hpp
+template <typename T, bool> struct VersionedAlbatrossType {
+  static const std::uint32_t version = 0;
+};
+
+// Here we define the version for serialization following the
+// example given here: https://github.com/USCiLab/cereal/issues/319
+template <typename T> struct VersionedAlbatrossType<T, true> {
+  static const std::uint32_t version = T::serialization_version;
+
+  static std::uint32_t registerVersion() {
+    ::cereal::detail::StaticObject<Versions>::getInstance().mapping.emplace(
+        std::type_index(typeid(T)).hash_code(), version);
+    return version;
+  }
+};
+
+// Propagate the `serialization_version` member into the cereal version.
+template <typename T>
+struct Version<T>
+    : public VersionedAlbatrossType<T, has_serialization_version<T>::value> {};
+
+} // namespace detail
+
+} // namespace cereal
 
 #endif

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -230,6 +230,8 @@ public:
 
   ~GaussianProcessBase(){};
 
+  static const std::uint32_t serialization_version = 1;
+
   // Create a fit based on a subset of predicted features (with the given joint
   // distribution) - the fit type also requires the prior covariance of the
   // features to determine the model that will give the same mean and covariance

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -392,7 +392,6 @@ TEST(test_serialize, test_variant_version_0) {
     cereal::JSONOutputArchive oarchive(os);
     save(oarchive, foo, 0);
   }
-  std::cout << os.str() << std::endl;
 
   // Deserialize it.
   std::istringstream is(os.str());
@@ -404,6 +403,20 @@ TEST(test_serialize, test_variant_version_0) {
   // Make sure the original and deserialized representations are
   // equivalent.
   EXPECT_TRUE(foo == deserialized);
+}
+
+TEST(test_serialize, test_gp_serialize_version) {
+  MakeGaussianProcess test_case;
+
+  EXPECT_TRUE(bool(cereal::detail::has_serialization_version<decltype(
+                       test_case.get_model())>::value));
+
+  const std::uint32_t expected_version =
+      test_case.get_model().serialization_version;
+  const std::uint32_t actual_version =
+      cereal::detail::Version<decltype(test_case.get_model())>::version;
+
+  EXPECT_EQ(actual_version, expected_version);
 }
 
 } // namespace albatross


### PR DESCRIPTION
Make it so that adding a `serialization_version` member to a class sets the cereal serialization version.

This comes after realizing that the existing `Version` specialization for Gaussian processes wasn't working.