### PR TITLE
convert exit() to assert()

### DIFF
--- a/include/albatross/src/core/parameter_handling_mixin.hpp
+++ b/include/albatross/src/core/parameter_handling_mixin.hpp
@@ -220,7 +220,7 @@ public:
     if (!map_contains(current_params, key)) {
       std::cerr << "Error: Key `" << key << "` not found in parameters: "
                 << pretty_params(current_params);
-      exit(EXIT_FAILURE);
+      assert(false);
     }
   }
 


### PR DESCRIPTION
The use of `exit()` actually exits the program normally which can mask errors, here I switch to `assert()`.