### PR TITLE
Fix Sparse GP Stability

### DIFF
--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -157,8 +157,8 @@ inline auto concatenate_datasets(const RegressionDataset<X> &x,
 
 template <typename X, typename std::enable_if_t<
                           albatross::is_streamable<X>::value, int> = 0>
-std::ostream &operator<<(std::ostream &os,
-                         const albatross::RegressionDataset<X> &dataset) {
+inline std::ostream &
+operator<<(std::ostream &os, const albatross::RegressionDataset<X> &dataset) {
   for (std::size_t i = 0; i < dataset.size(); ++i) {
     os << dataset.features[i] << "    " << dataset.targets.mean[i] << "   +/- "
        << std::sqrt(dataset.targets.get_diagonal(i)) << std::endl;
@@ -168,8 +168,8 @@ std::ostream &operator<<(std::ostream &os,
 
 template <typename X, typename std::enable_if_t<
                           !albatross::is_streamable<X>::value, int> = 0>
-std::ostream &operator<<(std::ostream &os,
-                         const albatross::RegressionDataset<X> &dataset) {
+inline std::ostream &
+operator<<(std::ostream &os, const albatross::RegressionDataset<X> &dataset) {
   for (std::size_t i = 0; i < dataset.size(); ++i) {
     os << i << "    " << dataset.targets.mean[i] << "   +/- "
        << std::sqrt(dataset.targets.get_diagonal(i)) << std::endl;

--- a/include/albatross/src/core/distribution.hpp
+++ b/include/albatross/src/core/distribution.hpp
@@ -274,4 +274,23 @@ concatenate_marginals(const std::vector<MarginalDistribution> &dists) {
 
 } // namespace albatross
 
+inline std::ostream &
+operator<<(std::ostream &os, const albatross::MarginalDistribution &marginal) {
+  for (std::size_t i = 0; i < marginal.size(); ++i) {
+    os << i << "    " << marginal.mean[i] << "   +/- "
+       << std::sqrt(marginal.get_diagonal(i)) << std::endl;
+  }
+  return os;
+}
+
+inline std::ostream &operator<<(std::ostream &os,
+                                const albatross::JointDistribution &joint) {
+  Eigen::MatrixXd combined(joint.covariance.rows(),
+                           joint.covariance.cols() + 1);
+  combined.rightCols(joint.covariance.cols()) = joint.covariance;
+  combined.col(0) = joint.mean;
+  std::cout << combined;
+  return os;
+}
+
 #endif

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -437,11 +437,15 @@ public:
 
     const Eigen::MatrixXd Q_sqrt =
         sparse_gp_fit.train_covariance.sqrt_solve(cross_cov);
-    marginal_variance -= Q_sqrt.cwiseProduct(Q_sqrt).array().colwise().sum();
+    const Eigen::VectorXd Q_diag =
+        Q_sqrt.cwiseProduct(Q_sqrt).array().colwise().sum();
+    marginal_variance -= Q_diag;
 
     const Eigen::MatrixXd S_sqrt = sqrt_solve(
         sparse_gp_fit.sigma_R, sparse_gp_fit.permutation_indices, cross_cov);
-    marginal_variance += S_sqrt.cwiseProduct(S_sqrt).array().colwise().sum();
+    const Eigen::VectorXd S_diag =
+        S_sqrt.cwiseProduct(S_sqrt).array().colwise().sum();
+    marginal_variance += S_diag;
 
     return MarginalDistribution(mean, marginal_variance);
   }

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -431,16 +431,17 @@ public:
     Eigen::VectorXd marginal_variance(
         static_cast<Eigen::Index>(features.size()));
     for (Eigen::Index i = 0; i < marginal_variance.size(); ++i) {
-      marginal_variance[i] = covariance_function_(features[i], features[i]);
+      marginal_variance[i] =
+          this->covariance_function_(features[i], features[i]);
     }
 
     const Eigen::MatrixXd Q_sqrt =
         sparse_gp_fit.train_covariance.sqrt_solve(cross_cov);
-    marginal_variance -= Q_sqrt.cwiseProduct(cross_cov).array().colwise().sum();
+    marginal_variance -= Q_sqrt.cwiseProduct(Q_sqrt).array().colwise().sum();
 
     const Eigen::MatrixXd S_sqrt = sqrt_solve(
         sparse_gp_fit.sigma_R, sparse_gp_fit.permutation_indices, cross_cov);
-    marginal_variance += S_sqrt.cwiseProduct(cross_cov).array().colwise().sum();
+    marginal_variance += S_sqrt.cwiseProduct(S_sqrt).array().colwise().sum();
 
     return MarginalDistribution(mean, marginal_variance);
   }

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -10,10 +10,10 @@
  * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#include <albatross/GP>
 #include <albatross/LeastSquares>
 #include <albatross/NullModel>
 #include <albatross/Ransac>
+#include <albatross/SparseGP>
 #include <gtest/gtest.h>
 
 #include "test_utils.h"
@@ -33,6 +33,21 @@ public:
   auto get_model() const {
     auto covariance = make_simple_covariance_function();
     return gp_from_covariance(covariance);
+  }
+
+  auto get_dataset() const { return make_toy_linear_data(); }
+};
+
+class MakeSparseGaussianProcess {
+public:
+  MakeSparseGaussianProcess(){};
+
+  auto get_model() const {
+    LeaveOneOutGrouper loo;
+    UniformlySpacedInducingPoints strategy(25);
+
+    auto covariance = make_simple_covariance_function();
+    return sparse_gp_from_covariance(covariance, loo, strategy, "example");
   }
 
   auto get_dataset() const { return make_toy_linear_data(); }
@@ -269,7 +284,7 @@ public:
 };
 
 typedef ::testing::Types<MakeLinearRegression, MakeGaussianProcess,
-                         MakeGaussianProcessWithMean,
+                         MakeGaussianProcessWithMean, MakeSparseGaussianProcess,
                          MakeAdaptedGaussianProcess, MakeRansacGaussianProcess,
                          MakeRansacChiSquaredGaussianProcess,
                          MakeRansacChiSquaredGaussianProcessWithMean,

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -348,37 +348,77 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_inducing_points) {
   EXPECT_GT((low_high_res_pred.mean - full_pred.mean).norm(), 10.);
 }
 
-TYPED_TEST(SparseGaussianProcessTest, test_shift_inducing_points) {
+TYPED_TEST(SparseGaussianProcessTest, test_rebase_and_update) {
+
   auto grouper = this->grouper;
   auto covariance = make_simple_covariance_function();
   auto dataset = make_toy_linear_data();
 
-  const double min =
-      *std::min_element(dataset.features.begin(), dataset.features.end());
-  const double max =
-      *std::max_element(dataset.features.begin(), dataset.features.end());
-
-  FixedInducingPoints strategy(min, max, 8);
-  auto sparse =
+  UniformlySpacedInducingPoints strategy(10);
+  auto model =
       sparse_gp_from_covariance(covariance, grouper, strategy, "sparse");
-  sparse.set_param(details::inducing_nugget_name(), 1e-3);
-  sparse.set_param(details::measurement_nugget_name(), 1e-12);
+  const auto inducing_points = strategy(covariance, dataset.features);
+  auto test_features = linspace(0.1, 9.9, 5);
 
-  const auto full_fit = sparse.fit(dataset);
-  const auto test_features = linspace(0.01, 9.9, 11);
-  const auto full_pred =
-      full_fit.predict_with_measurement_noise(test_features).joint();
+  const auto grouped = dataset.group_by(grouper).groups();
+  auto iteratively_fit_model = model.fit(grouped.first_value());
 
-  auto shifted_fit = full_fit;
-  Eigen::Index n = shifted_fit.get_fit().information.size();
-  shifted_fit.get_fit().shift_mean(Eigen::VectorXd::Ones(n));
+  // The first fit is going to space the inducing points only over the
+  // first group, here we set the inducing points to what they
+  // would be if we'd fit to everything
+  iteratively_fit_model =
+      rebase_inducing_points(iteratively_fit_model, inducing_points);
 
-  const auto shifted_pred =
-      shifted_fit.predict_with_measurement_noise(test_features).joint();
+  // Then iteratively update with the rest of the groups
+  bool first = true;
+  for (const auto &pair : grouped) {
+    if (!first) {
+      iteratively_fit_model.update_in_place(pair.second);
+    } else {
+      first = false;
+    }
+  }
 
-  const auto test_shift = Eigen::VectorXd::Ones(shifted_pred.mean.size());
-  EXPECT_LT((shifted_pred.mean - test_shift - full_pred.mean).norm(), 1e-4);
-  EXPECT_LT((shifted_pred.covariance - full_pred.covariance).norm(), 1e-8);
+  const auto direct_fit_model = model.fit(dataset);
+
+  const auto iter_pred = iteratively_fit_model.predict(test_features).joint();
+  const auto direct_pred = direct_fit_model.predict(test_features).joint();
+
+  EXPECT_LT((direct_pred.mean - iter_pred.mean).norm(), 1e-5);
+  EXPECT_LT((direct_pred.covariance - iter_pred.covariance).norm(), 1e-5);
 }
+
+// TYPED_TEST(SparseGaussianProcessTest, test_shift_inducing_points) {
+//  auto grouper = this->grouper;
+//  auto covariance = make_simple_covariance_function();
+//  auto dataset = make_toy_linear_data();
+//
+//  const double min =
+//      *std::min_element(dataset.features.begin(), dataset.features.end());
+//  const double max =
+//      *std::max_element(dataset.features.begin(), dataset.features.end());
+//
+//  FixedInducingPoints strategy(min, max, 8);
+//  auto sparse =
+//      sparse_gp_from_covariance(covariance, grouper, strategy, "sparse");
+//  sparse.set_param(details::inducing_nugget_name(), 1e-3);
+//  sparse.set_param(details::measurement_nugget_name(), 1e-12);
+//
+//  const auto full_fit = sparse.fit(dataset);
+//  const auto test_features = linspace(0.01, 9.9, 11);
+//  const auto full_pred =
+//      full_fit.predict_with_measurement_noise(test_features).joint();
+//
+//  auto shifted_fit = full_fit;
+//  Eigen::Index n = shifted_fit.get_fit().information.size();
+//  shifted_fit.get_fit().shift_mean(Eigen::VectorXd::Ones(n));
+//
+//  const auto shifted_pred =
+//      shifted_fit.predict_with_measurement_noise(test_features).joint();
+//
+//  const auto test_shift = Eigen::VectorXd::Ones(shifted_pred.mean.size());
+//  EXPECT_LT((shifted_pred.mean - test_shift - full_pred.mean).norm(), 1e-4);
+//  EXPECT_LT((shifted_pred.covariance - full_pred.covariance).norm(), 1e-8);
+//}
 
 } // namespace albatross

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -388,37 +388,37 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_and_update) {
   EXPECT_LT((direct_pred.covariance - iter_pred.covariance).norm(), 1e-5);
 }
 
-// TYPED_TEST(SparseGaussianProcessTest, test_shift_inducing_points) {
-//  auto grouper = this->grouper;
-//  auto covariance = make_simple_covariance_function();
-//  auto dataset = make_toy_linear_data();
-//
-//  const double min =
-//      *std::min_element(dataset.features.begin(), dataset.features.end());
-//  const double max =
-//      *std::max_element(dataset.features.begin(), dataset.features.end());
-//
-//  FixedInducingPoints strategy(min, max, 8);
-//  auto sparse =
-//      sparse_gp_from_covariance(covariance, grouper, strategy, "sparse");
-//  sparse.set_param(details::inducing_nugget_name(), 1e-3);
-//  sparse.set_param(details::measurement_nugget_name(), 1e-12);
-//
-//  const auto full_fit = sparse.fit(dataset);
-//  const auto test_features = linspace(0.01, 9.9, 11);
-//  const auto full_pred =
-//      full_fit.predict_with_measurement_noise(test_features).joint();
-//
-//  auto shifted_fit = full_fit;
-//  Eigen::Index n = shifted_fit.get_fit().information.size();
-//  shifted_fit.get_fit().shift_mean(Eigen::VectorXd::Ones(n));
-//
-//  const auto shifted_pred =
-//      shifted_fit.predict_with_measurement_noise(test_features).joint();
-//
-//  const auto test_shift = Eigen::VectorXd::Ones(shifted_pred.mean.size());
-//  EXPECT_LT((shifted_pred.mean - test_shift - full_pred.mean).norm(), 1e-4);
-//  EXPECT_LT((shifted_pred.covariance - full_pred.covariance).norm(), 1e-8);
-//}
+TYPED_TEST(SparseGaussianProcessTest, test_shift_inducing_points) {
+  auto grouper = this->grouper;
+  auto covariance = make_simple_covariance_function();
+  auto dataset = make_toy_linear_data();
+
+  const double min =
+      *std::min_element(dataset.features.begin(), dataset.features.end());
+  const double max =
+      *std::max_element(dataset.features.begin(), dataset.features.end());
+
+  FixedInducingPoints strategy(min, max, 8);
+  auto sparse =
+      sparse_gp_from_covariance(covariance, grouper, strategy, "sparse");
+  sparse.set_param(details::inducing_nugget_name(), 1e-3);
+  sparse.set_param(details::measurement_nugget_name(), 1e-12);
+
+  const auto full_fit = sparse.fit(dataset);
+  const auto test_features = linspace(0.01, 9.9, 11);
+  const auto full_pred =
+      full_fit.predict_with_measurement_noise(test_features).joint();
+
+  auto shifted_fit = full_fit;
+  Eigen::Index n = shifted_fit.get_fit().information.size();
+  shifted_fit.get_fit().shift_mean(Eigen::VectorXd::Ones(n));
+
+  const auto shifted_pred =
+      shifted_fit.predict_with_measurement_noise(test_features).joint();
+
+  const auto test_shift = Eigen::VectorXd::Ones(shifted_pred.mean.size());
+  EXPECT_LT((shifted_pred.mean - test_shift - full_pred.mean).norm(), 1e-4);
+  EXPECT_LT((shifted_pred.covariance - full_pred.covariance).norm(), 1e-8);
+}
 
 } // namespace albatross


### PR DESCRIPTION
A handful of fixes encountered while trying to make sure of the new Sparse GP methods downstream.

- Ran into some numerical instability in the `rebase_inducing_points` methods which was fixed by switching from an LDLT to a QR decomposition.
- Fixed a bug in the `.marginal()` prediction method of the sparse gaussian processes.
- Add some print helpers for distributions.