### PR TITLE
Bug Fix : vector types being resolve as Map<Key, Value>.

### DIFF
--- a/include/albatross/src/indexing/apply.hpp
+++ b/include/albatross/src/indexing/apply.hpp
@@ -43,7 +43,7 @@ inline std::vector<ApplyType> apply(const std::vector<ValueType> &xs,
   return output;
 }
 
-// Map
+// Generic Map
 
 template <
     template <typename...> class Map, typename KeyType, typename ValueType,
@@ -54,7 +54,7 @@ template <
                                 ApplyFunction, KeyType, ValueType>::value &&
                                 std::is_same<void, ApplyType>::value,
                             int>::type = 0>
-inline void apply(const Map<KeyType, ValueType> &map, ApplyFunction &&f) {
+inline void apply_map(const Map<KeyType, ValueType> &map, ApplyFunction &&f) {
   for (const auto &pair : map) {
     f(pair.first, pair.second);
   }
@@ -69,8 +69,8 @@ template <
                                 ApplyFunction, KeyType, ValueType>::value &&
                                 !std::is_same<void, ApplyType>::value,
                             int>::type = 0>
-inline Grouped<KeyType, ApplyType> apply(const Map<KeyType, ValueType> &map,
-                                         ApplyFunction &&f) {
+inline Grouped<KeyType, ApplyType> apply_map(const Map<KeyType, ValueType> &map,
+                                             ApplyFunction &&f) {
   Grouped<KeyType, ApplyType> output;
   for (const auto &pair : map) {
     output.emplace(pair.first, f(pair.first, pair.second));
@@ -86,8 +86,8 @@ template <template <typename...> class Map, typename KeyType,
                                       ApplyFunction, ValueType>::value &&
                                       !std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
-inline Grouped<KeyType, ApplyType> apply(const Map<KeyType, ValueType> &map,
-                                         ApplyFunction &&f) {
+inline Grouped<KeyType, ApplyType> apply_map(const Map<KeyType, ValueType> &map,
+                                             ApplyFunction &&f) {
   Grouped<KeyType, ApplyType> output;
   for (const auto &pair : map) {
     output.emplace(pair.first, f(pair.second));
@@ -103,10 +103,20 @@ template <template <typename...> class Map, typename KeyType,
                                       ApplyFunction, ValueType>::value &&
                                       std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
-inline void apply(const Map<KeyType, ValueType> &map, ApplyFunction &&f) {
+inline void apply_map(const Map<KeyType, ValueType> &map, ApplyFunction &&f) {
   for (const auto &pair : map) {
     f(pair.second);
   }
+}
+
+template <typename KeyType, typename ValueType, typename ApplyFunction>
+inline auto apply(const std::map<KeyType, ValueType> &map, ApplyFunction &&f) {
+  return apply_map(map, std::forward<ApplyFunction>(f));
+}
+
+template <typename KeyType, typename ValueType, typename ApplyFunction>
+inline auto apply(const Grouped<KeyType, ValueType> &map, ApplyFunction &&f) {
+  return apply_map(map, std::forward<ApplyFunction>(f));
 }
 
 } // namespace albatross

--- a/include/albatross/src/indexing/filter.hpp
+++ b/include/albatross/src/indexing/filter.hpp
@@ -39,8 +39,8 @@ template <template <typename...> class Map, typename KeyType,
           typename std::enable_if<details::is_valid_value_only_filter_function<
                                       ToKeepFunction, ValueType>::value,
                                   int>::type = 0>
-inline Grouped<KeyType, ValueType> filter(const Map<KeyType, ValueType> &map,
-                                          ToKeepFunction &&to_keep) {
+inline Grouped<KeyType, ValueType>
+filter_map(const Map<KeyType, ValueType> &map, ToKeepFunction &&to_keep) {
   Grouped<KeyType, ValueType> output;
   for (const auto &pair : map) {
     if (to_keep(pair.second)) {
@@ -56,8 +56,8 @@ template <
     typename std::enable_if<details::is_valid_key_value_filter_function<
                                 ToKeepFunction, KeyType, ValueType>::value,
                             int>::type = 0>
-inline Grouped<KeyType, ValueType> filter(const Map<KeyType, ValueType> &map,
-                                          ToKeepFunction &&to_keep) {
+inline Grouped<KeyType, ValueType>
+filter_map(const Map<KeyType, ValueType> &map, ToKeepFunction &&to_keep) {
   Grouped<KeyType, ValueType> output;
   for (const auto &pair : map) {
     if (to_keep(pair.first, pair.second)) {
@@ -65,6 +65,17 @@ inline Grouped<KeyType, ValueType> filter(const Map<KeyType, ValueType> &map,
     }
   }
   return output;
+}
+
+template <typename KeyType, typename ValueType, typename ToKeepFunction>
+inline auto filter(const std::map<KeyType, ValueType> &map,
+                   ToKeepFunction &&f) {
+  return filter_map(map, std::forward<ToKeepFunction>(f));
+}
+
+template <typename KeyType, typename ValueType, typename ToKeepFunction>
+inline auto filter(const Grouped<KeyType, ValueType> &map, ToKeepFunction &&f) {
+  return filter_map(map, std::forward<ToKeepFunction>(f));
 }
 
 } // namespace albatross

--- a/tests/test_apply.cc
+++ b/tests/test_apply.cc
@@ -133,6 +133,22 @@ TEST(test_apply, test_vector_apply_void) {
   EXPECT_EQ(call_count, xs.size());
 }
 
+struct AutoApplyTest {
+  AutoApplyTest(int x_) : x(x_){};
+  int x;
+};
+
+TEST(test_apply, test_works_with_auto) {
+
+  std::vector<AutoApplyTest> values;
+  values.emplace_back(0);
+  values.emplace_back(1);
+
+  auto apply_func_with_auto = [](const auto &f) { return f.x; };
+
+  const auto output = apply(values, apply_func_with_auto);
+}
+
 TEST(test_apply, test_vector_apply_all) {
 
   std::vector<std::vector<bool>> input;


### PR DESCRIPTION
This fixes a tricky bug in in the `apply` and `filter` free functions.  The problem is that we were detecting map-like arguments using a templated template parameter by doing something like this,
```
template<template <typename...> class Map, typename KeyType, typename ValueType>
void apply(Map<KeyType, ValueType> &map)
```
Which *does* match map-like types, but because vectors also take two template parameters (one is a default) it also matches `std::vector<T, allocator<T>>`.

More specifically the `apply` and `filter` methods for maps look something like this (I've abridged it a bit):

```
template <template <typename...> class Map, typename KeyType,
          typename ValueType, typename ApplyFunction,
          typename ApplyType = invoke_result_t<ApplyFunction, ValueType>>
auto apply(const Map<KeyType, ValueType> &map, ApplyFunction &&f)
```

To illustrate what happens we can start with a fully resolved lambda:
```
auto resolved = [](X x) ->void {};
```
We then try to call:
```
std::vector<X> xs;
apply(xs, resolved);
```
The compiler will first try the map version of apply with `Map = std::vector`, `KeyType = X`, `ValueType = std::allocator<X>`.  It then tries to resolve the `ApplyType` by using `invoke_result<ApplyFunction, ValueType>` which gets the type returned when calling `resolved(std::allocator<X>)` but realizes that `resolved` is not invocable with `std::allocator<X>` so it causes a substitution failure and proceeds trying to resolve the other overloaded candidates for `apply` and eventually lands on the `vector` version in which case it happily proceeds. 

Now, to understand this bug, consider the situation where we pass in an unresolved lambda method in as `ApplyFunction`.  Ie,
```
auto unresolved = [](auto x) {x.some_method_only_X_has};
```
In this situation the compiler will again try substituting `Map = std::vector`, `KeyType = X`, `ValueType = std::allocator<X>` into the map version of apply.  when it hits `invoke_result` it will try to get the result of calling `unresolved(std::allocator<X>)` which this time is a potentially valid call (with `auto = std::allocator<X>`).  So the compiler continues to try and resolve the return type which requires compiling the body of the lambda but in the process it encounters and error and hard fails.

Here's the important line from the [SFINAE](https://en.cppreference.com/w/cpp/language/sfinae) documentation:
> Only the failures in the types and expressions in the immediate context of the function type or its template parameter types or its explicit specifier (since C++20) are SFINAE errors. If the evaluation of a substituted type/expression causes a side-effect such as instantiation of some template specialization, generation of an implicitly-defined member function, etc, errors in those side-effects are treated as hard errors. **A lambda expression is not considered part of the immediate context.**

To fix this I switched all the template heavy `apply` and `filter` methods for maps to be `apply_map` and `filter_map` and then provided very specific wrappers around that for `std::map` and `albatross::Grouped` objects.