### PR TITLE
Detailed Ransac Output

### DIFF
--- a/include/albatross/src/cereal/ransac.hpp
+++ b/include/albatross/src/cereal/ransac.hpp
@@ -18,17 +18,28 @@ using albatross::GaussianProcessRansacStrategy;
 using albatross::GenericRansacStrategy;
 using albatross::Ransac;
 using albatross::RansacFit;
+using albatross::RansacIteration;
 using albatross::RansacOutput;
 
 namespace cereal {
 
 template <typename Archive, typename GroupKey>
+inline void serialize(Archive &archive,
+                      RansacIteration<GroupKey> &ransac_iteration,
+                      const std::uint32_t) {
+  archive(cereal::make_nvp("candidates", ransac_iteration.candidates));
+  archive(cereal::make_nvp("inliers", ransac_iteration.inliers));
+  archive(cereal::make_nvp("outliers", ransac_iteration.outliers));
+  archive(
+      cereal::make_nvp("consensus_metric", ransac_iteration.consensus_metric));
+}
+
+template <typename Archive, typename GroupKey>
 inline void serialize(Archive &archive, RansacOutput<GroupKey> &ransac_output,
                       const std::uint32_t) {
   archive(cereal::make_nvp("return_code", ransac_output.return_code));
-  archive(cereal::make_nvp("inliers", ransac_output.inliers));
-  archive(cereal::make_nvp("outliers", ransac_output.outliers));
-  archive(cereal::make_nvp("consensus_metric", ransac_output.consensus_metric));
+  archive(cereal::make_nvp("best", ransac_output.best));
+  archive(cereal::make_nvp("iterations", ransac_output.iterations));
 }
 
 template <typename Archive, typename ModelType, typename StrategyType,

--- a/include/albatross/src/cereal/ransac.hpp
+++ b/include/albatross/src/cereal/ransac.hpp
@@ -30,8 +30,8 @@ inline void serialize(Archive &archive,
   archive(cereal::make_nvp("candidates", ransac_iteration.candidates));
   archive(cereal::make_nvp("inliers", ransac_iteration.inliers));
   archive(cereal::make_nvp("outliers", ransac_iteration.outliers));
-  archive(
-      cereal::make_nvp("consensus_metric", ransac_iteration.consensus_metric));
+  archive(cereal::make_nvp("consensus_metric_value",
+                           ransac_iteration.consensus_metric_value));
 }
 
 template <typename Archive, typename GroupKey>

--- a/tests/test_ransac.cc
+++ b/tests/test_ransac.cc
@@ -43,16 +43,16 @@ TEST(test_outlier, test_ransac_direct) {
   const auto result = ransac(ransac_functions, indexer, inlier_threshold,
                              sample_size, min_consensus_size, max_iterations);
 
-  EXPECT_EQ(result.inliers.size(), dataset.features.size() - bad_inds.size());
+  const auto consensus = result.best.consensus();
+  EXPECT_EQ(consensus.size(), dataset.features.size() - bad_inds.size());
   EXPECT_TRUE(ransac_success(result.return_code));
-  EXPECT_FALSE(std::isnan(result.consensus_metric));
+  EXPECT_FALSE(std::isnan(result.best.consensus_metric));
 
   for (const auto &i : bad_inds) {
     // Make sure we threw out the correct features.
-    EXPECT_EQ(std::find(result.inliers.begin(), result.inliers.end(), i),
-              result.inliers.end());
-    EXPECT_NE(std::find(result.outliers.begin(), result.outliers.end(), i),
-              result.outliers.end());
+    EXPECT_EQ(std::find(consensus.begin(), consensus.end(), i),
+              consensus.end());
+    EXPECT_TRUE(map_contains(result.best.outliers, i));
   }
 }
 
@@ -85,11 +85,12 @@ TEST(test_outlier, test_ransac_model) {
   const auto indexer = ransac_strategy.get_indexer(dataset);
   const auto result = ransac(ransac_functions, indexer, inlier_threshold,
                              sample_size, min_consensus_size, max_iterations);
-  const auto inlier_keys = result.inliers;
-  const auto inlier_inds = indices_from_groups(indexer, inlier_keys);
-  const auto inlier_dataset = subset(dataset, inlier_inds);
+  const auto consensus_keys = result.best.consensus();
+  const auto consensus_inds = indices_from_groups(indexer, consensus_keys);
+  const auto consensus_dataset = subset(dataset, consensus_inds);
 
-  const auto direct_pred = model.fit(inlier_dataset).predict(dataset.features);
+  const auto direct_pred =
+      model.fit(consensus_dataset).predict(dataset.features);
   expect_predict_variants_consistent(direct_pred);
 
   EXPECT_EQ(pred.mean(), direct_pred.mean());
@@ -131,7 +132,7 @@ TEST(test_outlier, test_ransac_groups) {
 
   const auto result = ransac(ransac_functions, indexer, 0., 1, 1, 20);
   EXPECT_TRUE(ransac_success(result.return_code));
-  EXPECT_LE(result.inliers.size(), indexer.size());
+  EXPECT_LE(result.best.consensus().size(), indexer.size());
 }
 
 inline bool never_accept_candidates(const std::vector<std::string> &) {

--- a/tests/test_ransac.cc
+++ b/tests/test_ransac.cc
@@ -46,7 +46,7 @@ TEST(test_outlier, test_ransac_direct) {
   const auto consensus = result.best.consensus();
   EXPECT_EQ(consensus.size(), dataset.features.size() - bad_inds.size());
   EXPECT_TRUE(ransac_success(result.return_code));
-  EXPECT_FALSE(std::isnan(result.best.consensus_metric));
+  EXPECT_FALSE(std::isnan(result.best.consensus_metric_value));
 
   for (const auto &i : bad_inds) {
     // Make sure we threw out the correct features.


### PR DESCRIPTION
In a recent PR we added the ability to print debugging information out via a compile time flag: https://github.com/swift-nav/albatross/pull/249.  While helpful for debugging this doesn't allow programmatic comparisons of RANSAC output.  For example, if we wanted to prove that RANSAC could be deterministically repeated we'd want to be able to compare the details from one execution of RANSAC to those from another to demonstrate that each step taken was equivalent.

In this PR we add a `RansacIteration<>` class which holds details of results from a single iteration of RANSAC.  The `RansacOutput` struct was then modified to consist of a `best` iteration and a vector of all the iterations which will allow users to inspect details of what went on inside the algorithm.