### PR TITLE
Add update() to FitModel

### DIFF
--- a/include/albatross/src/eigen/serializable_ldlt.hpp
+++ b/include/albatross/src/eigen/serializable_ldlt.hpp
@@ -29,6 +29,8 @@ public:
   SerializableLDLT(const LDLT<MatrixXd, Lower> &&ldlt)
       : LDLT<MatrixXd, Lower>(std::move(ldlt)){};
 
+  bool is_positive_definite() const { return this->vectorD().minCoeff() > 0.; }
+
   LDLT<MatrixXd, Lower>::TranspositionType &mutable_transpositions() {
     return this->m_transpositions;
   }
@@ -90,6 +92,12 @@ public:
   Eigen::MatrixXd sqrt_solve(const MatrixBase<Rhs> &rhs) const {
     return diagonal_sqrt_inverse() *
            this->matrixL().solve(this->transpositionsP() * rhs);
+  }
+
+  Eigen::MatrixXd sqrt_transpose() const {
+    return this->diagonal_sqrt() * (this->transpositionsP().transpose() *
+                                    this->matrixL().toDenseMatrix())
+                                       .transpose();
   }
 
   /*

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -80,7 +80,7 @@ public:
 
   std::pair<KeyType, ValueType> first_group() const { return *map_.begin(); }
 
-  ValueType first_value() const { return map_.begin()->first; }
+  ValueType first_value() const { return map_.begin()->second; }
 
   // The min entry based on the values
   auto min() const {

--- a/include/albatross/src/utils/linalg_utils.hpp
+++ b/include/albatross/src/utils/linalg_utils.hpp
@@ -25,6 +25,9 @@ get_R(const Eigen::ColPivHouseholderQR<Eigen::MatrixXd> &qr) {
       .template triangularView<Eigen::Upper>();
 }
 
+/*
+ * Computes R^-T P^T rhs given R and P from a ColPivHouseholderQR decomposition.
+ */
 template <typename MatrixType>
 inline Eigen::MatrixXd sqrt_solve(const Eigen::MatrixXd &R,
                                   const Eigen::VectorXi &permutation_indices,

--- a/tests/test_gp.cc
+++ b/tests/test_gp.cc
@@ -158,9 +158,17 @@ TEST(test_gp, test_update_model_trait) {
   const auto dataset = test_unobservable_dataset();
 
   auto model = test_unobservable_model();
+  auto fit_model = model.fit(dataset);
 
-  using FitModelType = typename fit_model_type<decltype(model), double>::type;
-  using UpdatedFitType = typename updated_fit_type<FitModelType, int>::type;
+  std::vector<int> int_features;
+  for (int i = 0; i < static_cast<int>(dataset.features.size()); ++i) {
+    int_features.push_back(i);
+  }
+  RegressionDataset<int> int_dataset(int_features, dataset.targets);
+
+  auto updated_fit = fit_model.update(int_dataset);
+
+  using UpdatedFitType = decltype(updated_fit);
   using ExpectedType =
       FitModel<decltype(model),
                Fit<GPFit<BlockSymmetric<Eigen::SerializableLDLT>,

--- a/tests/test_group_by.cc
+++ b/tests/test_group_by.cc
@@ -440,11 +440,16 @@ TEST(test_groupby, test_group_by_first_group) {
 
   const auto fib = fibonacci(20);
 
-  const auto first_group = group_by(fib, number_of_digits).first_group();
+  const auto grouped = group_by(fib, number_of_digits);
+  const auto first_group = grouped.first_group();
 
   for (const auto &value : first_group.second) {
     EXPECT_EQ(number_of_digits(value), first_group.first);
   }
+
+  const auto groups = grouped.groups();
+  EXPECT_EQ(groups.first_group(), first_group);
+  EXPECT_EQ(groups.first_value(), first_group.second);
 }
 
 TEST(test_groupby, test_group_by_get_group) {

--- a/tests/test_traits_core.cc
+++ b/tests/test_traits_core.cc
@@ -337,4 +337,53 @@ TEST(test_traits_core, test_eigen_expressions) {
   EXPECT_FALSE(bool(is_eigen_xpr<LDLTType>::value));
 }
 
+class HasValidUpdateImpl : public ModelBase<HasValidUpdateImpl> {
+public:
+  Fit<HasValidUpdateImpl> _update_impl(const Fit<HasValidUpdateImpl> &,
+                                       const std::vector<X> &,
+                                       const MarginalDistribution &) const {
+    return {};
+  };
+};
+
+class HasInValidUpdateImpl : public ModelBase<HasValidUpdateImpl> {
+public:
+  double _update_impl(const Fit<HasValidUpdateImpl> &, const std::vector<X> &,
+                      const MarginalDistribution &) const {
+    return 0.;
+  };
+};
+
+class HasModifiedUpdateImpl : public ModelBase<HasValidUpdateImpl> {
+public:
+  Fit<X> _update_impl(const Fit<HasModifiedUpdateImpl> &,
+                      const std::vector<X> &,
+                      const MarginalDistribution &) const {
+    return {};
+  };
+};
+
+TEST(test_traits_core, update_traits) {
+  EXPECT_TRUE(
+      bool(fit_model_update_traits<HasValidUpdateImpl, Fit<HasValidUpdateImpl>,
+                                   X>::has_valid_update));
+  EXPECT_TRUE(
+      bool(fit_model_update_traits<HasValidUpdateImpl, Fit<HasValidUpdateImpl>,
+                                   X>::can_update_in_place));
+
+  EXPECT_FALSE(bool(
+      fit_model_update_traits<HasInValidUpdateImpl, Fit<HasValidUpdateImpl>,
+                              X>::has_valid_update));
+  EXPECT_FALSE(bool(
+      fit_model_update_traits<HasInValidUpdateImpl, Fit<HasValidUpdateImpl>,
+                              X>::can_update_in_place));
+
+  EXPECT_TRUE(bool(
+      fit_model_update_traits<HasModifiedUpdateImpl, Fit<HasModifiedUpdateImpl>,
+                              X>::has_valid_update));
+  EXPECT_FALSE(bool(
+      fit_model_update_traits<HasModifiedUpdateImpl, Fit<HasModifiedUpdateImpl>,
+                              X>::can_update_in_place));
+}
+
 } // namespace albatross


### PR DESCRIPTION
The primary change here is the addition of `update` methods to `FitModel` types.  If the model type supports an update (through an `_update_impl` method) the resulting fit model will be capable of,
```
auto partial_fit_model = model.fit(dataset_a);
auto fit_model = partial_fit_model.update(dataset_b);
```
which should be equivalent to,
```
auto fit_model = model.fit(concatenate_datasets(dataset_a, dataset_b));
```

Includes some miscellaneous touchups. 