### PR TITLE
Use universal references in apply and filter functions.

### DIFF
--- a/include/albatross/src/indexing/apply.hpp
+++ b/include/albatross/src/indexing/apply.hpp
@@ -16,6 +16,7 @@
 namespace albatross {
 
 // Vector
+
 template <typename ValueType, typename ApplyFunction,
           typename ApplyType = typename details::value_only_apply_result<
               ApplyFunction, ValueType>::type,
@@ -23,8 +24,8 @@ template <typename ValueType, typename ApplyFunction,
                                       ApplyFunction, ValueType>::value &&
                                       std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
-inline void apply(const std::vector<ValueType> &xs, const ApplyFunction &f) {
-  std::for_each(xs.begin(), xs.end(), f);
+inline void apply(const std::vector<ValueType> &xs, ApplyFunction &&f) {
+  std::for_each(xs.begin(), xs.end(), std::forward<ApplyFunction>(f));
 }
 
 template <typename ValueType, typename ApplyFunction,
@@ -35,9 +36,10 @@ template <typename ValueType, typename ApplyFunction,
                                       !std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
 inline std::vector<ApplyType> apply(const std::vector<ValueType> &xs,
-                                    const ApplyFunction &f) {
+                                    ApplyFunction &&f) {
   std::vector<ApplyType> output(xs.size());
-  std::transform(xs.begin(), xs.end(), output.begin(), f);
+  std::transform(xs.begin(), xs.end(), output.begin(),
+                 std::forward<ApplyFunction>(f));
   return output;
 }
 
@@ -52,7 +54,7 @@ template <
                                 ApplyFunction, KeyType, ValueType>::value &&
                                 std::is_same<void, ApplyType>::value,
                             int>::type = 0>
-inline void apply(const Map<KeyType, ValueType> &map, const ApplyFunction &f) {
+inline void apply(const Map<KeyType, ValueType> &map, ApplyFunction &&f) {
   for (const auto &pair : map) {
     f(pair.first, pair.second);
   }
@@ -68,7 +70,7 @@ template <
                                 !std::is_same<void, ApplyType>::value,
                             int>::type = 0>
 inline Grouped<KeyType, ApplyType> apply(const Map<KeyType, ValueType> &map,
-                                         const ApplyFunction &f) {
+                                         ApplyFunction &&f) {
   Grouped<KeyType, ApplyType> output;
   for (const auto &pair : map) {
     output.emplace(pair.first, f(pair.first, pair.second));
@@ -85,7 +87,7 @@ template <template <typename...> class Map, typename KeyType,
                                       !std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
 inline Grouped<KeyType, ApplyType> apply(const Map<KeyType, ValueType> &map,
-                                         const ApplyFunction &f) {
+                                         ApplyFunction &&f) {
   Grouped<KeyType, ApplyType> output;
   for (const auto &pair : map) {
     output.emplace(pair.first, f(pair.second));
@@ -101,7 +103,7 @@ template <template <typename...> class Map, typename KeyType,
                                       ApplyFunction, ValueType>::value &&
                                       std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
-inline void apply(const Map<KeyType, ValueType> &map, const ApplyFunction &f) {
+inline void apply(const Map<KeyType, ValueType> &map, ApplyFunction &&f) {
   for (const auto &pair : map) {
     f(pair.second);
   }

--- a/include/albatross/src/indexing/filter.hpp
+++ b/include/albatross/src/indexing/filter.hpp
@@ -22,7 +22,7 @@ template <typename ToKeepFunction, typename ValueType,
                                       ToKeepFunction, ValueType>::value,
                                   int>::type = 0>
 inline std::vector<ValueType> filter(const std::vector<ValueType> &values,
-                                     ToKeepFunction to_keep) {
+                                     ToKeepFunction &&to_keep) {
   std::vector<ValueType> output;
   for (const auto &v : values) {
     if (to_keep(v)) {
@@ -40,7 +40,7 @@ template <template <typename...> class Map, typename KeyType,
                                       ToKeepFunction, ValueType>::value,
                                   int>::type = 0>
 inline Grouped<KeyType, ValueType> filter(const Map<KeyType, ValueType> &map,
-                                          ToKeepFunction to_keep) {
+                                          ToKeepFunction &&to_keep) {
   Grouped<KeyType, ValueType> output;
   for (const auto &pair : map) {
     if (to_keep(pair.second)) {
@@ -57,7 +57,7 @@ template <
                                 ToKeepFunction, KeyType, ValueType>::value,
                             int>::type = 0>
 inline Grouped<KeyType, ValueType> filter(const Map<KeyType, ValueType> &map,
-                                          ToKeepFunction to_keep) {
+                                          ToKeepFunction &&to_keep) {
   Grouped<KeyType, ValueType> output;
   for (const auto &pair : map) {
     if (to_keep(pair.first, pair.second)) {

--- a/include/albatross/src/indexing/traits.hpp
+++ b/include/albatross/src/indexing/traits.hpp
@@ -143,7 +143,12 @@ class is_valid_filter_function {
   template <typename> static std::false_type test(...);
 
 public:
-  static constexpr bool value = decltype(test<FilterFunction>(0))::value;
+  // The functions passed into these checks are often derived from
+  // universal references which may add qualifiers to the type, without
+  // the use of decay here these qualifiers may interfere with
+  // the validity check.
+  static constexpr bool value =
+      decltype(test<typename std::decay<FilterFunction>::type>(0))::value;
 };
 
 template <typename FilterFunction, typename KeyType, typename ArgType>


### PR DESCRIPTION
The use of templated function types was pretty inconsistent in the `apply` and `filter` methods, this gets everything using universal references.