### PR TITLE
Positive Gaussian Prior

### DIFF
--- a/include/albatross/src/cereal/priors.hpp
+++ b/include/albatross/src/cereal/priors.hpp
@@ -34,6 +34,13 @@ inline void serialize(Archive &archive, albatross::GaussianPrior &prior,
 }
 
 template <typename Archive>
+inline void serialize(Archive &archive, albatross::PositiveGaussianPrior &prior,
+                      const std::uint32_t) {
+  archive(cereal::make_nvp("mu", prior.mu_),
+          cereal::make_nvp("sigma", prior.sigma_));
+}
+
+template <typename Archive>
 inline void serialize(Archive &archive, albatross::LogNormalPrior &prior,
                       const std::uint32_t) {
   archive(cereal::make_nvp("mu", prior.mu_),

--- a/include/albatross/src/core/priors.hpp
+++ b/include/albatross/src/core/priors.hpp
@@ -15,6 +15,7 @@
 
 namespace albatross {
 
+constexpr double LOG_2_ = 0.6931471805599453;
 constexpr double LOG_2PI_ = 1.8378770664093453;
 constexpr double LARGE_VAL = HUGE_VAL;
 
@@ -140,6 +141,32 @@ public:
   double sigma_;
 };
 
+class PositiveGaussianPrior : public Prior {
+public:
+  PositiveGaussianPrior(double mu = 0., double sigma = 1.)
+      : mu_(mu), sigma_(sigma) {}
+
+  bool operator==(const PositiveGaussianPrior &other) const {
+    return other.mu_ == mu_ && other.sigma_ == sigma_;
+  }
+
+  double lower_bound() const override { return 0.; }
+
+  std::string get_name() const override {
+    std::ostringstream oss;
+    oss << "positive_gaussian[" << mu_ << "," << sigma_ << "]";
+    return oss.str();
+  }
+
+  double log_pdf(double x) const override {
+    double deviation = (x - mu_) / sigma_;
+    return -0.5 * (LOG_2PI_ * 2 * log(sigma_) + deviation * deviation) + LOG_2_;
+  }
+
+  double mu_;
+  double sigma_;
+};
+
 class LogNormalPrior : public Prior {
 public:
   LogNormalPrior(double mu = 0., double sigma = 1.) : mu_(mu), sigma_(sigma) {}
@@ -166,7 +193,8 @@ public:
 // NOTE: Order here is very important for backward compatible seraialization.
 using PossiblePriors =
     variant<UninformativePrior, FixedPrior, NonNegativePrior, PositivePrior,
-            UniformPrior, LogScaleUniformPrior, GaussianPrior, LogNormalPrior>;
+            UniformPrior, LogScaleUniformPrior, GaussianPrior, LogNormalPrior,
+            PositiveGaussianPrior>;
 
 class PriorContainer : public Prior {
 public:

--- a/include/albatross/src/utils/linalg_utils.hpp
+++ b/include/albatross/src/utils/linalg_utils.hpp
@@ -75,13 +75,22 @@ inline void _print_eigen_directions(const Eigen::MatrixXd &matrix,
               return comp(std::get<0>(a), std::get<0>(b));
             });
 
+  std::ios_base::fmtflags f(stream->flags());
+
+  (*stream) << std::scientific;
+
   (*stream) << "MIN: " << values.minCoeff() << std::endl;
   (*stream) << "MAX: " << values.maxCoeff() << std::endl;
+
+  stream->flags(f);
 
   for (std::size_t i = 0; i < count; ++i) {
     const double value = std::get<0>(values_and_vectors[i]);
     const auto vector = std::get<1>(values_and_vectors[i]);
+
+    (*stream) << std::scientific;
     (*stream) << "eigen value: " << value << std::endl;
+    stream->flags(f);
 
     // Sort the indices from largest to smallest coef
     std::vector<std::size_t> sorted_idx(vector.size());


### PR DESCRIPTION
This adds an additional hyper parameter prior, the `PositiveGaussianPrior` aka half Gaussian.  The motivation for this is to allow a weakly-informative prior which encourages smaller values without influencing the posterior too much.

The choice of a Guassian distribution rescaled to reflect only positive support comes from [Prior distributions for variance parameters in hierarchical models](http://www.stat.columbia.edu/~gelman/research/published/taumain.pdf
) which suggests:

```
For a noninformative but proper prior distribution, we recommend approximating the
uniform density [...] or a half-normal centered at 0 with standard deviation set to a high
value such as 100. The latter approach is particularly easy to program as a N(0, 100^2)```