### PR TITLE
Add nlopt submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "third_party/variant"]
 	path = third_party/variant
 	url = https://github.com/swift-nav/variant.git
+[submodule "third_party/nlopt"]
+	path = third_party/nlopt
+	url = https://github.com/swift-nav/nlopt.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ matrix:
           - clang-6.0
           - clang-format-6.0
           - clang-tidy-6.0
-          - libnlopt-dev
     env:
       - C_COMPILER=gcc-6 CXX_COMPILER=g++-6
   - compiler: clang-6.0
@@ -46,7 +45,6 @@ matrix:
           - clang-6.0
           - clang-format-6.0
           - clang-tidy-6.0
-          - libnlopt-dev
     env:
       - C_COMPILER=clang-6.0 CXX_COMPILER=clang++-6.0
   - compiler: sphinx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(Eigen REQUIRED)
 find_package(FastCSV REQUIRED)
 find_package(Gzip-Hpp REQUIRED)
 find_package(Variant REQUIRED)
+find_package(Nlopt REQUIRED)
 
 add_library(albatross INTERFACE)
 target_include_directories(albatross INTERFACE

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -13,6 +13,7 @@
 #include "test_models.h"
 #include <albatross/Tune>
 #include <gtest/gtest.h>
+#include <nlopt.hpp>
 
 namespace albatross {
 


### PR DESCRIPTION
Swift Navigation has a fork of nlopt which is guaranteed to work with `albatross` instead of relying on compatibility with whichever version is installed locally.