### PR TITLE
Finite Difference Gradients

### DIFF
--- a/include/albatross/Tune
+++ b/include/albatross/Tune
@@ -20,5 +20,6 @@
 
 #include <albatross/src/tune/tuning_metrics.hpp>
 #include <albatross/src/tune/tune.hpp>
+#include <albatross/src/tune/finite_difference.hpp>
 
 #endif

--- a/include/albatross/Tune
+++ b/include/albatross/Tune
@@ -18,8 +18,8 @@
 #include "Core"
 #include "Evaluation"
 
+#include <albatross/src/tune/finite_difference.hpp>
 #include <albatross/src/tune/tuning_metrics.hpp>
 #include <albatross/src/tune/tune.hpp>
-#include <albatross/src/tune/finite_difference.hpp>
 
 #endif

--- a/include/albatross/src/core/parameter_handling_mixin.hpp
+++ b/include/albatross/src/core/parameter_handling_mixin.hpp
@@ -69,6 +69,8 @@ struct Parameter {
  */
 inline std::string pretty_params(const ParameterStore &params) {
   std::ostringstream ss;
+  ss << std::setprecision(12);
+  ss << std::scientific;
   ss << "{" << std::endl;
   for (const auto &pair : params) {
     ss << "    {\"" << pair.first << "\", " << pair.second.value << "},"

--- a/include/albatross/src/core/parameter_handling_mixin.hpp
+++ b/include/albatross/src/core/parameter_handling_mixin.hpp
@@ -20,6 +20,7 @@ constexpr double PARAMETER_EPSILON =
 constexpr double PARAMETER_MAX = std::numeric_limits<ParameterValue>::max();
 
 struct TunableParameters {
+  std::vector<std::string> names;
   std::vector<double> values;
   std::vector<double> lower_bounds;
   std::vector<double> upper_bounds;
@@ -141,6 +142,7 @@ inline TunableParameters get_tunable_parameters(const ParameterStore &params) {
         v = log(v);
       }
 
+      output.names.push_back(pair.first);
       output.values.push_back(v);
       output.lower_bounds.push_back(lb);
       output.upper_bounds.push_back(ub);

--- a/include/albatross/src/tune/finite_difference.hpp
+++ b/include/albatross/src/tune/finite_difference.hpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2021 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef INCLUDE_ALBATROSS_SRC_TUNE_FINITE_DIFFERENCE_HPP_
+#define INCLUDE_ALBATROSS_SRC_TUNE_FINITE_DIFFERENCE_HPP_
+
+namespace albatross {
+
+template <typename Function>
+inline std::vector<double>
+compute_gradient(Function f, const std::vector<double> &params, double f_val,
+                 bool use_async = false) {
+
+  std::vector<std::size_t> inds(params.size());
+  std::iota(std::begin(inds), std::end(inds), 0);
+  const double epsilon = 1e-6;
+
+  auto compute_single_gradient = [&](const std::size_t &ind) {
+    std::vector<double> perturbed(params);
+    perturbed[ind] += epsilon;
+    return (f(perturbed) - f_val) / epsilon;
+  };
+
+  if (use_async) {
+    return albatross::async_apply(inds, compute_single_gradient);
+  } else {
+    return albatross::apply(inds, compute_single_gradient);
+  }
+}
+
+template <typename Function>
+inline std::vector<double>
+compute_gradient(Function f, const ParameterStore &params, double f_val,
+                 bool use_async = false) {
+
+  TunableParameters tunable_params = get_tunable_parameters(params);
+
+  std::vector<std::size_t> inds(tunable_params.values.size());
+  std::iota(std::begin(inds), std::end(inds), 0);
+
+  auto get_perturbed = [&](std::size_t i, double epsilon) {
+    std::vector<double> perturbed(tunable_params.values);
+    perturbed[i] = tunable_params.values[i] + epsilon;
+    return set_tunable_params_values(params, perturbed);
+  };
+
+  std::vector<double> output(inds.size());
+
+  auto compute_single_sub_gradient = [&](std::size_t i) {
+    double epsilon = 1e-6;
+    const double range =
+        tunable_params.upper_bounds[i] - tunable_params.lower_bounds[i];
+    if (std::isfinite(range)) {
+      epsilon = 1e-8 * range;
+    }
+    auto perturbed_params = get_perturbed(i, epsilon);
+
+    if (!params_are_valid(perturbed_params)) {
+      epsilon *= -1;
+      perturbed_params = get_perturbed(i, epsilon);
+    }
+
+    double grad_i = (f(perturbed_params) - f_val) / epsilon;
+
+    if (tunable_params.values[i] >= tunable_params.upper_bounds[i] &&
+        grad_i < 0) {
+      grad_i = 0;
+    }
+
+    if (tunable_params.values[i] <= tunable_params.lower_bounds[i] &&
+        grad_i > 0) {
+      grad_i = 0;
+    }
+
+    return grad_i;
+  };
+
+  if (use_async) {
+    return albatross::async_apply(inds, compute_single_sub_gradient);
+  } else {
+    return albatross::apply(inds, compute_single_sub_gradient);
+  }
+}
+
+} // namespace albatross
+
+#endif /* INCLUDE_ALBATROSS_SRC_TUNE_FINITE_DIFFERENCE_HPP_ */

--- a/include/albatross/src/tune/tune.hpp
+++ b/include/albatross/src/tune/tune.hpp
@@ -102,11 +102,12 @@ struct GenericTuner {
   ParameterStore initial_params;
   nlopt::opt optimizer;
   std::ostream &output_stream;
+  bool use_async;
 
   GenericTuner(const ParameterStore &initial_params_,
                std::ostream &output_stream_ = std::cout)
       : initial_params(initial_params_), optimizer(),
-        output_stream(output_stream_) {
+        output_stream(output_stream_), use_async(false) {
     optimizer = default_optimizer(initial_params);
   };
 
@@ -127,7 +128,8 @@ struct GenericTuner {
 
     auto param_wrapped_objective = [&](const std::vector<double> &x,
                                        std::vector<double> &grad) {
-      ParameterStore params = set_tunable_params_values(initial_params, x);
+      const ParameterStore params =
+          set_tunable_params_values(initial_params, x);
 
       if (!params_are_valid(params)) {
         this->output_stream << "Invalid Parameters:" << std::endl;

--- a/include/albatross/src/tune/tune.hpp
+++ b/include/albatross/src/tune/tune.hpp
@@ -137,6 +137,20 @@ struct GenericTuner {
 
       double metric = objective(params);
 
+      if (grad.size() > 0) {
+
+        const auto tunable = get_tunable_parameters(initial_params);
+
+        const auto grad_eval =
+            compute_gradient(objective, params, metric, use_async);
+        this->output_stream << "gradient" << std::endl;
+        for (std::size_t i = 0; i < grad_eval.size(); ++i) {
+          this->output_stream << "  " << tunable.names[i] << " : "
+                              << grad_eval[i] << std::endl;
+          grad[i] = grad_eval[i];
+        }
+      }
+
       if (std::isnan(metric)) {
         metric = INFINITY;
       }
@@ -165,10 +179,18 @@ struct GenericTuner {
 
     auto grad_free_objective = [&](const std::vector<double> &x,
                                    std::vector<double> &grad) {
-      assert(grad.size() == 0 &&
-             "Gradient based algorithm used with a gradient free objective");
-
       double metric = objective(x);
+
+      if (grad.size() > 0) {
+        const auto grad_eval =
+            compute_gradient(objective, x, metric, use_async);
+        this->output_stream << "gradient" << std::endl;
+        for (std::size_t i = 0; i < grad_eval.size(); ++i) {
+          this->output_stream << "  " << i << " : " << grad_eval[i]
+                              << std::endl;
+          grad[i] = grad_eval[i];
+        }
+      }
 
       if (std::isnan(metric)) {
         metric = INFINITY;

--- a/include/albatross/src/tune/tune.hpp
+++ b/include/albatross/src/tune/tune.hpp
@@ -51,8 +51,6 @@ inline void set_objective_function(nlopt::opt &optimizer,
 inline nlopt::opt
 default_optimizer(const ParameterStore &params,
                   const nlopt::algorithm &algorithm = nlopt::LN_SBPLX) {
-  // The various algorithms in nlopt are coded by the first two characters.
-  // In this case LN stands for local, gradient free.
   const auto tunable_params = get_tunable_parameters(params);
 
   nlopt::opt optimizer(algorithm, (unsigned)tunable_params.values.size());
@@ -65,6 +63,20 @@ default_optimizer(const ParameterStore &params,
   // terminate based on xtol if the change is super small.
   optimizer.set_xtol_abs(1e-18);
   optimizer.set_xtol_rel(1e-18);
+  return optimizer;
+}
+
+inline nlopt::opt default_gradient_optimizer(
+    const ParameterStore &params,
+    const nlopt::algorithm &algorithm = nlopt::LD_SLSQP) {
+  const auto tunable_params = get_tunable_parameters(params);
+  nlopt::opt optimizer(algorithm, (unsigned)tunable_params.values.size());
+  optimizer.set_ftol_abs(1e-4);
+  optimizer.set_ftol_rel(1e-4);
+  optimizer.set_lower_bounds(tunable_params.lower_bounds);
+  optimizer.set_upper_bounds(tunable_params.upper_bounds);
+  optimizer.set_xtol_abs(1e-6);
+  optimizer.set_xtol_rel(1e-6);
   return optimizer;
 }
 

--- a/include/albatross/src/utils/async_utils.hpp
+++ b/include/albatross/src/utils/async_utils.hpp
@@ -32,7 +32,8 @@ template <typename ValueType, typename ApplyFunction,
                                       ApplyFunction, ValueType>::value &&
                                       std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
-void async_apply(const std::vector<ValueType> &xs, const ApplyFunction &func) {
+inline void async_apply(const std::vector<ValueType> &xs,
+                        const ApplyFunction &func) {
   std::vector<std::future<void>> futures;
   for (const auto &x : xs) {
     futures.emplace_back(async_safe(func, x));
@@ -49,7 +50,8 @@ template <typename ValueType, typename ApplyFunction,
                                       ApplyFunction, ValueType>::value &&
                                       !std::is_same<void, ApplyType>::value,
                                   int>::type = 0>
-auto async_apply(const std::vector<ValueType> &xs, const ApplyFunction &func) {
+inline auto async_apply(const std::vector<ValueType> &xs,
+                        const ApplyFunction &func) {
   std::vector<std::future<ApplyType>> futures;
   for (const auto &x : xs) {
     futures.emplace_back(async_safe(func, x));

--- a/include/albatross/utils/AsyncUtils
+++ b/include/albatross/utils/AsyncUtils
@@ -14,6 +14,7 @@
 #define ALBATROSS_UTILS_ASYNC_UTILS_H
 
 #include <future>
+#include <mutex>
 
 #include "../src/utils/async_utils.hpp"
 


### PR DESCRIPTION
In this PR we add some methods for computing the finite difference gradient of a function (`compute_gradient`) and then use that method to enable tuning with gradient based optimization methods such as the [Sequential Least Squares](https://nlopt.readthedocs.io/en/latest/NLopt_Algorithms/#slsqp).

This approach isn't ideal.  Finite difference gradients destroy some of the assumptions used by gradient based optimization routines for determining convergence, but in practice this works "pretty well".  The most notable issue I've found happens near optimal solutions.  In these situations a finite difference gradient may return a non zero gradient implying that further optimization can be achieved.  This confuses the algorithms into attempting iterations for which it can't actually find a satisfactory next step, at which point they typically fail.  One work around is to loosen the convergence criteria, which I've done in the `default_gradient_optimizer`, in an attempt to have the algorithm terminate before it gets into a regime in which the imprecise gradients cause problems.