### PR TITLE
Add/Improve Dataset Utilities

### DIFF
--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -96,6 +96,32 @@ deduplicate(const RegressionDataset<FeatureType> &dataset) {
 }
 
 template <typename X>
+inline auto align_datasets(RegressionDataset<X> *x, RegressionDataset<X> *y) {
+
+  std::vector<std::size_t> x_inds;
+  std::vector<std::size_t> y_inds;
+  for (std::size_t i = 0; i < x->size(); ++i) {
+    for (std::size_t j = 0; j < y->size(); ++j) {
+      if (x->features[i] == y->features[j]) {
+        x_inds.push_back(i);
+        y_inds.push_back(j);
+        continue;
+      }
+    }
+  }
+
+  assert(x_inds.size() == y_inds.size());
+
+  if (x_inds.size() == 0) {
+    *x = RegressionDataset<X>();
+    *y = RegressionDataset<X>();
+  } else {
+    *x = subset(*x, x_inds);
+    *y = subset(*y, y_inds);
+  }
+}
+
+template <typename X>
 inline auto concatenate_datasets(const RegressionDataset<X> &x,
                                  const RegressionDataset<X> &y) {
   const auto targets = concatenate_marginals(x.targets, y.targets);

--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -129,4 +129,26 @@ inline auto concatenate_datasets(const RegressionDataset<X> &x,
 
 } // namespace albatross
 
+template <typename X, typename std::enable_if_t<
+                          albatross::is_streamable<X>::value, int> = 0>
+std::ostream &operator<<(std::ostream &os,
+                         const albatross::RegressionDataset<X> &dataset) {
+  for (std::size_t i = 0; i < dataset.size(); ++i) {
+    os << dataset.features[i] << "    " << dataset.targets.mean[i] << "   +/- "
+       << std::sqrt(dataset.targets.get_diagonal(i)) << std::endl;
+  }
+  return os;
+}
+
+template <typename X, typename std::enable_if_t<
+                          !albatross::is_streamable<X>::value, int> = 0>
+std::ostream &operator<<(std::ostream &os,
+                         const albatross::RegressionDataset<X> &dataset) {
+  for (std::size_t i = 0; i < dataset.size(); ++i) {
+    os << i << "    " << dataset.targets.mean[i] << "   +/- "
+       << std::sqrt(dataset.targets.get_diagonal(i)) << std::endl;
+  }
+  return os;
+}
+
 #endif

--- a/include/albatross/src/details/traits.hpp
+++ b/include/albatross/src/details/traits.hpp
@@ -72,6 +72,22 @@ template <typename T>
 struct is_measurement : public is_templated_type<Measurement, T> {};
 
 /*
+ * is_streamable
+ */
+
+template <typename T> class is_streamable {
+  template <typename C>
+  static auto test(int)
+      -> decltype(std::declval<std::ostream &>() << std::declval<C>(),
+                  std::true_type());
+
+  template <typename> static std::false_type test(...);
+
+public:
+  static const bool value = decltype(test<T>(0))::value;
+};
+
+/*
  * is_in_variant
  */
 

--- a/include/albatross/src/indexing/subset.hpp
+++ b/include/albatross/src/indexing/subset.hpp
@@ -23,6 +23,8 @@ inline std::vector<X> subset(const std::vector<X> &v,
                              const std::vector<SizeType> &indices) {
   std::vector<X> out(indices.size());
   for (std::size_t i = 0; i < static_cast<std::size_t>(indices.size()); i++) {
+    assert(indices[i] >= 0 && "Invalid indices provided to subset");
+    assert(indices[i] < v.size() && "Invalid indices provided to subset");
     out[i] = v[static_cast<std::size_t>(indices[i])];
   }
   return out;
@@ -36,8 +38,10 @@ inline Eigen::VectorXd subset(const Eigen::VectorXd &v,
                               const std::vector<SizeType> &indices) {
   Eigen::VectorXd out(static_cast<Eigen::Index>(indices.size()));
   for (std::size_t i = 0; i < indices.size(); i++) {
-    out[static_cast<Eigen::Index>(i)] =
-        v[static_cast<Eigen::Index>(indices[i])];
+    const Eigen::Index ind_i = static_cast<Eigen::Index>(indices[i]);
+    assert(ind_i >= 0 && "Invalid indices provided to subset");
+    assert(ind_i < v.size() && "Invalid indices provided to subset");
+    out[static_cast<Eigen::Index>(i)] = v[ind_i];
   }
   return out;
 }
@@ -52,6 +56,8 @@ inline Eigen::MatrixXd subset_cols(const Eigen::MatrixXd &v,
   for (std::size_t i = 0; i < col_indices.size(); i++) {
     auto ii = static_cast<Eigen::Index>(i);
     auto col_index = static_cast<Eigen::Index>(col_indices[i]);
+    assert(col_index >= 0 && "Invalid indices provided to subset");
+    assert(col_index < v.cols() && "Invalid indices provided to subset");
     out.col(ii) = v.col(col_index);
   }
   return out;
@@ -67,6 +73,8 @@ inline Eigen::MatrixXd subset_rows(const Eigen::MatrixXd &v,
   for (std::size_t i = 0; i < row_indices.size(); i++) {
     auto ii = static_cast<Eigen::Index>(i);
     auto row_index = static_cast<Eigen::Index>(row_indices[i]);
+    assert(row_index >= 0 && "Invalid indices provided to subset");
+    assert(row_index < v.rows() && "Invalid indices provided to subset");
     out.row(ii) = v.row(row_index);
   }
   return out;
@@ -87,6 +95,10 @@ inline Eigen::MatrixXd subset(const Eigen::MatrixXd &v,
       auto jj = static_cast<Eigen::Index>(j);
       auto row_index = static_cast<Eigen::Index>(row_indices[i]);
       auto col_index = static_cast<Eigen::Index>(col_indices[j]);
+      assert(row_index >= 0 && "Invalid indices provided to subset");
+      assert(row_index < v.rows() && "Invalid indices provided to subset");
+      assert(col_index >= 0 && "Invalid indices provided to subset");
+      assert(col_index < v.cols() && "Invalid indices provided to subset");
       out(ii, jj) = v(row_index, col_index);
     }
   }
@@ -126,8 +138,10 @@ inline void set_subset(const Eigen::VectorXd &from,
                        Eigen::VectorXd *to) {
   assert(static_cast<Eigen::Index>(indices.size()) == from.size());
   for (std::size_t i = 0; i < indices.size(); ++i) {
-    (*to)[static_cast<Eigen::Index>(indices[i])] =
-        from[static_cast<Eigen::Index>(i)];
+    const Eigen::Index ind_i = static_cast<Eigen::Index>(indices[i]);
+    assert(ind_i >= 0 && "Invalid indices provided to subset");
+    assert(ind_i < to->size() && "Invalid indices provided to subset");
+    (*to)[ind_i] = from[static_cast<Eigen::Index>(i)];
   }
 }
 
@@ -143,8 +157,10 @@ inline void set_subset(const Eigen::DiagonalMatrix<Scalar, Size> &from,
                        Eigen::DiagonalMatrix<Scalar, Size> *to) {
   assert(static_cast<Eigen::Index>(indices.size()) == from.diagonal().size());
   for (std::size_t i = 0; i < indices.size(); i++) {
-    to->diagonal()[static_cast<Eigen::Index>(indices[i])] =
-        from.diagonal()[static_cast<Eigen::Index>(i)];
+    const Eigen::Index ind_i = static_cast<Eigen::Index>(indices[i]);
+    assert(ind_i >= 0 && "Invalid indices provided to subset");
+    assert(ind_i < to->size() && "Invalid indices provided to subset");
+    to->diagonal()[ind_i] = from.diagonal()[static_cast<Eigen::Index>(i)];
   }
 }
 

--- a/tests/test_core_dataset.cc
+++ b/tests/test_core_dataset.cc
@@ -43,6 +43,64 @@ TEST(test_dataset, test_deduplicate) {
   EXPECT_EQ(dedupped, deduplicate(dedupped));
 }
 
+TEST(test_dataset, test_align_datasets_a_in_b) {
+  std::vector<int> features_a = {0, 1, 2};
+  Eigen::VectorXd targets_a = Eigen::VectorXd::Random(features_a.size());
+  RegressionDataset<int> dataset_a(features_a, targets_a);
+
+  std::vector<int> features_b = {2, 3, 0, 1};
+  Eigen::VectorXd targets_b = Eigen::VectorXd::Random(features_b.size());
+  RegressionDataset<int> dataset_b(features_b, targets_b);
+
+  EXPECT_NE(dataset_a.features, dataset_b.features);
+  align_datasets(&dataset_a, &dataset_b);
+  EXPECT_EQ(dataset_a.size(), 3);
+  EXPECT_EQ(dataset_a.features, dataset_b.features);
+}
+
+TEST(test_dataset, test_align_datasets_a_in_b_unordered) {
+  std::vector<int> features_a = {0, 2, 1};
+  Eigen::VectorXd targets_a = Eigen::VectorXd::Random(features_a.size());
+  RegressionDataset<int> dataset_a(features_a, targets_a);
+
+  std::vector<int> features_b = {2, 3, 0, 1};
+  Eigen::VectorXd targets_b = Eigen::VectorXd::Random(features_b.size());
+  RegressionDataset<int> dataset_b(features_b, targets_b);
+
+  EXPECT_NE(dataset_a.features, dataset_b.features);
+  align_datasets(&dataset_a, &dataset_b);
+  EXPECT_EQ(dataset_a.size(), 3);
+  EXPECT_EQ(dataset_a.features, dataset_b.features);
+}
+
+TEST(test_dataset, test_align_datasets_a_not_in_b) {
+  std::vector<int> features_a = {0, 1, 2, 3};
+  Eigen::VectorXd targets_a = Eigen::VectorXd::Random(features_a.size());
+  RegressionDataset<int> dataset_a(features_a, targets_a);
+
+  std::vector<int> features_b = {2, 4, 0};
+  Eigen::VectorXd targets_b = Eigen::VectorXd::Random(features_b.size());
+  RegressionDataset<int> dataset_b(features_b, targets_b);
+
+  EXPECT_NE(dataset_a.features, dataset_b.features);
+  align_datasets(&dataset_a, &dataset_b);
+  EXPECT_EQ(dataset_a.size(), 2);
+  EXPECT_EQ(dataset_a.features, dataset_b.features);
+}
+
+TEST(test_dataset, test_align_datasets_no_intersect) {
+  std::vector<int> features_a = {0, 1, 2};
+  Eigen::VectorXd targets_a = Eigen::VectorXd::Random(features_a.size());
+  RegressionDataset<int> dataset_a(features_a, targets_a);
+
+  std::vector<int> features_b = {3, 4, 5};
+  Eigen::VectorXd targets_b = Eigen::VectorXd::Random(features_b.size());
+  RegressionDataset<int> dataset_b(features_b, targets_b);
+
+  align_datasets(&dataset_a, &dataset_b);
+  EXPECT_EQ(dataset_a.size(), 0);
+}
+
 void expect_split_recombine(const RegressionDataset<int> &dataset) {
   std::vector<std::size_t> first_indices = {0, 1};
   const auto first = subset(dataset, first_indices);

--- a/tests/test_core_dataset.cc
+++ b/tests/test_core_dataset.cc
@@ -102,4 +102,25 @@ TEST(test_dataset, test_concatenate_different_type) {
   }
 }
 
+TEST(test_dataset, test_streamable_features) {
+  std::vector<int> features = {3, 7, 1};
+  Eigen::VectorXd targets = Eigen::VectorXd::Random(3);
+  RegressionDataset<int> dataset(features, targets);
+
+  std::ostringstream oss;
+  oss << dataset << std::endl;
+}
+
+struct NotStreamable {};
+
+TEST(test_dataset, test_not_streamable_features) {
+  std::vector<NotStreamable> features = {NotStreamable(), NotStreamable(),
+                                         NotStreamable()};
+  Eigen::VectorXd targets = Eigen::VectorXd::Random(3);
+  RegressionDataset<NotStreamable> dataset(features, targets);
+
+  std::ostringstream oss;
+  oss << dataset << std::endl;
+}
+
 } // namespace albatross

--- a/tests/test_core_dataset.cc
+++ b/tests/test_core_dataset.cc
@@ -99,6 +99,7 @@ TEST(test_dataset, test_align_datasets_no_intersect) {
 
   align_datasets(&dataset_a, &dataset_b);
   EXPECT_EQ(dataset_a.size(), 0);
+  EXPECT_EQ(dataset_b.size(), 0);
 }
 
 void expect_split_recombine(const RegressionDataset<int> &dataset) {

--- a/tests/test_gp.cc
+++ b/tests/test_gp.cc
@@ -257,8 +257,8 @@ TEST(test_gp, test_update_model_different_types) {
       new_perturbed_model.predict(dataset.features).marginal();
 
   // Make sure constraining to a different value changes the results.
-  EXPECT_GE((perturbed_inducing_pred.mean - new_pred.mean).norm(), 1.);
-  EXPECT_GE((perturbed_train_pred.mean - train_pred.mean).norm(), 1.);
+  EXPECT_GE((perturbed_inducing_pred.mean - new_pred.mean).norm(), 0.5);
+  EXPECT_GE((perturbed_train_pred.mean - train_pred.mean).norm(), 0.5);
 }
 
 TEST(test_gp, test_model_from_different_datasets) {


### PR DESCRIPTION
Adds:
-  assertions to the `subset` methods if they're about to index out of range.
-  the ability to do `std::cout << dataset`
-  a method which aligns datasets so they can more easily be compared `align_datasets(&a, &b)`