### PR TITLE
First pass async with maps

### DIFF
--- a/include/albatross/Indexing
+++ b/include/albatross/Indexing
@@ -19,6 +19,9 @@
 #include <albatross/src/indexing/subset.hpp>
 #include <albatross/src/indexing/filter.hpp>
 #include <albatross/src/indexing/apply.hpp>
+
+#include "utils/AsyncUtils"
+
 #include <albatross/src/indexing/group_by.hpp>
 
 #endif

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -36,9 +36,9 @@ auto select_overload(ReturnType (*fptr)(const Arg &)) {
  * that facilitates applying a function to all values, filtering etc ...
  */
 
-template <typename KeyType, typename ValueType>
-class GroupedBase {
- public:
+template <typename KeyType, typename ValueType> class GroupedBase {
+
+public:
   GroupedBase() : map_(){};
   GroupedBase(const GroupedBase &other) = default;
   GroupedBase(std::map<KeyType, ValueType> &&map) : map_(std::move(map)){};
@@ -101,8 +101,7 @@ class GroupedBase {
    * groups you would like to keep.  This is done by providing a function which
    * returns bool when provided with a group (or group key and group)
    */
-  template <typename FilterFunction>
-  auto filter(FilterFunction &&f) const {
+  template <typename FilterFunction> auto filter(FilterFunction &&f) const {
     return albatross::filter(map_, std::forward<FilterFunction>(f));
   }
 
@@ -112,17 +111,15 @@ class GroupedBase {
    * (or group key and group).  If the function returns something other than
    * void the results will be aggregated into a new Grouped object.
    */
-  template <typename ApplyFunction>
-  auto apply(ApplyFunction &&f) const {
+  template <typename ApplyFunction> auto apply(ApplyFunction &&f) const {
     return albatross::apply(map_, std::forward<ApplyFunction>(f));
   }
 
-  template <typename ApplyFunction>
-  auto async_apply(ApplyFunction &&f) const {
+  template <typename ApplyFunction> auto async_apply(ApplyFunction &&f) const {
     return albatross::async_apply(map_, std::forward<ApplyFunction>(f));
   }
 
- protected:
+protected:
   std::map<KeyType, ValueType> map_;
 };
 
@@ -142,7 +139,7 @@ class Grouped<KeyType, ValueType,
   using Base = GroupedBase<KeyType, ValueType>;
   using Base::Base;
 
- public:
+public:
   bool all() const { return albatross::all(this->values()); }
 
   auto any() const { return albatross::any(this->values()); }
@@ -159,7 +156,7 @@ class Grouped<KeyType, ValueType,
   using Base = GroupedBase<KeyType, ValueType>;
   using Base::Base;
 
- public:
+public:
   auto sum() const {
     ValueType output = 0.;
     for (const auto &pair : this->map_) {
@@ -191,7 +188,7 @@ class Grouped<KeyType, EigenXpr,
 template <typename KeyType>
 class Grouped<KeyType, GroupIndices>
     : public GroupedBase<KeyType, GroupIndices> {
- public:
+public:
   using Base = GroupedBase<KeyType, GroupIndices>;
   using Base::Base;
 
@@ -219,15 +216,15 @@ class Grouped<KeyType, GroupIndices>
  */
 template <template <typename...> class Map, typename KeyType,
           typename FeatureType>
-RegressionDataset<FeatureType> combine(
-    const Map<KeyType, RegressionDataset<FeatureType>> &groups) {
+RegressionDataset<FeatureType>
+combine(const Map<KeyType, RegressionDataset<FeatureType>> &groups) {
   return concatenate_datasets(map_values(groups));
 }
 
 template <template <typename...> class Map, typename KeyType,
           typename FeatureType>
-std::vector<FeatureType> combine(
-    const Map<KeyType, std::vector<FeatureType>> &groups) {
+std::vector<FeatureType>
+combine(const Map<KeyType, std::vector<FeatureType>> &groups) {
   return concatenate(map_values(groups));
 }
 
@@ -249,7 +246,7 @@ Eigen::VectorXd combine(const Map<KeyType, double> &groups) {
  */
 template <typename KeyType, typename ValueType>
 class CombinableBase : public GroupedBase<KeyType, ValueType> {
- public:
+public:
   using Base = GroupedBase<KeyType, ValueType>;
   using Base::Base;
 
@@ -276,8 +273,8 @@ class Grouped<KeyType, std::vector<FeatureType>>
  * indices not the actual values.  This `IndexBuilder` class is responsible
  * for distinguishing between these different approaches.
  */
-template <typename GrouperFunction>
-struct IndexerBuilder {
+template <typename GrouperFunction> struct IndexerBuilder {
+
   template <
       typename Iterable,
       typename IterableValue = typename const_ref<typename std::iterator_traits<
@@ -308,8 +305,7 @@ struct IndexerBuilder {
 };
 
 struct LeaveOneOutGrouper {
-  template <typename Arg>
-  std::size_t operator()(const Arg &) const {
+  template <typename Arg> std::size_t operator()(const Arg &) const {
     static_assert(
         delay_static_assert<Arg>::value,
         "You shouldn't be calling LeaveOneOutGrouper directly, pass it into "
@@ -318,8 +314,8 @@ struct LeaveOneOutGrouper {
   };
 };
 
-template <>
-struct IndexerBuilder<LeaveOneOutGrouper> {
+template <> struct IndexerBuilder<LeaveOneOutGrouper> {
+
   template <typename Iterable>
   static auto build(const LeaveOneOutGrouper &grouper_function,
                     const Iterable &iterable) {
@@ -337,12 +333,12 @@ struct IndexerBuilder<LeaveOneOutGrouper> {
 };
 
 struct KFoldGrouper {
+
   KFoldGrouper(std::size_t k_ = 2) : k(k_){};
 
   std::size_t k;
 
-  template <typename Arg>
-  std::size_t operator()(const Arg &) const {
+  template <typename Arg> std::size_t operator()(const Arg &) const {
     static_assert(
         delay_static_assert<Arg>::value,
         "You shouldn't be calling KFoldGrouper directly, pass it into "
@@ -351,8 +347,8 @@ struct KFoldGrouper {
   };
 };
 
-template <>
-struct IndexerBuilder<KFoldGrouper> {
+template <> struct IndexerBuilder<KFoldGrouper> {
+
   template <typename Iterable>
   static auto build(const KFoldGrouper &grouper_function,
                     const Iterable &iterable) {
@@ -381,9 +377,9 @@ inline auto build_indexer(const GrouperFunction &grouper_function,
  * This is the base class holding common operations for classes which can
  * be grouped.
  */
-template <typename Derived>
-class GroupByBase {
- public:
+template <typename Derived> class GroupByBase {
+
+public:
   using KeyType = typename details::group_by_traits<Derived>::KeyType;
   using ValueType = typename details::group_by_traits<Derived>::ValueType;
   using GrouperType = typename details::group_by_traits<Derived>::GrouperType;
@@ -409,8 +405,7 @@ class GroupByBase {
 
   std::size_t size() const { return indexers().size(); }
 
-  template <typename ApplyFunction>
-  auto apply(const ApplyFunction &f) const {
+  template <typename ApplyFunction> auto apply(const ApplyFunction &f) const {
     return groups().apply(f);
   }
 
@@ -459,8 +454,7 @@ class GroupByBase {
     }
   }
 
-  template <typename FilterFunction>
-  auto filter(FilterFunction f) const {
+  template <typename FilterFunction> auto filter(FilterFunction f) const {
     return groups().filter(f);
   }
 
@@ -472,12 +466,12 @@ class GroupByBase {
     return output;
   }
 
- protected:
+protected:
   ValueType parent_;
   GrouperType grouper_;
   IndexerType indexers_;
 
- private:
+private:
   IndexerType build_indexers() const {
     return albatross::build_indexer(grouper_, derived()._get_iterable());
   }
@@ -496,11 +490,12 @@ template <typename FeatureType, typename GrouperFunction>
 class GroupBy<RegressionDataset<FeatureType>, GrouperFunction>
     : public GroupByBase<
           GroupBy<RegressionDataset<FeatureType>, GrouperFunction>> {
+
   static_assert(!std::is_same<GrouperFunction, void>::value,
                 "GrouperFunction is void (this may indicate the function won't "
                 "compile).");
 
- public:
+public:
   using Base =
       GroupByBase<GroupBy<RegressionDataset<FeatureType>, GrouperFunction>>;
   using Base::Base;
@@ -514,11 +509,12 @@ class GroupBy<RegressionDataset<FeatureType>, GrouperFunction>
 template <typename FeatureType, typename GrouperFunction>
 class GroupBy<std::vector<FeatureType>, GrouperFunction>
     : public GroupByBase<GroupBy<std::vector<FeatureType>, GrouperFunction>> {
+
   static_assert(!std::is_same<GrouperFunction, void>::value,
                 "GrouperFunction is void (this may indicate the function won't "
                 "compile).");
 
- public:
+public:
   using Base = GroupByBase<GroupBy<std::vector<FeatureType>, GrouperFunction>>;
   using Base::Base;
 
@@ -553,6 +549,6 @@ auto group_by(const std::vector<FeatureType> &vector, GrouperFunc grouper) {
                                                         std::move(grouper));
 }
 
-}  // namespace albatross
+} // namespace albatross
 
 #endif /* ALBATROSS_INDEXING_GROUPBY_HPP_ */

--- a/include/albatross/src/utils/async_utils.hpp
+++ b/include/albatross/src/utils/async_utils.hpp
@@ -32,10 +32,10 @@ template <typename ValueType, typename ApplyFunction,
                                       ApplyFunction, ValueType>::value &&
                                       std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
-void async_apply(const std::vector<ValueType> &xs, const ApplyFunction &f) {
+void async_apply(const std::vector<ValueType> &xs, const ApplyFunction &func) {
   std::vector<std::future<void>> futures;
   for (const auto &x : xs) {
-    futures.emplace_back(async_safe(f, x));
+    futures.emplace_back(async_safe(func, x));
   }
   for (auto &f : futures) {
     f.get();
@@ -49,10 +49,10 @@ template <typename ValueType, typename ApplyFunction,
                                       ApplyFunction, ValueType>::value &&
                                       !std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
-auto async_apply(const std::vector<ValueType> &xs, const ApplyFunction &f) {
+auto async_apply(const std::vector<ValueType> &xs, const ApplyFunction &func) {
   std::vector<std::future<ApplyType>> futures;
   for (const auto &x : xs) {
-    futures.emplace_back(async_safe(f, x));
+    futures.emplace_back(async_safe(func, x));
   }
 
   std::vector<ApplyType> output;
@@ -70,16 +70,15 @@ template <template <typename...> class Map, typename KeyType,
                                       ApplyFunction, ValueType>::value &&
                                       std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
-void async_apply_map(const Map<KeyType, ValueType> &xs,
-                     const ApplyFunction &f) {
+inline void async_apply_map(const Map<KeyType, ValueType> &xs,
+                            const ApplyFunction &func) {
   std::vector<std::future<void>> futures;
   for (const auto &x : xs) {
-    futures.emplace_back(async_safe(f, x.second));
+    futures.emplace_back(async_safe(func, x.second));
   }
   for (auto &f : futures) {
     f.get();
   }
-  std::cout << "This was called, void, no key" << std::endl;
 }
 
 template <template <typename...> class Map, typename KeyType,
@@ -91,17 +90,16 @@ template <template <typename...> class Map, typename KeyType,
                                       !std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
 inline Grouped<KeyType, ApplyType> async_apply_map(
-    const Map<KeyType, ValueType> &xs, const ApplyFunction &f) {
-  Map<KeyType, std::future<ApplyType>> futures;
+    const Map<KeyType, ValueType> &xs, const ApplyFunction &func) {
+  Grouped<KeyType, std::future<ApplyType>> futures;
   for (const auto &x : xs) {
-    futures[x.first] = async_safe(f, x.second);
+    futures[x.first] = async_safe(func, x.second);
   }
 
-  Map<KeyType, ApplyType> output;
+  Grouped<KeyType, ApplyType> output;
   for (auto &f : futures) {
     output[f.first] = f.second.get();
   }
-  std::cout << "This was called, return, no key" << std::endl;
   return output;
 }
 
@@ -114,16 +112,15 @@ template <
                                 ApplyFunction, KeyType, ValueType>::value &&
                                 std::is_same<void, ApplyType>::value,
                             int>::type = 0>
-void async_apply_map(const Map<KeyType, ValueType> &xs,
-                     const ApplyFunction &f) {
+inline void async_apply_map(const Map<KeyType, ValueType> &xs,
+                            const ApplyFunction &func) {
   std::vector<std::future<void>> futures;
   for (const auto &x : xs) {
-    futures.emplace_back(async_safe(f, x.first, x.second));
+    futures.emplace_back(async_safe(func, x.first, x.second));
   }
   for (auto &f : futures) {
     f.get();
   }
-  std::cout << "This was called, void, with key" << std::endl;
 }
 
 template <
@@ -136,17 +133,16 @@ template <
                                 !std::is_same<void, ApplyType>::value,
                             int>::type = 0>
 inline Grouped<KeyType, ApplyType> async_apply_map(
-    const Map<KeyType, ValueType> &xs, const ApplyFunction &f) {
-  Map<KeyType, std::future<ApplyType>> futures;
+    const Map<KeyType, ValueType> &xs, const ApplyFunction &func) {
+  Grouped<KeyType, std::future<ApplyType>> futures;
   for (const auto &x : xs) {
-    futures[x.first] = async_safe(f, x.first, x.second);
+    futures[x.first] = async_safe(func, x.first, x.second);
   }
 
-  Map<KeyType, ApplyType> output;
+  Grouped<KeyType, ApplyType> output;
   for (auto &f : futures) {
     output[f.first] = f.second.get();
   }
-  std::cout << "This was called, return, with key" << std::endl;
   return output;
 }
 

--- a/include/albatross/src/utils/async_utils.hpp
+++ b/include/albatross/src/utils/async_utils.hpp
@@ -150,6 +150,16 @@ inline Grouped<KeyType, ApplyType> async_apply_map(
   return output;
 }
 
+    template <typename KeyType, typename ValueType, typename ApplyFunction>
+    inline auto async_apply(const std::map<KeyType, ValueType> &map, ApplyFunction &&f) {
+      return async_apply_map(map, std::forward<ApplyFunction>(f));
+    }
+
+    template <typename KeyType, typename ValueType, typename ApplyFunction>
+    inline auto async_apply(const Grouped<KeyType, ValueType> &map, ApplyFunction &&f) {
+      return async_apply_map(map, std::forward<ApplyFunction>(f));
+    }
+
 }  // namespace albatross
 
 #endif /* INCLUDE_ALBATROSS_SRC_UTILS_ASYNC_UTILS_HPP_ */

--- a/include/albatross/src/utils/async_utils.hpp
+++ b/include/albatross/src/utils/async_utils.hpp
@@ -150,15 +150,17 @@ inline Grouped<KeyType, ApplyType> async_apply_map(
   return output;
 }
 
-    template <typename KeyType, typename ValueType, typename ApplyFunction>
-    inline auto async_apply(const std::map<KeyType, ValueType> &map, ApplyFunction &&f) {
-      return async_apply_map(map, std::forward<ApplyFunction>(f));
-    }
+template <typename KeyType, typename ValueType, typename ApplyFunction>
+inline auto async_apply(const std::map<KeyType, ValueType> &map,
+                        ApplyFunction &&f) {
+  return async_apply_map(map, std::forward<ApplyFunction>(f));
+}
 
-    template <typename KeyType, typename ValueType, typename ApplyFunction>
-    inline auto async_apply(const Grouped<KeyType, ValueType> &map, ApplyFunction &&f) {
-      return async_apply_map(map, std::forward<ApplyFunction>(f));
-    }
+template <typename KeyType, typename ValueType, typename ApplyFunction>
+inline auto async_apply(const Grouped<KeyType, ValueType> &map,
+                        ApplyFunction &&f) {
+  return async_apply_map(map, std::forward<ApplyFunction>(f));
+}
 
 }  // namespace albatross
 

--- a/include/albatross/src/utils/async_utils.hpp
+++ b/include/albatross/src/utils/async_utils.hpp
@@ -89,8 +89,8 @@ template <template <typename...> class Map, typename KeyType,
                                       ApplyFunction, ValueType>::value &&
                                       !std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
-inline Grouped<KeyType, ApplyType> async_apply_map(
-    const Map<KeyType, ValueType> &xs, const ApplyFunction &func) {
+inline Grouped<KeyType, ApplyType>
+async_apply_map(const Map<KeyType, ValueType> &xs, const ApplyFunction &func) {
   Grouped<KeyType, std::future<ApplyType>> futures;
   for (const auto &x : xs) {
     futures[x.first] = async_safe(func, x.second);
@@ -132,8 +132,8 @@ template <
                                 ApplyFunction, KeyType, ValueType>::value &&
                                 !std::is_same<void, ApplyType>::value,
                             int>::type = 0>
-inline Grouped<KeyType, ApplyType> async_apply_map(
-    const Map<KeyType, ValueType> &xs, const ApplyFunction &func) {
+inline Grouped<KeyType, ApplyType>
+async_apply_map(const Map<KeyType, ValueType> &xs, const ApplyFunction &func) {
   Grouped<KeyType, std::future<ApplyType>> futures;
   for (const auto &x : xs) {
     futures[x.first] = async_safe(func, x.first, x.second);
@@ -158,6 +158,6 @@ inline auto async_apply(const Grouped<KeyType, ValueType> &map,
   return async_apply_map(map, std::forward<ApplyFunction>(f));
 }
 
-}  // namespace albatross
+} // namespace albatross
 
 #endif /* INCLUDE_ALBATROSS_SRC_UTILS_ASYNC_UTILS_HPP_ */

--- a/include/albatross/src/utils/async_utils.hpp
+++ b/include/albatross/src/utils/async_utils.hpp
@@ -62,6 +62,47 @@ auto async_apply(const std::vector<ValueType> &xs, const ApplyFunction &f) {
   return output;
 }
 
-} // namespace albatross
+template <typename KeyType, typename ValueType, typename ApplyFunction,
+          typename ApplyType = typename details::value_only_apply_result<
+              ApplyFunction, ValueType>::type,
+          typename std::enable_if<details::is_valid_value_only_apply_function<
+                                      ApplyFunction, ValueType>::value &&
+                                      std::is_same<void, ApplyType>::value,
+                                  int>::type = 0>
+void async_apply(const std::map<KeyType, ValueType> &xs,
+                 const ApplyFunction &f) {
+  std::map<KeyType, std::future<void>> futures;
+  for (const auto &x : xs) {
+    futures[x.first] = async_safe(f, x.second);
+  }
+  for (auto &f : futures) {
+    f.second.get();
+  }
+  std::cout << "This was called, void" << std::endl;
+}
+
+template <typename KeyType, typename ValueType, typename ApplyFunction,
+          typename ApplyType = typename details::value_only_apply_result<
+              ApplyFunction, ValueType>::type,
+          typename std::enable_if<details::is_valid_value_only_apply_function<
+                                      ApplyFunction, ValueType>::value &&
+                                      !std::is_same<void, ApplyType>::value,
+                                  int>::type = 0>
+auto async_apply(const std::map<KeyType, ValueType> &xs,
+                 const ApplyFunction &f) {
+  std::map<KeyType, std::future<ApplyType>> futures;
+  for (const auto &x : xs) {
+    futures[x.first] = async_safe(f, x.second);
+  }
+
+  std::map<KeyType, ApplyType> output;
+  for (auto &f : futures) {
+    output[f.first] = f.second.get();
+  }
+  std::cout << "This was called, return" << std::endl;
+  return output;
+}
+
+}  // namespace albatross
 
 #endif /* INCLUDE_ALBATROSS_SRC_UTILS_ASYNC_UTILS_HPP_ */

--- a/tests/test_async_utils.cc
+++ b/tests/test_async_utils.cc
@@ -176,4 +176,4 @@ TEST(test_async_utils, test_async_apply_speedup_key_value_function) {
   EXPECT_GT(end_direct - start_direct, std::chrono::seconds(xs.size() - 1));
 }
 
-}  // namespace albatross
+} // namespace albatross

--- a/tests/test_async_utils.cc
+++ b/tests/test_async_utils.cc
@@ -45,7 +45,7 @@ TEST(test_async_utils, test_async_apply_with_capture) {
   EXPECT_NE(order_processed, xs);
 }
 
-TEST(test_async_utils, test_async_apply_with_capture_map) {
+TEST(test_async_utils, test_async_apply_map_value_only_function) {
   std::map<std::string, int> xs = {{"0", 0}, {"1", 1}, {"2", 2},
                                    {"3", 3}, {"4", 4}, {"5", 5}};
 
@@ -69,7 +69,7 @@ TEST(test_async_utils, test_async_apply_with_capture_map) {
   EXPECT_NE(order_processed, map_order);
 }
 
-TEST(test_async_utils, test_async_apply_with_capture_map_key) {
+TEST(test_async_utils, test_async_apply_map_key_value_function) {
   std::map<std::string, int> xs = {{"0", 0}, {"1", 1}, {"2", 2},
                                    {"3", 3}, {"4", 4}, {"5", 5}};
 
@@ -94,7 +94,7 @@ TEST(test_async_utils, test_async_apply_with_capture_map_key) {
   EXPECT_NE(order_processed, map_order);
 }
 
-TEST(test_async_utils, test_async_is_faster) {
+TEST(test_async_utils, test_async_apply_speedup_vector) {
   auto slow_process = [&](const int i) {
     const auto start = std::chrono::system_clock::now();
     std::chrono::seconds delay(1);
@@ -119,11 +119,10 @@ TEST(test_async_utils, test_async_is_faster) {
   const auto end_direct = std::chrono::system_clock::now();
 
   EXPECT_EQ(actual, expected);
-
   EXPECT_GT(end_direct - start_direct, std::chrono::seconds(inds.size() - 1));
 }
 
-TEST(test_async_utils, test_async_is_faster_maps) {
+TEST(test_async_utils, test_async_apply_speedup_value_only_function) {
   auto slow_square = [&](const int i) {
     const auto start = std::chrono::system_clock::now();
     std::chrono::seconds delay(1);
@@ -139,10 +138,6 @@ TEST(test_async_utils, test_async_is_faster_maps) {
   const auto end = std::chrono::system_clock::now();
 
   EXPECT_LT(end - start, std::chrono::seconds(xs.size() - 1));
-  const double time =
-      std::chrono::duration_cast<std::chrono::duration<double>>(end - start)
-          .count();
-  std::cout << time << std::endl;
 
   const auto start_direct = std::chrono::system_clock::now();
   const auto expected = apply(xs, slow_square);
@@ -152,14 +147,9 @@ TEST(test_async_utils, test_async_is_faster_maps) {
     EXPECT_EQ(actual.at(x.first), x.second);
   }
   EXPECT_GT(end_direct - start_direct, std::chrono::seconds(xs.size() - 1));
-  const double time_direct =
-      std::chrono::duration_cast<std::chrono::duration<double>>(end_direct -
-                                                                start_direct)
-          .count();
-  std::cout << time_direct << std::endl;
 }
 
-TEST(test_async_utils, test_async_is_faster_map_key) {
+TEST(test_async_utils, test_async_apply_speedup_key_value_function) {
   auto slow_square = [&](const double key, const int i) {
     const auto start = std::chrono::system_clock::now();
     std::chrono::seconds delay(1);
@@ -175,10 +165,6 @@ TEST(test_async_utils, test_async_is_faster_map_key) {
   const auto end = std::chrono::system_clock::now();
 
   EXPECT_LT(end - start, std::chrono::seconds(xs.size() - 1));
-  const double time =
-      std::chrono::duration_cast<std::chrono::duration<double>>(end - start)
-          .count();
-  std::cout << time << std::endl;
 
   const auto start_direct = std::chrono::system_clock::now();
   const auto expected = apply(xs, slow_square);
@@ -188,11 +174,6 @@ TEST(test_async_utils, test_async_is_faster_map_key) {
     EXPECT_EQ(actual.at(x.first), x.second);
   }
   EXPECT_GT(end_direct - start_direct, std::chrono::seconds(xs.size() - 1));
-  const double time_direct =
-      std::chrono::duration_cast<std::chrono::duration<double>>(end_direct -
-                                                                start_direct)
-          .count();
-  std::cout << time_direct << std::endl;
 }
 
 }  // namespace albatross

--- a/tests/test_async_utils.cc
+++ b/tests/test_async_utils.cc
@@ -61,7 +61,32 @@ TEST(test_async_utils, test_async_apply_with_capture_map) {
     order_processed.push_back(x);
   };
 
-  async_apply(xs, add_to_sum);
+  async_apply_map(xs, add_to_sum);
+
+  EXPECT_EQ(sum, 15);
+  // Make sure the async apply was indeed processed out of order.
+  std::vector<int> map_order = {0, 1, 2, 3, 4, 5};
+  EXPECT_NE(order_processed, map_order);
+}
+
+TEST(test_async_utils, test_async_apply_with_capture_map_key) {
+  std::map<std::string, int> xs = {{"0", 0}, {"1", 1}, {"2", 2},
+                                   {"3", 3}, {"4", 4}, {"5", 5}};
+
+  std::mutex mu;
+  int sum = 0.;
+
+  std::vector<int> order_processed;
+
+  auto add_to_sum = [&](const std::string &key, const int x) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(abs(x - 2)));
+    std::lock_guard<std::mutex> lock(mu);
+    sum += x;
+    order_processed.push_back(x);
+    std::cout << key << std::endl;
+  };
+
+  async_apply_map(xs, add_to_sum);
 
   EXPECT_EQ(sum, 15);
   // Make sure the async apply was indeed processed out of order.
@@ -110,7 +135,43 @@ TEST(test_async_utils, test_async_is_faster_maps) {
   std::map<std::string, int> xs = {{"0", 0}, {"1", 1}, {"2", 2}, {"3", 3}};
 
   const auto start = std::chrono::system_clock::now();
-  const auto actual = async_apply(xs, slow_square);
+  const auto actual = async_apply_map(xs, slow_square);
+  const auto end = std::chrono::system_clock::now();
+
+  EXPECT_LT(end - start, std::chrono::seconds(xs.size() - 1));
+  const double time =
+      std::chrono::duration_cast<std::chrono::duration<double>>(end - start)
+          .count();
+  std::cout << time << std::endl;
+
+  const auto start_direct = std::chrono::system_clock::now();
+  const auto expected = apply(xs, slow_square);
+  const auto end_direct = std::chrono::system_clock::now();
+
+  for (const auto &x : expected) {
+    EXPECT_EQ(actual.at(x.first), x.second);
+  }
+  EXPECT_GT(end_direct - start_direct, std::chrono::seconds(xs.size() - 1));
+  const double time_direct =
+      std::chrono::duration_cast<std::chrono::duration<double>>(end_direct -
+                                                                start_direct)
+          .count();
+  std::cout << time_direct << std::endl;
+}
+
+TEST(test_async_utils, test_async_is_faster_map_key) {
+  auto slow_square = [&](const double key, const int i) {
+    const auto start = std::chrono::system_clock::now();
+    std::chrono::seconds delay(1);
+    while (std::chrono::system_clock::now() - start < delay) {
+    };
+    return key * i;
+  };
+
+  std::map<double, int> xs = {{0., 0}, {1., 1}, {2., 2}, {3., 3}};
+
+  const auto start = std::chrono::system_clock::now();
+  const auto actual = async_apply_map(xs, slow_square);
   const auto end = std::chrono::system_clock::now();
 
   EXPECT_LT(end - start, std::chrono::seconds(xs.size() - 1));

--- a/tests/test_async_utils.cc
+++ b/tests/test_async_utils.cc
@@ -45,8 +45,31 @@ TEST(test_async_utils, test_async_apply_with_capture) {
   EXPECT_NE(order_processed, xs);
 }
 
-TEST(test_async_utils, test_async_is_faster) {
+TEST(test_async_utils, test_async_apply_with_capture_map) {
+  std::map<std::string, int> xs = {{"0", 0}, {"1", 1}, {"2", 2},
+                                   {"3", 3}, {"4", 4}, {"5", 5}};
 
+  std::mutex mu;
+  int sum = 0.;
+
+  std::vector<int> order_processed;
+
+  auto add_to_sum = [&](const int x) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(abs(x - 2)));
+    std::lock_guard<std::mutex> lock(mu);
+    sum += x;
+    order_processed.push_back(x);
+  };
+
+  async_apply(xs, add_to_sum);
+
+  EXPECT_EQ(sum, 15);
+  // Make sure the async apply was indeed processed out of order.
+  std::vector<int> map_order = {0, 1, 2, 3, 4, 5};
+  EXPECT_NE(order_processed, map_order);
+}
+
+TEST(test_async_utils, test_async_is_faster) {
   auto slow_process = [&](const int i) {
     const auto start = std::chrono::system_clock::now();
     std::chrono::seconds delay(1);
@@ -75,4 +98,40 @@ TEST(test_async_utils, test_async_is_faster) {
   EXPECT_GT(end_direct - start_direct, std::chrono::seconds(inds.size() - 1));
 }
 
-} // namespace albatross
+TEST(test_async_utils, test_async_is_faster_maps) {
+  auto slow_square = [&](const int i) {
+    const auto start = std::chrono::system_clock::now();
+    std::chrono::seconds delay(1);
+    while (std::chrono::system_clock::now() - start < delay) {
+    };
+    return i * i;
+  };
+
+  std::map<std::string, int> xs = {{"0", 0}, {"1", 1}, {"2", 2}, {"3", 3}};
+
+  const auto start = std::chrono::system_clock::now();
+  const auto actual = async_apply(xs, slow_square);
+  const auto end = std::chrono::system_clock::now();
+
+  EXPECT_LT(end - start, std::chrono::seconds(xs.size() - 1));
+  const double time =
+      std::chrono::duration_cast<std::chrono::duration<double>>(end - start)
+          .count();
+  std::cout << time << std::endl;
+
+  const auto start_direct = std::chrono::system_clock::now();
+  const auto expected = apply(xs, slow_square);
+  const auto end_direct = std::chrono::system_clock::now();
+
+  for (const auto &x : expected) {
+    EXPECT_EQ(actual.at(x.first), x.second);
+  }
+  EXPECT_GT(end_direct - start_direct, std::chrono::seconds(xs.size() - 1));
+  const double time_direct =
+      std::chrono::duration_cast<std::chrono::duration<double>>(end_direct -
+                                                                start_direct)
+          .count();
+  std::cout << time_direct << std::endl;
+}
+
+}  // namespace albatross

--- a/tests/test_async_utils.cc
+++ b/tests/test_async_utils.cc
@@ -61,7 +61,7 @@ TEST(test_async_utils, test_async_apply_with_capture_map) {
     order_processed.push_back(x);
   };
 
-  async_apply_map(xs, add_to_sum);
+  async_apply(xs, add_to_sum);
 
   EXPECT_EQ(sum, 15);
   // Make sure the async apply was indeed processed out of order.
@@ -86,7 +86,7 @@ TEST(test_async_utils, test_async_apply_with_capture_map_key) {
     std::cout << key << std::endl;
   };
 
-  async_apply_map(xs, add_to_sum);
+  async_apply(xs, add_to_sum);
 
   EXPECT_EQ(sum, 15);
   // Make sure the async apply was indeed processed out of order.
@@ -135,7 +135,7 @@ TEST(test_async_utils, test_async_is_faster_maps) {
   std::map<std::string, int> xs = {{"0", 0}, {"1", 1}, {"2", 2}, {"3", 3}};
 
   const auto start = std::chrono::system_clock::now();
-  const auto actual = async_apply_map(xs, slow_square);
+  const auto actual = async_apply(xs, slow_square);
   const auto end = std::chrono::system_clock::now();
 
   EXPECT_LT(end - start, std::chrono::seconds(xs.size() - 1));
@@ -171,7 +171,7 @@ TEST(test_async_utils, test_async_is_faster_map_key) {
   std::map<double, int> xs = {{0., 0}, {1., 1}, {2., 2}, {3., 3}};
 
   const auto start = std::chrono::system_clock::now();
-  const auto actual = async_apply_map(xs, slow_square);
+  const auto actual = async_apply(xs, slow_square);
   const auto end = std::chrono::system_clock::now();
 
   EXPECT_LT(end - start, std::chrono::seconds(xs.size() - 1));


### PR DESCRIPTION
```
[----------] 4 tests from test_async_utils
[ RUN      ] test_async_utils.test_async_apply_with_capture
[       OK ] test_async_utils.test_async_apply_with_capture (4 ms)
[ RUN      ] test_async_utils.test_async_apply_with_capture_map
This was called, void
[       OK ] test_async_utils.test_async_apply_with_capture_map (4 ms)
[ RUN      ] test_async_utils.test_async_is_faster
[       OK ] test_async_utils.test_async_is_faster (5000 ms)
[ RUN      ] test_async_utils.test_async_is_faster_maps
This was called, return
1.00013
4.00003
[       OK ] test_async_utils.test_async_is_faster_maps (5000 ms)
[----------] 4 tests from test_async_utils (10008 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (10008 ms total)
[  PASSED  ] 4 tests.
```