### PR TITLE
Improve Compile Errors with invalid predict methods.

### DIFF
--- a/include/albatross/src/core/prediction.hpp
+++ b/include/albatross/src/core/prediction.hpp
@@ -141,9 +141,7 @@ public:
       typename std::enable_if<!can_predict_mean<MeanPredictor, ModelType,
                                                 DummyType, FitType>::value,
                               int>::type = 0>
-  void mean() const
-      ALBATROSS_FAIL(DummyType, "No valid predict method in ModelType for the "
-                                "mean with FitType and FeatureType.");
+  Eigen::VectorXd mean() const = delete; // No valid predict method found.
 
   // Marginal
   template <
@@ -162,9 +160,8 @@ public:
                 !can_predict_marginal<MarginalPredictor, ModelType, DummyType,
                                       FitType>::value,
                 int>::type = 0>
-  void marginal() const
-      ALBATROSS_FAIL(DummyType, "No valid predict method in ModelType for the "
-                                "marginal with FitType and FeatureType.");
+  MarginalDistribution
+  marginal() const = delete; // No valid predict method found.
 
   // Joint
   template <
@@ -183,9 +180,7 @@ public:
       typename std::enable_if<!can_predict_joint<JointPredictor, ModelType,
                                                  DummyType, FitType>::value,
                               int>::type = 0>
-  void joint() const
-      ALBATROSS_FAIL(DummyType, "No valid predict method in ModelType for the "
-                                "joint with FitType and FeatureType.");
+  JointDistribution joint() const = delete; // No valid predict method found.
 
   template <typename PredictType>
   PredictType get(PredictTypeIdentity<PredictType> =


### PR DESCRIPTION
This PR aims to fix an edge case for developer experience when implementing new models.  For example, consider the case where we're creating a new model for which we want to define a joint prediction method which should look something like this,
```
class Foo : public ModelBase<Foo> {
  ...
  JointDistribution
  _predict_impl(const std::vector<X> &features,
                const FooFit &fit,
                PredictTypeIdentity<JointDistribution> &&) const {
    return make_prediction();
  }
}
```
What if we've improperly define the predict implementation (note the lack of `const` on one of the arguments):
```
class Foo : public ModelBase<Foo> {
  ...
  JointDistribution
  _predict_impl(const std::vector<X> &features,
                FooFit &fit,
                PredictTypeIdentity<JointDistribution> &&) const {
    return make_prediction();
  }
}
```
At the moment if you try to run:
```
foo.fit(dataset).predict(features).joint();
```
You'll actually get a relatively informative error, but if you try to run cross validation,
```
  LeaveOneOutGrouper leave_one_out;
  const auto predictions = foo.cross_validate().predictions(dataset, leave_one_out);
```
You'll get a much more opaque error:
```
include/albatross/src/core/prediction.hpp:212:24: error: could not convert ‘albatross::Prediction<ModelType, FeatureType, FitType>::joint<long unsigned int, 0>()’ from ‘void’ to ‘albatross::JointDistribution’
     return this->joint();
```

The reason why this happens comes down to [the `has_joint` trait](https://github.com/swift-nav/albatross/blob/master/include/albatross/src/core/traits.hpp#L203) which actually returns true when we've used `ALBATROSS_FAIL` (which delays assertion).  By switching to using `= delete;` the compiler fails closer to the source of the problem leading to a more informative error:
```
include/albatross/src/core/prediction.hpp:207:24: error: use of deleted function ‘albatross::JointDistribution albatross::Prediction<ModelType, FeatureType, FitType>::joint() const [with DummyType = long unsigned int; typename std::enable_if<(! albatross::can_predict_joint<albatross::JointPredictor, ModelType, DummyType, FitType>::value), int>::type <anonymous> = 0; ModelType = albatross::ConditionalGaussian; FeatureType = long unsigned int; FitType = albatross::ConditionalFit]’
     return this->joint();
                        ^
include/albatross/src/core/prediction.hpp:183:21: note: declared here
   JointDistribution joint() const = delete; // No valid predict method found.
```