### PR TITLE
Serialize linear combinations

### DIFF
--- a/include/albatross/src/cereal/gp.hpp
+++ b/include/albatross/src/cereal/gp.hpp
@@ -16,6 +16,7 @@
 using albatross::Fit;
 using albatross::GaussianProcessBase;
 using albatross::GPFit;
+using albatross::LinearCombination;
 using albatross::SparseGPFit;
 
 #ifndef GP_SERIALIZATION_VERSION
@@ -68,6 +69,13 @@ void load(Archive &archive,
   archive(cereal::make_nvp("params", params));
   gp.set_params(params);
   archive(cereal::make_nvp("insights", gp.insights));
+}
+
+template <typename Archive, typename FeatureType>
+inline void serialize(Archive &archive, LinearCombination<FeatureType> &combo,
+                      const std::uint32_t) {
+  archive(cereal::make_nvp("values", combo.values));
+  archive(cereal::make_nvp("coefficients", combo.coefficients));
 }
 
 } // namespace cereal

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -266,6 +266,15 @@ struct BlockSymmetricMatrix
   }
 };
 
+struct LinearCombo : public SerializableType<LinearCombination<double>> {
+  LinearCombination<double> create() const override {
+    std::vector<double> values = {1., 2., 5.};
+    Eigen::VectorXd coefs(3);
+    coefs << 10., 20., 50.;
+    return LinearCombination<double>(values, coefs);
+  }
+};
+
 REGISTER_TYPED_TEST_CASE_P(SerializeTest, test_roundtrip_serialize_json,
                            test_roundtrip_serialize_binary);
 
@@ -275,7 +284,7 @@ typedef ::testing::Types<LDLT, ExplainedCovarianceRepresentation, EigenMatrix3d,
                          FullJointDistribution, FullMarginalDistribution,
                          ParameterStoreType, Dataset, DatasetWithMetadata,
                          SerializableType<MockModel>, VariantAsInt,
-                         VariantAsDouble, BlockSymmetricMatrix>
+                         VariantAsDouble, BlockSymmetricMatrix, LinearCombo>
     ToTest;
 
 INSTANTIATE_TYPED_TEST_CASE_P(Albatross, SerializeTest, ToTest);


### PR DESCRIPTION
This adds serializations for the `LinearCombination<X>` helper so if the feature types, `X`, are serializable the `LinearCombination` will be as well.