### PR TITLE
Add method to get prior from GPs

### DIFF
--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -67,7 +67,6 @@ struct Fit<GPFit<CovarianceRepresentation, FeatureType>> {
     cov += targets.covariance;
     assert(!cov.hasNaN());
     train_covariance = CovarianceRepresentation(cov);
-    // Precompute the information vector
     information = train_covariance.solve(targets.mean);
   }
 
@@ -418,6 +417,13 @@ public:
   CovFunc get_covariance() const { return covariance_function_; }
 
   MeanFunc get_mean() const { return mean_function_; };
+
+  template <typename FeatureType>
+  JointDistribution prior(const std::vector<FeatureType> &features) const {
+    const auto measurement_features = as_measurements(features);
+    return JointDistribution(mean_function_(measurement_features),
+                             covariance_function_(measurement_features));
+  }
 
   template <typename FeatureType>
   Eigen::MatrixXd

--- a/tests/test_gp.cc
+++ b/tests/test_gp.cc
@@ -436,4 +436,20 @@ TEST(test_gp, test_nonzero_mean) {
   EXPECT_GT((pred_without_mean.mean - actual.mean).norm(), 1.);
 }
 
+TEST(test_gp, test_get_prior) {
+
+  MakeGaussianProcessWithMean gp_with_mean_case;
+
+  const auto dataset = gp_with_mean_case.get_dataset();
+  const auto model = gp_with_mean_case.get_model();
+
+  const auto prior = model.prior(dataset.features);
+
+  const auto cov = model.get_covariance();
+  EXPECT_EQ(prior.covariance, cov(as_measurements(dataset.features)));
+
+  const auto mean = model.get_mean()(as_measurements(dataset.features));
+  EXPECT_EQ(prior.mean, mean);
+}
+
 } // namespace albatross


### PR DESCRIPTION
This adds a method which makes it easy to get the prior distribution for a set of features from a Gaussian process.  For example,
```
JointDistribution prior = model.prior(features);
```
I anticipate using this in a helper model I'm putting together to improve the GP ransac flow.