### PR TITLE
Add dataset.subset()

### DIFF
--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -51,6 +51,9 @@ template <typename FeatureType> struct RegressionDataset {
 
   std::size_t size() const { return features.size(); }
 
+  template <typename SizeType>
+  RegressionDataset subset(const std::vector<SizeType> &indices) const;
+
   template <typename GrouperFunc>
   GroupBy<RegressionDataset<FeatureType>, GrouperFunc>
   group_by(GrouperFunc grouper) const;
@@ -71,6 +74,13 @@ subset(const RegressionDataset<FeatureType> &dataset,
        const std::vector<SizeType> &indices) {
   return RegressionDataset<FeatureType>(subset(dataset.features, indices),
                                         subset(dataset.targets, indices));
+}
+
+template <typename FeatureType>
+template <typename SizeType>
+RegressionDataset<FeatureType> RegressionDataset<FeatureType>::subset(
+    const std::vector<SizeType> &indices) const {
+  return albatross::subset(*this, indices);
 }
 
 template <typename FeatureType>

--- a/tests/test_core_dataset.cc
+++ b/tests/test_core_dataset.cc
@@ -26,7 +26,7 @@ TEST(test_dataset, test_construct_and_subset) {
   EXPECT_EQ(dataset.size(), static_cast<std::size_t>(targets.size()));
 
   std::vector<std::size_t> indices = {0, 2};
-  const auto subset_dataset = subset(dataset, indices);
+  const auto subset_dataset = dataset.subset(indices);
   EXPECT_EQ(subset_dataset.size(), indices.size());
 
   auto is_3_or_1 = [](const int &x) { return x == 3 || x == 1; };
@@ -44,7 +44,7 @@ TEST(test_dataset, test_deduplicate) {
 
   const std::vector<std::size_t> expected_inds = {0, 2, 3};
 
-  EXPECT_EQ(dedupped, albatross::subset(dataset, expected_inds));
+  EXPECT_EQ(dedupped, dataset.subset(expected_inds));
   EXPECT_EQ(dedupped, deduplicate(dedupped));
 }
 


### PR DESCRIPTION
Adds a convenience method to `RegressionDataset<T>` which lets you do:
```
dataset.subset(indices);
```
instead of
```
albatross::subset(dataset, indices);
```
which aligns with the distributions which also support,
```
joint_distribution.subset(indices);
```