### PR TITLE
Restore updated_fit_model_type trait

### DIFF
--- a/include/albatross/src/core/fit_model.hpp
+++ b/include/albatross/src/core/fit_model.hpp
@@ -23,6 +23,9 @@ public:
       std::is_move_constructible<Fit>::value,
       "Fit type must be move constructible to avoid unexpected copying.");
 
+  typedef ModelType model_type;
+  typedef Fit fit_type;
+
   FitModel(){};
 
   FitModel(const ModelType &model, const Fit &fit) = delete;

--- a/include/albatross/src/core/traits.hpp
+++ b/include/albatross/src/core/traits.hpp
@@ -247,6 +247,24 @@ struct can_update_in_place {
                               FeatureType>::can_update_in_place;
 };
 
+/*
+ * Determines the type of updated_fit in a call along the lines of :
+ *
+ *   auto fit_model = model.fit(dataset);
+ *   auto updated_fit_model = fit_model.update(other_dataset);
+ */
+template <typename T, typename FeatureType> class updated_fit_model_type {
+
+  using ModelType = typename T::model_type;
+  using FitType = typename T::fit_type;
+  using UpdatedFitType =
+      typename fit_model_update_traits<ModelType, FitType,
+                                       FeatureType>::UpdateFitType;
+
+public:
+  typedef FitModel<ModelType, UpdatedFitType> type;
+};
+
 } // namespace albatross
 
 #endif

--- a/tests/test_gp.cc
+++ b/tests/test_gp.cc
@@ -170,9 +170,7 @@ TEST(test_gp, test_update_model_trait) {
 
   using UpdatedFitType = decltype(updated_fit);
   using ExpectedType =
-      FitModel<decltype(model),
-               Fit<GPFit<BlockSymmetric<Eigen::SerializableLDLT>,
-                         variant<double, int>>>>;
+      typename updated_fit_model_type<decltype(fit_model), int>::type;
 
   EXPECT_TRUE(bool(std::is_same<UpdatedFitType, ExpectedType>::value));
 }


### PR DESCRIPTION
Left this out when I refactored the `update` methods.

https://github.com/swift-nav/albatross/commit/79bd5a1ccdb705e5e273da20879effd6d25017c4