### PR TITLE
Add 'cmake-build' dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@
 .DS_Store
 .deps
 build*/
+cmake-build*/
 .project
 .cproject
 .pydevproject


### PR DESCRIPTION
Small change found in other repositories - ignore Clion default build directory.