### PR TITLE
Add extract_from_variants

### DIFF
--- a/include/albatross/src/utils/variant_utils.hpp
+++ b/include/albatross/src/utils/variant_utils.hpp
@@ -69,6 +69,22 @@ to_variant_vector(const std::vector<X> &xs,
   return output;
 }
 
+template <
+    typename OutputType, typename... VariantTypes,
+    std::enable_if_t<is_in_variant<OutputType, variant<VariantTypes...>>::value,
+                     int> = 0>
+inline std::vector<OutputType>
+extract_from_variants(const std::vector<variant<VariantTypes...>> &xs,
+                      details::ToVariantIdentity<OutputType> && = {}) {
+  std::vector<OutputType> output;
+  for (const auto &x : xs) {
+    x.match([&](const OutputType &f) { output.emplace_back(f); },
+            [](const auto &) {});
+  }
+
+  return output;
+}
+
 } // namespace albatross
 
 #endif /* ALBATROSS_UTILS_VARIANT_UTILS_HPP_ */

--- a/tests/test_variant_utils.cc
+++ b/tests/test_variant_utils.cc
@@ -114,4 +114,33 @@ TEST(test_variant_utils, test_to_variant_vector) {
   }
 }
 
+TEST(test_variant_utils, test_extract_from_variants) {
+  const auto doubles = linspace(0., 10., 11);
+  const auto variants =
+      to_variant_vector<variant<int, double, VariantUtilsTestType>>(doubles);
+  EXPECT_EQ(variants.size(), doubles.size());
+
+  const std::vector<double> actual = extract_from_variants<double>(variants);
+
+  EXPECT_EQ(actual, doubles);
+
+  double a = 1.;
+  double b = 2.;
+  VariantUtilsTestType x_a = {a};
+  VariantUtilsTestType x_b = {b};
+
+  std::vector<variant<double, VariantUtilsTestType>> mixed;
+  mixed.emplace_back(a);
+  mixed.emplace_back(b);
+  mixed.emplace_back(x_a);
+  mixed.emplace_back(x_b);
+
+  const auto only_test_types =
+      extract_from_variants<VariantUtilsTestType>(mixed);
+
+  EXPECT_EQ(only_test_types[0], x_a);
+  EXPECT_EQ(only_test_types[1], x_b);
+  EXPECT_EQ(only_test_types.size(), 2);
+}
+
 } // namespace albatross


### PR DESCRIPTION
Adds a method `extract_from_variants` which lets you find the subset of a vector of `variant` types which are of a specific type.