### PR TITLE
Switch Sparse GP to the QR Decomposition

### DIFF
--- a/include/albatross/SparseGP
+++ b/include/albatross/SparseGP
@@ -14,6 +14,7 @@
 #define ALBATROSS_SPARSE_GP_H
 
 #include "GP"
+#include "utils/LinalgUtils"
 
 #include <albatross/src/utils/block_utils.hpp>
 #include <albatross/src/utils/eigen_utils.hpp>

--- a/include/albatross/serialize/Common
+++ b/include/albatross/serialize/Common
@@ -13,6 +13,8 @@
 #ifndef ALBATROSS_SERIALIZE_COMMON_H
 #define ALBATROSS_SERIALIZE_COMMON_H
 
+#include <albatross/Common>
+
 #include <cereal/cereal.hpp>
 #include <cereal/archives/binary.hpp>
 #include <cereal/archives/json.hpp>

--- a/include/albatross/serialize/Core
+++ b/include/albatross/serialize/Core
@@ -15,6 +15,8 @@
 
 #include "Common"
 
+#include <albatross/Core>
+
 #include "../src/cereal/dataset.hpp"
 #include "../src/cereal/distribution.hpp"
 #include "../src/cereal/fit_model.hpp"

--- a/include/albatross/serialize/GP
+++ b/include/albatross/serialize/GP
@@ -14,6 +14,7 @@
 #define ALBATROSS_SERIALIZE_GP_H
 
 #include "Core"
+#include <albatross/SparseGP>
 
 #include "../src/cereal/block_utils.hpp"
 #include "../src/cereal/serializable_ldlt.hpp"

--- a/include/albatross/serialize/Ransac
+++ b/include/albatross/serialize/Ransac
@@ -15,6 +15,8 @@
 
 #include "Core"
 
+#include <albatross/Ransac>
+
 #include "../src/cereal/ransac.hpp"
 
 #endif

--- a/include/albatross/src/cereal/gp.hpp
+++ b/include/albatross/src/cereal/gp.hpp
@@ -16,6 +16,7 @@
 using albatross::Fit;
 using albatross::GaussianProcessBase;
 using albatross::GPFit;
+using albatross::SparseGPFit;
 
 #ifndef GP_SERIALIZATION_VERSION
 #define GP_SERIALIZATION_VERSION 1
@@ -31,6 +32,16 @@ inline void serialize(Archive &archive,
   archive(cereal::make_nvp("information", fit.information));
   archive(cereal::make_nvp("train_ldlt", fit.train_covariance));
   archive(cereal::make_nvp("train_features", fit.train_features));
+}
+
+template <typename Archive, typename FeatureType>
+inline void serialize(Archive &archive, Fit<SparseGPFit<FeatureType>> &fit,
+                      const std::uint32_t) {
+  archive(cereal::make_nvp("information", fit.information));
+  archive(cereal::make_nvp("train_covariance", fit.train_covariance));
+  archive(cereal::make_nvp("train_features", fit.train_features));
+  archive(cereal::make_nvp("sigma_R", fit.sigma_R));
+  archive(cereal::make_nvp("permutation_indices", fit.permutation_indices));
 }
 
 template <typename Archive, typename CovFunc, typename MeanFunc,

--- a/include/albatross/src/utils/linalg_utils.hpp
+++ b/include/albatross/src/utils/linalg_utils.hpp
@@ -15,6 +15,37 @@
 
 namespace albatross {
 
+inline Eigen::MatrixXd
+get_R(const Eigen::ColPivHouseholderQR<Eigen::MatrixXd> &qr) {
+  // Unfortunately the matrixR() method in Eigen's QR decomposition isn't
+  // actually the R matrix, it's tall skinny matrix whose lower trapezoid
+  // contains internal data, only the upper triangular portion is useful
+  return qr.matrixR()
+      .topRows(qr.matrixR().cols())
+      .template triangularView<Eigen::Upper>();
+}
+
+template <typename MatrixType>
+inline Eigen::MatrixXd sqrt_solve(const Eigen::MatrixXd &R,
+                                  const Eigen::VectorXi &permutation_indices,
+                                  const MatrixType &rhs) {
+
+  Eigen::MatrixXd sqrt(rhs.rows(), rhs.cols());
+  for (Eigen::Index i = 0; i < permutation_indices.size(); ++i) {
+    sqrt.row(i) = rhs.row(permutation_indices.coeff(i));
+  }
+  sqrt = R.template triangularView<Eigen::Upper>().transpose().solve(sqrt);
+  return sqrt;
+}
+
+template <typename MatrixType>
+inline Eigen::MatrixXd
+sqrt_solve(const Eigen::ColPivHouseholderQR<Eigen::MatrixXd> &qr,
+           const MatrixType &rhs) {
+  const Eigen::MatrixXd R = get_R(qr);
+  return sqrt_solve(R, qr.colsPermutation().indices(), rhs);
+}
+
 namespace details {
 
 constexpr double DEFAULT_EIGEN_VALUE_PRINT_THRESHOLD = 1e-3;

--- a/tests/test_block_utils.cc
+++ b/tests/test_block_utils.cc
@@ -112,10 +112,12 @@ TEST(test_block_utils, test_sqrt_methods) {
   Eigen::MatrixXd rhs = Eigen::MatrixXd::Random(dense.cols(), 3);
   const auto block_ldlt = block_diag.ldlt();
 
-  const Eigen::MatrixXd block_result = block_ldlt.sqrt_solve(rhs);
+  const Eigen::MatrixXd block_sqrt = block_ldlt.sqrt_solve(rhs);
+  const Eigen::MatrixXd block_result = block_sqrt.transpose() * block_sqrt;
 
   const Eigen::SerializableLDLT dense_ldlt = dense.ldlt();
-  const Eigen::MatrixXd dense_result = dense_ldlt.sqrt_solve(rhs);
+  const Eigen::MatrixXd dense_sqrt = dense_ldlt.sqrt_solve(rhs);
+  const Eigen::MatrixXd dense_result = dense_sqrt.transpose() * dense_sqrt;
 
   EXPECT_LE((block_result - dense_result).norm(), 1e-6);
 }

--- a/tests/test_linalg_utils.cc
+++ b/tests/test_linalg_utils.cc
@@ -16,6 +16,21 @@
 
 namespace albatross {
 
+TEST(test_linalg_utils, test_qr_sqrt_solve) {
+  const int n = 5;
+  const Eigen::MatrixXd A = Eigen::MatrixXd::Random(2 * n, n);
+
+  const auto qr = A.colPivHouseholderQr();
+
+  const Eigen::MatrixXd rhs = Eigen::MatrixXd::Random(n, 3);
+  const Eigen::MatrixXd expected_quad =
+      rhs.transpose() * (A.transpose() * A).ldlt().solve(rhs);
+  const Eigen::MatrixXd sqrt = sqrt_solve(qr, rhs);
+  const Eigen::MatrixXd actual_quad = sqrt.transpose() * sqrt;
+
+  EXPECT_LT((actual_quad - expected_quad).norm(), 1e-14);
+}
+
 TEST(test_linalg_utils, test_print_eigen_values) {
 
   Eigen::Index k = 10;

--- a/tests/test_serializable_ldlt.cc
+++ b/tests/test_serializable_ldlt.cc
@@ -74,6 +74,14 @@ TEST_F(SerializableLDLTTest, test_sqrt_solve) {
   const Eigen::VectorXd actual_inverse = inv * information;
 
   EXPECT_LE((cov.ldlt().solve(information) - actual_inverse).norm(), 1e-8);
+
+  const Eigen::MatrixXd L = serializable_ldlt.sqrt_product(identity);
+
+  EXPECT_LE((identity - serializable_ldlt.sqrt_solve(L)).norm(), 1e-14);
+
+  const Eigen::MatrixXd LT = L.transpose();
+  EXPECT_LE((identity - serializable_ldlt.sqrt_transpose_solve(LT)).norm(),
+            1e-14);
 }
 
 } // namespace albatross

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -10,11 +10,6 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <albatross/Common>
-#include <albatross/GP>
-#include <albatross/Ransac>
-
-#include <albatross/serialize/Common>
 #include <albatross/serialize/GP>
 #include <albatross/serialize/LeastSquares>
 #include <albatross/serialize/Ransac>

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -201,7 +201,7 @@ TYPED_TEST(SparseGaussianProcessTest, test_likelihood) {
   const double expected = -negative_log_likelihood(dataset.targets.mean, K);
   const double actual = sparse.log_likelihood(dataset);
 
-  EXPECT_NEAR(expected, actual, 1e-6);
+  EXPECT_NEAR(expected, actual, 1e-2);
 }
 
 } // namespace albatross


### PR DESCRIPTION
This PR addresses a numerical stability issue we noticed with the previous approach to the `SparseGaussianProcess`.  In particular the posterior covariance used to be computed as:
```
  C = L^-T R^T R B^-1 L^-1
```
Notice that there is not way to break that formula into a square root form and as a result what was happening is that as the system becomes ill-conditioned not only does the mean computation become unstable (at some point that's unavoidable regardless of approach) but the predicted covariance also because asymmetric.  This would cause steps downstream to fail since subsequent computations using the covariance might fail hard.

To fix this we switched to the QR based approach proposed in,

[Stable and Efficient Gaussian Process Calculations](http://www.jmlr.org/papers/volume10/foster09a/foster09a.pdf)

An outline of the specifics to our approach was included in code comments, but here is a (much) more detailed description:

[Sparse_Gaussian_Process.pdf](https://github.com/swift-nav/albatross/files/4494112/Sparse_Gaussian_Process.pdf)

@pgrgich 