### PR TITLE
Rebase Inducing Points

### DIFF
--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -654,14 +654,14 @@ auto rebase_inducing_points(
   // to predict the new inducing points then we see that the predictive
   // covariance (see documentation above) would be,:
   //
-  //    C = K_zz - Q_zz + K_zz Sigma K_*zz
+  //    C = K_zz - Q_zz + K_zz Sigma K_zz
   //
   // We can use this, knowing that at the inducing points K_zz = Q_zz, to
   // derive our updated Sigma,
   //
-  //    C = K_zz - K_zz + K_zz Sigma K_**
-  //    C  = K_zz Sigma K_**
-  //    Sigma = K_zz^-1 C K_zz
+  //    C = K_zz - K_zz + K_zz Sigma K_zz
+  //    C  = K_zz Sigma K_zz
+  //    Sigma = K_zz^-1 C K_zz^-1
   //
   // And since we need to store Sigma in sqrt form we get,
   //

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -89,6 +89,11 @@ template <typename FeatureType> struct Fit<SparseGPFit<FeatureType>> {
         sigma_R(sigma_R_), permutation_indices(permutation_indices_),
         information(information_) {}
 
+  void shift_mean(const Eigen::VectorXd &mean_shift) {
+    assert(mean_shift.size() == information.size());
+    information += train_covariance.solve(mean_shift);
+  }
+
   bool operator==(const Fit<SparseGPFit<FeatureType>> &other) const {
     return (train_features == other.train_features &&
             train_covariance == other.train_covariance &&

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -237,7 +237,7 @@ TEST(test_sparse_gp, test_update_exists) {
   EXPECT_TRUE(bool(can_update_in_place<SparseGPR, FitType, double>::value));
 }
 
- TYPED_TEST(SparseGaussianProcessTest, test_update) {
+TYPED_TEST(SparseGaussianProcessTest, test_update) {
   auto grouper = this->grouper;
   auto covariance = make_simple_covariance_function();
   auto dataset = make_toy_linear_data();
@@ -346,6 +346,39 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_inducing_points) {
       low_high_res_fit.predict_with_measurement_noise(test_features).joint();
   // Decreasing then increasing the inducing points should lose info
   EXPECT_GT((low_high_res_pred.mean - full_pred.mean).norm(), 10.);
+}
+
+TYPED_TEST(SparseGaussianProcessTest, test_shift_inducing_points) {
+  auto grouper = this->grouper;
+  auto covariance = make_simple_covariance_function();
+  auto dataset = make_toy_linear_data();
+
+  const double min =
+      *std::min_element(dataset.features.begin(), dataset.features.end());
+  const double max =
+      *std::max_element(dataset.features.begin(), dataset.features.end());
+
+  FixedInducingPoints strategy(min, max, 8);
+  auto sparse =
+      sparse_gp_from_covariance(covariance, grouper, strategy, "sparse");
+  sparse.set_param(details::inducing_nugget_name(), 1e-3);
+  sparse.set_param(details::measurement_nugget_name(), 1e-12);
+
+  const auto full_fit = sparse.fit(dataset);
+  const auto test_features = linspace(0.01, 9.9, 11);
+  const auto full_pred =
+      full_fit.predict_with_measurement_noise(test_features).joint();
+
+  auto shifted_fit = full_fit;
+  Eigen::Index n = shifted_fit.get_fit().information.size();
+  shifted_fit.get_fit().shift_mean(Eigen::VectorXd::Ones(n));
+
+  const auto shifted_pred =
+      shifted_fit.predict_with_measurement_noise(test_features).joint();
+
+  const auto test_shift = Eigen::VectorXd::Ones(shifted_pred.mean.size());
+  EXPECT_LT((shifted_pred.mean - test_shift - full_pred.mean).norm(), 1e-4);
+  EXPECT_LT((shifted_pred.covariance - full_pred.covariance).norm(), 1e-8);
 }
 
 } // namespace albatross


### PR DESCRIPTION
This adds some methods for manipulating sparse Gaussian processes.  In particular it allows you "rebase" the inducing points, this can be used to do something like,
```
fit_model = sparse_gp.fit(dataset_a);
rebased_model = rebase_inducing_points(fit_model, new_inducing_points);
rebased_model.update(dataset_b);
```
For some applications it might make more sense to simply fit everything all at once, `sparse_g.fit(datasets_a_and_b)` or simply perform and update `fit_model.update(dataset_b)` but the rebase and update process may prove very useful when working with time series. 

For example, consider the situation where you have data arriving in real time.  In this situation you'd get `dataset_a` before `dataset_b` and you might want to make a prediction using the data you have so far.
```
fit_model = sparse_gp.fit(dataset_a);
fit_model.predict(something_at_time_a);
```
You then get new data, `dataset_b`, and want to update the model with it but calling `fit_model.update(dataset_b)` might not be ideal because the inducing points used may only span up to time `a` so and using them to predict after `a` might incur loses.  This is where you may then want to rebase before updating.  The entire process might then consist of having a sliding window of inducing points such that you have,
```
// develop estimates of quantities in the time range: [a - T, a] given data up to a
fit_model = sparse_gp.fit(dataset_a)
// shift the model to contain estimates in the time range: [b - T, b] given data up to a
rebased_model = rebase_inducing_points(fit_model, new_inducing_points);
// update the model to contain estimates given data up to b
rebased_model.update(dataset_b);
```