### PR TITLE
Remove LDLT assertion

### DIFF
--- a/include/albatross/src/eigen/serializable_ldlt.hpp
+++ b/include/albatross/src/eigen/serializable_ldlt.hpp
@@ -20,26 +20,16 @@ class SerializableLDLT : public LDLT<MatrixXd, Lower> {
 public:
   SerializableLDLT() : LDLT<MatrixXd, Lower>(){};
 
-  SerializableLDLT(const MatrixXd &x) : LDLT<MatrixXd, Lower>(x.ldlt()) {
-    assert_valid();
-  };
+  SerializableLDLT(const MatrixXd &x) : LDLT<MatrixXd, Lower>(x.ldlt()){};
 
   SerializableLDLT(const LDLT<MatrixXd, Lower> &ldlt)
       // Can we get around copying here?
-      : LDLT<MatrixXd, Lower>(ldlt) {
-    assert_valid();
-  };
+      : LDLT<MatrixXd, Lower>(ldlt){};
 
   SerializableLDLT(const LDLT<MatrixXd, Lower> &&ldlt)
-      : LDLT<MatrixXd, Lower>(std::move(ldlt)) {
-    assert_valid();
-  };
+      : LDLT<MatrixXd, Lower>(std::move(ldlt)){};
 
-  void assert_valid() const {
-    if (this->vectorD().minCoeff() <= 0.) {
-      assert(false && "Attempt to compute LDLT of a non PSD matrix");
-    }
-  }
+  void is_valid() const { return this->vectorD().minCoeff() > 0.; }
 
   LDLT<MatrixXd, Lower>::TranspositionType &mutable_transpositions() {
     return this->m_transpositions;

--- a/include/albatross/src/eigen/serializable_ldlt.hpp
+++ b/include/albatross/src/eigen/serializable_ldlt.hpp
@@ -29,8 +29,6 @@ public:
   SerializableLDLT(const LDLT<MatrixXd, Lower> &&ldlt)
       : LDLT<MatrixXd, Lower>(std::move(ldlt)){};
 
-  void is_valid() const { return this->vectorD().minCoeff() > 0.; }
-
   LDLT<MatrixXd, Lower>::TranspositionType &mutable_transpositions() {
     return this->m_transpositions;
   }


### PR DESCRIPTION
This removes the assertion that the LDLT is positive definite.  While checking that the minimum diagonal value is positive is certainly a good thing to do we don't want a hard failure when you encounter that situation.  Instead checking `is_valid` and deciding how to deal with it appropriately is left to the user.