### PR TITLE
Combine Eigen::VectorXd

### DIFF
--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -280,6 +280,24 @@ Eigen::VectorXd combine(const Map<KeyType, double> &groups) {
   return output;
 }
 
+template <template <typename...> class Map, typename KeyType>
+Eigen::VectorXd combine(const Map<KeyType, Eigen::VectorXd> &groups) {
+
+  auto get_size = [](const auto &x) { return x.size(); };
+  Eigen::Index n = albatross::apply_map(groups, get_size).sum();
+
+  Eigen::VectorXd output(n, 1);
+  Eigen::Index i = 0;
+  for (const auto &x : map_values(groups)) {
+    if (x.size() > 0) {
+      output.block(i, 0, x.size(), 1) = x;
+      i += x.size();
+    }
+  }
+  assert(i == output.size());
+  return output;
+}
+
 /*
  * Combinable grouped objects support operations in which you can
  * collapse a `map<Key, Value>` into a single `Value`
@@ -304,6 +322,13 @@ template <typename KeyType, typename FeatureType>
 class Grouped<KeyType, std::vector<FeatureType>>
     : public CombinableBase<KeyType, std::vector<FeatureType>> {
   using Base = CombinableBase<KeyType, std::vector<FeatureType>>;
+  using Base::Base;
+};
+
+template <typename KeyType>
+class Grouped<KeyType, Eigen::VectorXd>
+    : public CombinableBase<KeyType, Eigen::VectorXd> {
+  using Base = CombinableBase<KeyType, Eigen::VectorXd>;
   using Base::Base;
 };
 

--- a/tests/test_group_by.cc
+++ b/tests/test_group_by.cc
@@ -436,6 +436,21 @@ TEST(test_groupby, test_group_by_nested_filter) {
   }
 }
 
+TEST(test_groupby, test_group_by_combine_eigen) {
+
+  albatross::Grouped<Eigen::Index, Eigen::VectorXd> grouped;
+  grouped[3] = Eigen::VectorXd::Constant(3, 1, 3.);
+  grouped[1] = Eigen::VectorXd::Constant(1, 1, 1.);
+  grouped[0] = Eigen::VectorXd();
+  grouped[5] = Eigen::VectorXd::Constant(5, 1, 5.);
+
+  Eigen::VectorXd expected(9);
+  expected << 1., 3., 3., 3., 5., 5., 5., 5., 5.;
+
+  Eigen::VectorXd actual = grouped.combine();
+  EXPECT_EQ(expected, actual);
+}
+
 TEST(test_groupby, test_group_by_first_group) {
 
   const auto fib = fibonacci(20);


### PR DESCRIPTION
This expands the `.combine()` methods to work with mapped `Eigen::VectorXd` types.