### PR TITLE
Tune Using Free Functions

### DIFF
--- a/include/albatross/src/core/parameter_handling_mixin.hpp
+++ b/include/albatross/src/core/parameter_handling_mixin.hpp
@@ -165,8 +165,8 @@ inline double ensure_value_within_bounds(const Parameter &param,
 }
 
 inline ParameterStore
-set_tunable_params_values(const std::vector<ParameterValue> &x,
-                          const ParameterStore &params,
+set_tunable_params_values(const ParameterStore &params,
+                          const std::vector<ParameterValue> &x,
                           const bool force_bounds = true) {
   ParameterStore output(params);
   std::size_t i = 0;
@@ -188,6 +188,15 @@ set_tunable_params_values(const std::vector<ParameterValue> &x,
   // Make sure we used all the parameters that were passed in.
   assert(x.size() == i);
   return output;
+}
+
+inline bool params_are_valid(const ParameterStore &params) {
+  for (const auto &pair : params) {
+    if (!pair.second.is_valid()) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /*
@@ -271,12 +280,7 @@ public:
   }
 
   bool params_are_valid() const {
-    for (const auto &pair : get_params()) {
-      if (!pair.second.is_valid()) {
-        return false;
-      }
-    }
-    return true;
+    return albatross::params_are_valid(this->get_params());
   }
 
   double prior_log_likelihood() const {
@@ -302,7 +306,7 @@ public:
                                  bool force_bounds = true) {
 
     const auto modified_params =
-        albatross::set_tunable_params_values(x, get_params(), force_bounds);
+        albatross::set_tunable_params_values(get_params(), x, force_bounds);
 
     for (const auto &pair : modified_params) {
       unchecked_set_param(pair.first, pair.second);

--- a/include/albatross/src/samplers/callbacks.hpp
+++ b/include/albatross/src/samplers/callbacks.hpp
@@ -39,7 +39,7 @@ inline void write_ensemble_sampler_state(
     std::map<std::string, std::string> row;
 
     const auto params =
-        set_tunable_params_values(ensemble[i].params, param_store);
+        set_tunable_params_values(param_store, ensemble[i].params);
     for (const auto &param : params) {
       row[param.first] = std::to_string(param.second.value);
     }
@@ -65,7 +65,7 @@ struct MaximumLikelihoodTrackingCallback {
     for (const auto &state : ensembles) {
       if (state.log_prob > max_ll) {
         max_ll = state.log_prob;
-        param_store = set_tunable_params_values(state.params, param_store);
+        param_store = set_tunable_params_values(param_store, state.params);
         (*stream) << "===================" << std::endl;
         (*stream) << "Iteration: " << iteration << std::endl;
         (*stream) << "LL: " << max_ll << std::endl;

--- a/include/albatross/src/tune/tune.hpp
+++ b/include/albatross/src/tune/tune.hpp
@@ -68,7 +68,7 @@ default_optimizer(const ParameterStore &params,
   return optimizer;
 }
 
-inline ParameterStore uniformative_params(const std::vector<double> &values) {
+inline ParameterStore uninformative_params(const std::vector<double> &values) {
   ParameterStore params;
   for (std::size_t i = 0; i < values.size(); ++i) {
     params[std::to_string(i)] = {values[i], UninformativePrior()};
@@ -112,7 +112,7 @@ struct GenericTuner {
 
   GenericTuner(const std::vector<double> &initial_params,
                std::ostream &output_stream_ = std::cout)
-      : GenericTuner(uniformative_params(initial_params), output_stream_){};
+      : GenericTuner(uninformative_params(initial_params), output_stream_){};
 
   template <
       typename ObjectiveFunction,


### PR DESCRIPTION
This change refactors tuning a bit to allow easier tuning using free functions (and lambdas).

For example, you can now do something like this:

```
  std::vector<double> initial_x = create_initial_guess();
  GenericTuner tuner(initial_x);
  const std::vector<double> tuned_params = tuner.tune([](const std::vector<double> &xs) {return foo(xs);});
```
or
```
  ParameterStore initial_x = create_initial_guess();
  GenericTuner tuner(initial_x);
  const ParameterStore tuned_params = tuner.tune([](const ParameterStore &xs) {return foo(xs);});
```
or
```
  Eigen::VectorXd initial_x = create_initial_guess();
  GenericTuner tuner(initial_x);
  const Eigen::VectorXd tuned_params = tuner.tune([](const Eigen::VectorXd &xs) {return foo(xs);});
```