### PR TITLE
Avoid Copying Fit Models

### DIFF
--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -31,10 +31,10 @@ namespace albatross {
  * This type conversion utility will turn a type `T` into `const T&`
  */
 template <class T> struct const_ref {
-  typedef
-      typename std::add_lvalue_reference<typename std::add_const<T>::type>::type
-          type;
+  typedef std::add_lvalue_reference_t<std::add_const_t<T>> type;
 };
+
+template <typename T> using const_ref_t = typename const_ref<T>::type;
 
 /*
  * Model
@@ -50,8 +50,7 @@ class Prediction;
 
 template <typename ModelType, typename FeatureType, typename FitType>
 using PredictionReference =
-    Prediction<typename const_ref<ModelType>::type, FeatureType,
-               typename const_ref<FitType>::type>;
+    Prediction<const_ref_t<ModelType>, FeatureType, const_ref_t<FitType>>;
 
 template <typename ModelType, typename FitType> class FitModel;
 

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -24,6 +24,19 @@ using mapbox::util::variant;
 namespace albatross {
 
 /*
+ * We frequently inspect for definitions of functions which
+ * must be defined for const references to objects
+ * (so that repeated evaluations return the same thing
+ *  and so the computations are not repeatedly copying.)
+ * This type conversion utility will turn a type `T` into `const T&`
+ */
+template <class T> struct const_ref {
+  typedef
+      typename std::add_lvalue_reference<typename std::add_const<T>::type>::type
+          type;
+};
+
+/*
  * Model
  */
 template <typename ModelType> class ModelBase;
@@ -34,6 +47,11 @@ template <typename T> struct PredictTypeIdentity;
 
 template <typename ModelType, typename FeatureType, typename FitType>
 class Prediction;
+
+template <typename ModelType, typename FeatureType, typename FitType>
+using PredictionReference =
+    Prediction<typename const_ref<ModelType>::type, FeatureType,
+               typename const_ref<FitType>::type>;
 
 template <typename ModelType, typename FitType> class FitModel;
 

--- a/include/albatross/src/core/prediction.hpp
+++ b/include/albatross/src/core/prediction.hpp
@@ -113,14 +113,17 @@ public:
 template <typename ModelType, typename FeatureType, typename FitType>
 class Prediction {
 
+  using PlainModelType = typename std::decay<ModelType>::type;
+  using PlainFitType = typename std::decay<FitType>::type;
+
 public:
-  Prediction(const ModelType &model, const FitType &fit,
+  Prediction(const PlainModelType &model, const PlainFitType &fit,
              const std::vector<FeatureType> &features)
       : model_(model), fit_(fit), features_(features) {}
 
-  Prediction(const ModelType &model, const FitType &fit,
-             std::vector<FeatureType> &&features)
-      : model_(model), fit_(fit), features_(std::move(features)) {}
+  Prediction(PlainModelType &&model, PlainFitType &&fit,
+             const std::vector<FeatureType> &features)
+      : model_(std::move(model)), fit_(std::move(fit)), features_(features) {}
 
   // Mean
   template <typename DummyType = FeatureType,

--- a/include/albatross/src/details/traits.hpp
+++ b/include/albatross/src/details/traits.hpp
@@ -16,19 +16,6 @@
 namespace albatross {
 
 /*
- * We frequently inspect for definitions of functions which
- * must be defined for const references to objects
- * (so that repeated evaluations return the same thing
- *  and so the computations are not repeatedly copying.)
- * This type conversion utility will turn a type `T` into `const T&`
- */
-template <class T> struct const_ref {
-  typedef
-      typename std::add_lvalue_reference<typename std::add_const<T>::type>::type
-          type;
-};
-
-/*
  * This little trick was borrowed from cereal, you can think of it as
  * a function that will always return false ... but that doesn't
  * get resolved until template instantiation, which when combined


### PR DESCRIPTION
Modify `Prediction` to avoid copying the model and fit when used in a chained call such as:

  `model.fit(dataset).predict(features);`

This was done by overloading the `predict` method int the `FitModel` class such that when `predict` is called on an rvalue the `Fit` and `Model` types are moved into the resulting `Prediction` class and when `predict` is called on an lvalue a `PredictionReference` class is returned which internally holds references to the fit and model.
