### PR TITLE
Improve Sampler Callbacks

### DIFF
--- a/examples/plot_sampler_output.py
+++ b/examples/plot_sampler_output.py
@@ -5,7 +5,6 @@ import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
-import corner
 
 from scipy import stats
 
@@ -17,27 +16,32 @@ def create_parser():
     p.add_argument("input")
     p.add_argument("--thin", type=int, default=10)
     p.add_argument("--burn-in", type=int, default=100)
+    p.add_argument("--variables", type=str, default=None, nargs="*")
+    p.add_argument("--mode", choices=["corner", "plume", "list"], default="corner")
     return p
 
 
-
-
-
-if __name__ == "__main__":
-
-    p = create_parser()
-    args = p.parse_args()
-
+def corner_plot(args):
     df = pd.read_csv(args.input);
     for k in df.columns:
         df[k] = df[k].astype('f')
     df = df.iloc[np.all(np.isfinite(df.values), axis=1)]
 
     samples = [v for k, v in df.groupby('iteration')]
+    
+    if args.burn_in > len(samples):
+        raise ValueError("burn in exceeds the number of samples")
+
     samples = samples[args.burn_in:]
     samples = samples[::args.thin]
 
     columns = np.setdiff1d(samples[0].columns, ['iteration', 'log_probability', 'ensemble_index'])
+
+    if args.variables:
+        for var_name in args.variables:
+            if var_name not in columns:
+                print("requested variable %s is not valid" % var_name)
+        columns = args.variables
 
     data = np.vstack([s[columns].values.astype('f') for s in samples])
     log_p = np.concatenate([s["log_probability"].values for s in samples])
@@ -45,17 +49,34 @@ if __name__ == "__main__":
 
     iteration = np.concatenate([s["iteration"].values for s in samples])
     good = log_p >= stats.mstats.mquantiles(log_p, [0.1])
-    limits = stats.mstats.mquantiles(data[good], [0.05, 0.95], axis=0).data.T
 
-    def rescale(lim):
-        d = 0.05 * (lim[1] - lim[0])
+    def get_limits(values):
+        low, high = stats.mstats.mquantiles(values, [0.05, 0.95])
+        d = 0.05 * (high - low)
         if d == 0.:
             d = 1e-4
-        return (lim[0] - d, lim[1] + d)
+        low = max(np.min(values), low - d)
+        high = min(np.max(values), high + d)
+        return (low, high)
 
-    limits = [rescale(lim) for lim in limits]
+    limits = [get_limits(vals) for vals in data[good].T]
 
-    bins = [np.linspace(lim[0], lim[1], 20) for lim in limits]
+    def get_yscale(low, high):
+        if abs(high / max(1e-8, low)) > 100:
+            return 'log'
+        else:
+            return 'linear'
+
+    yscales = [get_yscale(low, high) for low, high in limits]
+
+    def get_bins(low, high, yscale):
+        if yscale == 'log':
+            return np.logspace(np.log10(low), np.log10(high), 30)
+        else:
+            return np.linspace(low, high, 20)
+
+
+    bins = [get_bins(lim[0], lim[1], yscale) for lim, yscale in zip(limits, yscales)]
 
     k = data.shape[1]
     fig = plt.figure(figsize=(16, 16))
@@ -75,9 +96,12 @@ if __name__ == "__main__":
             ax = fig.add_subplot(grid[i, j], **ax_kwdargs)
 
             if i == j:
-                ax.hist(data[:, i], bins=40, color='steelblue')
+                ax.hist(data[:, i], bins=bins[i], color='steelblue')
+                ax.set_xscale(yscales[i])
             else:
                 ax.hist2d(data[:, j], data[:, i], bins=[bins[j], bins[i]], norm=mcolors.PowerNorm(0.5))
+                ax.set_yscale(yscales[i])
+                ax.set_xscale(yscales[j])
                 ax.set_ylim(limits[i])
                 ax.set_xlim(limits[j])
             if i == k - 1:
@@ -85,7 +109,7 @@ if __name__ == "__main__":
             if j == 0:
                 ax.set_ylabel(columns[i])
 
-    if k > 1:
+    if k > 2:
         mid = int(np.ceil(k / 3))
         ax = fig.add_subplot(grid[:mid, (mid + 1):], xticklabels=[])
     else:
@@ -103,4 +127,60 @@ if __name__ == "__main__":
     ax.set_xticks(x_ticks)
     ax.set_xticklabels(map(lambda x : str(int(x)), x_ticks))
     plt.show()
+
+
+def plume_plot(args):
+    df = pd.read_csv(args.input);
+    for k in df.columns:
+        df[k] = df[k].astype('f')
+    df = df.iloc[np.all(np.isfinite(df.values), axis=1)]
+
+    samples = [v for k, v in df.groupby('iteration')]
+    samples = samples[args.burn_in:]
+    samples = samples[::args.thin]
+
+    columns = np.setdiff1d(samples[0].columns, ['iteration', 'log_probability', 'ensemble_index'])
+
+    if args.variables:
+        for var_name in args.variables:
+            if var_name not in columns:
+                print("requested variable %s is not valid" % var_name)
+        columns = args.variables
+
+    fig, axes = plt.subplots(len(columns), 1, figsize=(12, 12))
+    if len(columns) == 1:
+        axes = [axes]
+
+    for ax, var_name in zip(axes, columns):
+        data = np.concatenate([s[var_name].values for s in samples])
+        log_p = np.concatenate([s["log_probability"].values for s in samples])
+        log_p = np.ma.masked_array(log_p, mask=~np.isfinite(log_p))
+        iteration = np.concatenate([s["iteration"].values for s in samples])
+    
+        ax.plot(iteration, np.log10(data), '.')
+        ax.set_ylabel(var_name)
+        ax.set_xlabel("iterations")  
+        x_ticks = np.linspace(np.min(iteration), np.max(iteration), 11)
+        ax.set_xticks(x_ticks)
+        ax.set_xticklabels(map(lambda x : str(int(x)), x_ticks))
+    plt.show()
+
+def list_columns(args):
+    df = pd.read_csv(args.input);
+    columns = np.setdiff1d(df.columns, ['iteration', 'log_probability', 'ensemble_index'])
+    print('\n'.join(columns))
+
+if __name__ == "__main__":
+
+    p = create_parser()
+    args = p.parse_args()
+
+    if args.mode == "corner":
+        corner_plot(args)
+    elif args.mode == "plume":
+        plume_plot(args)
+    elif args.mode == "list":
+        list_columns(args)
+    else:
+        print("Invalid mode")
 

--- a/include/albatross/Samplers
+++ b/include/albatross/Samplers
@@ -18,6 +18,7 @@
 #include <albatross/utils/RandomUtils>
 
 #include <albatross/src/samplers/state.hpp>
+#include <albatross/src/samplers/initialization.hpp>
 #include <albatross/src/samplers/callbacks.hpp>
 #include <albatross/src/samplers/ensemble.hpp>
 

--- a/include/albatross/src/samplers/callbacks.hpp
+++ b/include/albatross/src/samplers/callbacks.hpp
@@ -19,7 +19,8 @@ struct NullCallback {
   void operator()(std::size_t, const EnsembleSamplerState &){};
 };
 
-inline std::vector<std::string> get_columns(const ParameterStore &example) {
+inline std::vector<std::string>
+get_sampler_csv_columns(const ParameterStore &example) {
   std::vector<std::string> columns;
   columns.push_back("iteration");
   columns.push_back("log_probability");
@@ -29,19 +30,17 @@ inline std::vector<std::string> get_columns(const ParameterStore &example) {
   return columns;
 }
 
-template <typename ModelType>
-inline void
-write_ensemble_sampler_state(std::ostream &stream, const ModelType &model,
-                             const EnsembleSamplerState &ensemble,
-                             std::size_t iteration,
-                             const std::vector<std::string> &columns) {
+inline void write_ensemble_sampler_state(
+    std::ostream &stream, const ParameterStore &param_store,
+    const EnsembleSamplerState &ensemble, std::size_t iteration,
+    const std::vector<std::string> &columns) {
 
-  ModelType m(model);
   for (std::size_t i = 0; i < ensemble.size(); ++i) {
     std::map<std::string, std::string> row;
 
-    m.set_tunable_params_values(ensemble[i].params);
-    for (const auto &param : m.get_params()) {
+    const auto params =
+        set_tunable_params_values(ensemble[i].params, param_store);
+    for (const auto &param : params) {
       row[param.first] = std::to_string(param.second.value);
     }
     row["iteration"] = std::to_string(iteration);
@@ -51,42 +50,72 @@ write_ensemble_sampler_state(std::ostream &stream, const ModelType &model,
   }
 }
 
-template <typename ModelType> struct CsvWritingCallback {
+struct MaximumLikelihoodTrackingCallback {
 
-  CsvWritingCallback(const ModelType &model_,
+  MaximumLikelihoodTrackingCallback(const ParameterStore &param_store_,
+                                    std::shared_ptr<std::ostream> &stream_)
+      : param_store(param_store_), stream(stream_){};
+
+  MaximumLikelihoodTrackingCallback(const ParameterStore &param_store_,
+                                    std::shared_ptr<std::ostream> &&stream_)
+      : param_store(param_store_), stream(std::move(stream_)){};
+
+  void operator()(std::size_t iteration,
+                  const EnsembleSamplerState &ensembles) {
+    for (const auto &state : ensembles) {
+      if (state.log_prob > max_ll) {
+        max_ll = state.log_prob;
+        param_store = set_tunable_params_values(state.params, param_store);
+        (*stream) << "===================" << std::endl;
+        (*stream) << "Iteration: " << iteration << std::endl;
+        (*stream) << "LL: " << max_ll << std::endl;
+        (*stream) << pretty_params(param_store) << std::endl;
+      }
+    }
+  }
+
+  double max_ll = -HUGE_VAL;
+  ParameterStore param_store;
+  std::shared_ptr<std::ostream> stream;
+};
+
+struct CsvWritingCallback {
+
+  CsvWritingCallback(const ParameterStore &param_store_,
                      std::shared_ptr<std::ostream> &stream_)
-      : model(model_), stream(stream_){};
+      : param_store(param_store_), stream(stream_){};
 
-  CsvWritingCallback(const ModelType &model_,
+  CsvWritingCallback(const ParameterStore &param_store_,
                      std::shared_ptr<std::ostream> &&stream_)
-      : model(model_), stream(std::move(stream_)){};
+      : param_store(param_store_), stream(std::move(stream_)){};
 
   void operator()(std::size_t iteration,
                   const EnsembleSamplerState &ensembles) {
     if (iteration == 0) {
-      columns = get_columns(model.get_params());
+      columns = get_sampler_csv_columns(param_store);
       write_header(*stream, columns);
     }
-    write_ensemble_sampler_state(*stream, model, ensembles, iteration, columns);
+    write_ensemble_sampler_state(*stream, param_store, ensembles, iteration,
+                                 columns);
   }
 
-  ModelType model;
+  ParameterStore param_store;
   std::shared_ptr<std::ostream> stream;
   std::vector<std::string> columns;
 };
 
 template <typename ModelType>
-CsvWritingCallback<ModelType> get_csv_writing_callback(const ModelType &model,
-                                                       std::string path) {
-  return CsvWritingCallback<ModelType>(model,
-                                       std::make_shared<std::ofstream>(path));
+CsvWritingCallback get_csv_writing_callback(const ModelType &model,
+                                            std::string path) {
+  return CsvWritingCallback(model.get_params(),
+                            std::make_shared<std::ofstream>(path));
 }
 
 template <typename ModelType>
-CsvWritingCallback<ModelType>
+CsvWritingCallback
 get_csv_writing_callback(const ModelType &model,
                          std::shared_ptr<std::ostream> &stream) {
-  return CsvWritingCallback<ModelType>(model, stream);
+  return CsvWritingCallback(model.get_params(), stream);
 }
 
 } // namespace albatross

--- a/include/albatross/src/samplers/ensemble.hpp
+++ b/include/albatross/src/samplers/ensemble.hpp
@@ -35,28 +35,6 @@ inline std::size_t random_complement(std::size_t n, std::size_t i,
   }
 }
 
-template <typename JitterDistribution>
-std::vector<std::vector<double>> initial_params_from_jitter(
-    const ParameterStore &params, JitterDistribution &jitter_distribution,
-    std::default_random_engine &gen, std::size_t n = -1) {
-
-  n = std::max(n, 2 * params.size() + 1);
-
-  std::vector<std::vector<double>> output;
-  std::vector<double> double_params = get_tunable_parameters(params).values;
-  output.push_back(double_params);
-  for (std::size_t i = 0; i < n - 1; ++i) {
-
-    std::vector<double> perturbed(double_params);
-    for (auto &d : perturbed) {
-      d += jitter_distribution(gen);
-    };
-
-    output.push_back(perturbed);
-  }
-  return output;
-}
-
 void assert_valid_states(const EnsembleSamplerState &ensembles) {
   for (std::size_t i = 0; i < ensembles.size(); ++i) {
     assert(std::isfinite(ensembles[i].log_prob));

--- a/include/albatross/src/samplers/ensemble.hpp
+++ b/include/albatross/src/samplers/ensemble.hpp
@@ -91,8 +91,16 @@ EnsembleSamplerState stretch_move_step(const EnsembleSamplerState &ensembles,
 
       // proposed = x_j + z * (x_k - x_j)
       for (std::size_t i = 0; i < n_dim; ++i) {
-        double v_j = next_ensembles[j].params[i];
-        proposed.params[i] = v_j + z * (proposed.params[i] - v_j);
+        const double v_j = next_ensembles[j].params[i];
+        double delta = (proposed.params[i] - v_j);
+        // Occasionally (especially with bounds) some
+        // parameters can end up identical across samples
+        // in this occasion we switch to a gaussian style
+        // move with very small variance.
+        if (delta == 0.) {
+          delta = 1e-6;
+        }
+        proposed.params[i] = v_j + z * delta;
       }
 
       proposed.log_prob = compute_log_prob(proposed.params);

--- a/include/albatross/src/samplers/initialization.hpp
+++ b/include/albatross/src/samplers/initialization.hpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef INCLUDE_ALBATROSS_SRC_SAMPLERS_INITIALIZATION_HPP_
+#define INCLUDE_ALBATROSS_SRC_SAMPLERS_INITIALIZATION_HPP_
+
+namespace albatross {
+
+inline std::vector<std::string> split_string(const std::string &s,
+                                             char delimiter) {
+  std::vector<std::string> tokens;
+  std::string token;
+  std::istringstream token_stream(s);
+  while (std::getline(token_stream, token, delimiter)) {
+    tokens.push_back(token);
+  }
+  return tokens;
+}
+
+std::vector<double> parse_line(const std::string &line) {
+  std::vector<double> output;
+  for (const auto &s : split_string(line, ',')) {
+    output.push_back(std::stod(s));
+  }
+  return output;
+}
+
+std::vector<std::map<std::string, double>>
+initial_params_from_csv(std::istream &ss) {
+
+  std::vector<std::map<std::string, double>> output;
+
+  std::string line;
+  double iteration = 0;
+
+  assert(std::getline(ss, line));
+  const std::vector<std::string> columns = split_string(line, ',');
+
+  assert(columns[0] == "iteration");
+  assert(columns[1] == "log_probability");
+  assert(columns[2] == "ensemble_index");
+
+  while (std::getline(ss, line)) {
+    const std::vector<double> values = parse_line(line);
+    if (values[0] > iteration) {
+      iteration = values[0];
+      output.clear();
+    }
+
+    std::map<std::string, double> param_values;
+    assert(values.size() == columns.size());
+    for (std::size_t i = 3; i < columns.size(); ++i) {
+      param_values[columns[i]] = values[i];
+    }
+
+    output.emplace_back(param_values);
+  }
+
+  return output;
+}
+
+std::vector<std::vector<double>>
+initial_params_from_csv(const ParameterStore &param_store, std::istream &ss) {
+
+  const auto all_params = initial_params_from_csv(ss);
+
+  std::vector<std::vector<double>> output;
+  for (const auto &value_map : all_params) {
+    assert(value_map.size() == param_store.size());
+    ParameterStore params(param_store);
+    for (const auto &value_pair : value_map) {
+      params[value_pair.first].value = ensure_value_within_bounds(
+          params[value_pair.first], value_pair.second);
+    }
+
+    output.emplace_back(get_tunable_parameters(params).values);
+  }
+
+  return output;
+}
+
+template <typename JitterDistribution>
+std::vector<std::vector<double>> initial_params_from_jitter(
+    const ParameterStore &params, JitterDistribution &jitter_distribution,
+    std::default_random_engine &gen, std::size_t n = -1) {
+
+  n = std::max(n, 2 * params.size() + 1);
+
+  std::vector<std::vector<double>> output;
+  std::vector<double> double_params = get_tunable_parameters(params).values;
+  output.push_back(double_params);
+  for (std::size_t i = 0; i < n - 1; ++i) {
+
+    std::vector<double> perturbed(double_params);
+    for (auto &d : perturbed) {
+      d += jitter_distribution(gen);
+    };
+
+    output.push_back(perturbed);
+  }
+  return output;
+}
+
+} // namespace albatross
+
+#endif /* INCLUDE_ALBATROSS_SRC_SAMPLERS_INITIALIZATION_HPP_ */


### PR DESCRIPTION
This change adds a few modifications to the callbacks available for the samplers.  In particular it lets you:

- Restart a run using a previously logged csv file (this is the most important change.  This makes it so you can run the sampler, kill the process and pick-up right where it left off).
- Keep track of the maximum likelihood set of parameters
- Create a csv callback more easily
- Plot parameters using a log scale when they have a large range.