### PR TITLE
Miscellaneous Helpers

### DIFF
--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -73,6 +73,28 @@ subset(const RegressionDataset<FeatureType> &dataset,
                                         subset(dataset.targets, indices));
 }
 
+template <typename FeatureType>
+RegressionDataset<FeatureType>
+deduplicate(const RegressionDataset<FeatureType> &dataset) {
+  auto is_unique = [&](std::size_t index) -> bool {
+    for (std::size_t j = index + 1; j < dataset.features.size(); ++j) {
+      if (dataset.features[index] == dataset.features[j]) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  std::vector<std::size_t> unique_inds;
+  for (std::size_t i = 0; i < dataset.size(); ++i) {
+    if (is_unique(i)) {
+      unique_inds.push_back(i);
+    }
+  }
+
+  return albatross::subset(dataset, unique_inds);
+}
+
 template <typename X>
 inline auto concatenate_datasets(const RegressionDataset<X> &x,
                                  const RegressionDataset<X> &y) {

--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -76,18 +76,18 @@ subset(const RegressionDataset<FeatureType> &dataset,
 template <typename FeatureType>
 RegressionDataset<FeatureType>
 deduplicate(const RegressionDataset<FeatureType> &dataset) {
-  auto is_unique = [&](std::size_t index) -> bool {
+  auto appears_later = [&](std::size_t index) -> bool {
     for (std::size_t j = index + 1; j < dataset.features.size(); ++j) {
       if (dataset.features[index] == dataset.features[j]) {
-        return false;
+        return true;
       }
     }
-    return true;
+    return false;
   };
 
   std::vector<std::size_t> unique_inds;
   for (std::size_t i = 0; i < dataset.size(); ++i) {
-    if (is_unique(i)) {
+    if (!appears_later(i)) {
       unique_inds.push_back(i);
     }
   }

--- a/include/albatross/src/covariance_functions/linear_combination.hpp
+++ b/include/albatross/src/covariance_functions/linear_combination.hpp
@@ -33,6 +33,10 @@ template <typename X> struct LinearCombination {
     assert(values_.size() == static_cast<std::size_t>(coefficients_.size()));
   };
 
+  bool operator==(const LinearCombination &other) const {
+    return values == other.values && coefficients == other.coefficients;
+  }
+
   std::vector<X> values;
   Eigen::VectorXd coefficients;
 };

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -82,18 +82,38 @@ public:
 
   ValueType first_value() const { return map_.begin()->first; }
 
-  auto min_value() const {
+  // The min entry based on the values
+  auto min() const {
     const auto value_compare = [](const auto &x, const auto &y) {
       return x.second < y.second;
     };
-    return std::min_element(begin(), end(), value_compare)->second;
+    return *std::min_element(begin(), end(), value_compare);
   }
 
-  auto max_value() const {
+  // The max entry based on the values
+  auto max() const {
     const auto value_compare = [](const auto &x, const auto &y) {
       return x.second < y.second;
     };
-    return std::max_element(begin(), end(), value_compare)->second;
+    return *std::max_element(begin(), end(), value_compare);
+  }
+
+  // The key corresponding to the minimum value
+  KeyType min_key() const {
+    return min().first;
+  }
+
+  // The key corresponding to the maximum value
+  KeyType max_value() const {
+    return max().first;
+  }
+
+  ValueType min_value() const {
+    return min().second;
+  }
+
+  ValueType max_value() const {
+    return max().second;
   }
 
   /*

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -99,22 +99,14 @@ public:
   }
 
   // The key corresponding to the minimum value
-  KeyType min_key() const {
-    return min().first;
-  }
+  KeyType min_key() const { return min().first; }
 
   // The key corresponding to the maximum value
-  KeyType max_value() const {
-    return max().first;
-  }
+  KeyType max_key() const { return max().first; }
 
-  ValueType min_value() const {
-    return min().second;
-  }
+  ValueType min_value() const { return min().second; }
 
-  ValueType max_value() const {
-    return max().second;
-  }
+  ValueType max_value() const { return max().second; }
 
   /*
    * Filtering a Grouped object consists of deciding which of the

--- a/include/albatross/src/utils/linalg_utils.hpp
+++ b/include/albatross/src/utils/linalg_utils.hpp
@@ -84,13 +84,15 @@ inline void _print_eigen_directions(const Eigen::MatrixXd &matrix,
     std::vector<std::size_t> sorted_idx(vector.size());
     std::iota(sorted_idx.begin(), sorted_idx.end(), 0);
     std::sort(sorted_idx.begin(), sorted_idx.end(),
-         [&vector](std::size_t ii, std::size_t jj) {return fabs(vector[ii]) > fabs(vector[jj]);});
+              [&vector](std::size_t ii, std::size_t jj) {
+                return fabs(vector[ii]) > fabs(vector[jj]);
+              });
 
-    for (Eigen::Index j = 0; j < sorted_idx.size(); ++j) {
+    for (std::size_t j = 0; j < sorted_idx.size(); ++j) {
       double coef = vector[sorted_idx[j]];
       if (fabs(coef) > print_if_above) {
-        (*stream) << "    " << std::setw(12) << coef << "   " << features[sorted_idx[j]]
-                  << std::endl;
+        (*stream) << "    " << std::setw(12) << coef << "   "
+                  << features[sorted_idx[j]] << std::endl;
       }
     }
   }

--- a/include/albatross/src/utils/linalg_utils.hpp
+++ b/include/albatross/src/utils/linalg_utils.hpp
@@ -79,10 +79,17 @@ inline void _print_eigen_directions(const Eigen::MatrixXd &matrix,
     const double value = std::get<0>(values_and_vectors[i]);
     const auto vector = std::get<1>(values_and_vectors[i]);
     (*stream) << "eigen value: " << value << std::endl;
-    for (Eigen::Index j = 0; j < vector.size(); ++j) {
-      double coef = vector[j];
+
+    // Sort the indices from largest to smallest coef
+    std::vector<std::size_t> sorted_idx(vector.size());
+    std::iota(sorted_idx.begin(), sorted_idx.end(), 0);
+    std::sort(sorted_idx.begin(), sorted_idx.end(),
+         [&vector](std::size_t ii, std::size_t jj) {return fabs(vector[ii]) > fabs(vector[jj]);});
+
+    for (Eigen::Index j = 0; j < sorted_idx.size(); ++j) {
+      double coef = vector[sorted_idx[j]];
       if (fabs(coef) > print_if_above) {
-        (*stream) << "    " << std::setw(12) << coef << "   " << features[j]
+        (*stream) << "    " << std::setw(12) << coef << "   " << features[sorted_idx[j]]
                   << std::endl;
       }
     }

--- a/include/albatross/src/utils/variant_utils.hpp
+++ b/include/albatross/src/utils/variant_utils.hpp
@@ -85,6 +85,25 @@ extract_from_variants(const std::vector<variant<VariantTypes...>> &xs,
   return output;
 }
 
+template <
+    typename OutputType, typename... VariantTypes,
+    std::enable_if_t<is_in_variant<OutputType, variant<VariantTypes...>>::value,
+                     int> = 0>
+inline RegressionDataset<OutputType>
+extract_from_variants(const RegressionDataset<variant<VariantTypes...>> &dataset,
+                      details::ToVariantIdentity<OutputType> && = {}) {
+  std::vector<std::size_t> indices;
+  std::vector<OutputType> features;
+  for (std::size_t i = 0; i < dataset.size(); ++i) {
+    dataset.features[i].match([&](const OutputType &f) {
+      indices.emplace_back(i);
+      features.emplace_back(f);
+    },
+            [](const auto &) {});
+  }
+  return RegressionDataset<OutputType>(features, subset(dataset.targets, indices));
+}
+
 } // namespace albatross
 
 #endif /* ALBATROSS_UTILS_VARIANT_UTILS_HPP_ */

--- a/include/albatross/src/utils/variant_utils.hpp
+++ b/include/albatross/src/utils/variant_utils.hpp
@@ -89,19 +89,21 @@ template <
     typename OutputType, typename... VariantTypes,
     std::enable_if_t<is_in_variant<OutputType, variant<VariantTypes...>>::value,
                      int> = 0>
-inline RegressionDataset<OutputType>
-extract_from_variants(const RegressionDataset<variant<VariantTypes...>> &dataset,
-                      details::ToVariantIdentity<OutputType> && = {}) {
+inline RegressionDataset<OutputType> extract_from_variants(
+    const RegressionDataset<variant<VariantTypes...>> &dataset,
+    details::ToVariantIdentity<OutputType> && = {}) {
   std::vector<std::size_t> indices;
   std::vector<OutputType> features;
   for (std::size_t i = 0; i < dataset.size(); ++i) {
-    dataset.features[i].match([&](const OutputType &f) {
-      indices.emplace_back(i);
-      features.emplace_back(f);
-    },
-            [](const auto &) {});
+    dataset.features[i].match(
+        [&](const OutputType &f) {
+          indices.emplace_back(i);
+          features.emplace_back(f);
+        },
+        [](const auto &) {});
   }
-  return RegressionDataset<OutputType>(features, subset(dataset.targets, indices));
+  return RegressionDataset<OutputType>(features,
+                                       subset(dataset.targets, indices));
 }
 
 } // namespace albatross

--- a/tests/test_core_dataset.cc
+++ b/tests/test_core_dataset.cc
@@ -30,6 +30,19 @@ TEST(test_dataset, test_construct_and_subset) {
   EXPECT_EQ(subset_dataset.size(), indices.size());
 }
 
+TEST(test_dataset, test_deduplicate) {
+  std::vector<int> features = {0, 1, 1, 2};
+  Eigen::VectorXd targets = Eigen::VectorXd::Random(features.size());
+  RegressionDataset<int> dataset(features, targets);
+
+  const auto dedupped = deduplicate(dataset);
+
+  const std::vector<std::size_t> expected_inds = {0, 1, 3};
+
+  EXPECT_EQ(dedupped, albatross::subset(dataset, expected_inds));
+  EXPECT_EQ(dedupped, deduplicate(dedupped));
+}
+
 void expect_split_recombine(const RegressionDataset<int> &dataset) {
   std::vector<std::size_t> first_indices = {0, 1};
   const auto first = subset(dataset, first_indices);

--- a/tests/test_core_dataset.cc
+++ b/tests/test_core_dataset.cc
@@ -37,7 +37,7 @@ TEST(test_dataset, test_deduplicate) {
 
   const auto dedupped = deduplicate(dataset);
 
-  const std::vector<std::size_t> expected_inds = {0, 1, 3};
+  const std::vector<std::size_t> expected_inds = {0, 2, 3};
 
   EXPECT_EQ(dedupped, albatross::subset(dataset, expected_inds));
   EXPECT_EQ(dedupped, deduplicate(dedupped));

--- a/tests/test_group_by.cc
+++ b/tests/test_group_by.cc
@@ -524,6 +524,20 @@ TEST(test_groupby, test_group_by_sum_mean) {
   EXPECT_EQ(expected_sum, means.sum());
 }
 
+TEST(test_groupby, test_group_by_min_max) {
+
+  Grouped<std::string, int> example;
+  example["one"] = 1;
+  example["two"] = 2;
+  example["negative"] = -5;
+  example["large"] = 7;
+
+  EXPECT_EQ(example.max_value(), 7);
+  EXPECT_EQ(example.max_key(), "large");
+  EXPECT_EQ(example.min_value(), -5);
+  EXPECT_EQ(example.min_key(), "negative");
+}
+
 TEST(test_groupby, test_group_by_any_all) {
 
   const auto fib = fibonacci(20);


### PR DESCRIPTION
This adds a few changes that have been helpful upstream:

- min/max key and value lookups: `group_by(get_key).apply(get_value).max_key()` will return the key corresponding to the maximum value returned by `get_value`.
- the eigen value printing utilities now do so sorted by contribution to that eigen vector.
- you can extract subsets from datasets which hold variants.
- an equality operator for linear combinations so they can be compared.
- a `deduplicate` method for datasets.