### PR TITLE
Ransac Uses Conditional Gaussian

### DIFF
--- a/include/albatross/Ransac
+++ b/include/albatross/Ransac
@@ -13,7 +13,7 @@
 #ifndef ALBATROSS_RANSAC_H
 #define ALBATROSS_RANSAC_H
 
-#include "Core"
+#include "GP"
 #include "Evaluation"
 
 #include <albatross/src/utils/random_utils.hpp>

--- a/include/albatross/src/models/ransac_gp.hpp
+++ b/include/albatross/src/models/ransac_gp.hpp
@@ -71,9 +71,7 @@ get_gp_ransac_consensus_metric(const ConditionalGaussian &model,
 struct DifferentialEntropyConsensusMetric {
   double operator()(const JointDistribution &pred,
                     const MarginalDistribution &truth) const {
-    Eigen::MatrixXd cov = pred.covariance;
-    cov += truth.covariance;
-    return differential_entropy(cov);
+    return differential_entropy(pred.covariance);
   }
 };
 

--- a/include/albatross/src/models/ransac_gp.hpp
+++ b/include/albatross/src/models/ransac_gp.hpp
@@ -15,147 +15,105 @@
 
 namespace albatross {
 
-template <typename ModelType, typename FeatureType> struct FitAndIndices {
-  using FitType = typename fit_type<ModelType, FeatureType>::type;
+template <typename GroupKey>
+inline typename RansacFunctions<ConditionalFit, GroupKey>::FitterFunc
+get_gp_ransac_fitter(const ConditionalGaussian &model,
+                     const GroupIndexer<GroupKey> &indexer) {
 
-  FitType fit;
-  GroupIndices indices;
-};
-
-template <typename ModelType, typename FeatureType, typename GroupKey>
-inline typename RansacFunctions<FitAndIndices<ModelType, FeatureType>,
-                                GroupKey>::FitterFunc
-get_gp_ransac_fitter(const RegressionDataset<FeatureType> &dataset,
-                     const GroupIndexer<GroupKey> &indexer,
-                     const Eigen::MatrixXd &cov) {
-  return [&, indexer, cov, dataset](const std::vector<GroupKey> &groups) {
-    auto inds = indices_from_groups(indexer, groups);
-    const auto train_dataset = subset(dataset, inds);
-    const auto train_cov = symmetric_subset(cov, inds);
-
-    using GPFitType = typename FitAndIndices<ModelType, FeatureType>::FitType;
-    const GPFitType fit(train_dataset.features, train_cov,
-                        train_dataset.targets);
-    const FitAndIndices<ModelType, FeatureType> fit_and_indices = {fit, inds};
-    return fit_and_indices;
+  return [&, model, indexer](const std::vector<GroupKey> &groups) {
+    auto indices = indices_from_groups(indexer, groups);
+    return model.fit_from_indices(indices);
   };
 }
 
-template <typename ModelType, typename FeatureType,
-          typename IsValidCandidateMetric, typename GroupKey>
-inline typename RansacFunctions<FitAndIndices<ModelType, FeatureType>,
-                                GroupKey>::IsValidCandidate
-get_gp_ransac_is_valid_candidate(const RegressionDataset<FeatureType> &dataset,
+template <typename IsValidCandidateMetric, typename GroupKey>
+inline typename RansacFunctions<ConditionalFit, GroupKey>::IsValidCandidate
+get_gp_ransac_is_valid_candidate(const ConditionalGaussian &model,
                                  const GroupIndexer<GroupKey> &indexer,
-                                 const Eigen::MatrixXd &cov,
                                  const IsValidCandidateMetric &metric) {
 
-  return [&, indexer, cov, dataset](const std::vector<GroupKey> &groups) {
-    const auto inds = indices_from_groups(indexer, groups);
-    return metric(inds, dataset, cov);
+  return [&, model, indexer](const std::vector<GroupKey> &groups) {
+    const auto indices = indices_from_groups(indexer, groups);
+    const auto prior = model.get_prior(indices);
+    const auto truth = model.get_truth(indices);
+    return metric(prior, truth);
   };
 }
 
-template <typename ModelType, typename FeatureType, typename InlierMetricType,
-          typename GroupKey>
-inline typename RansacFunctions<FitAndIndices<ModelType, FeatureType>,
-                                GroupKey>::InlierMetric
-get_gp_ransac_inlier_metric(const RegressionDataset<FeatureType> &dataset,
+template <typename InlierMetricType, typename GroupKey>
+inline typename RansacFunctions<ConditionalFit, GroupKey>::InlierMetric
+get_gp_ransac_inlier_metric(const ConditionalGaussian &model,
                             const GroupIndexer<GroupKey> &indexer,
-                            const Eigen::MatrixXd &cov, const ModelType &model,
                             const InlierMetricType &metric) {
 
-  return [&, indexer, cov, model, dataset](
-             const GroupKey &group,
-             const FitAndIndices<ModelType, FeatureType> &fit_and_indices) {
-    const auto inds = indexer.at(group);
-    const auto test_dataset = subset(dataset, inds);
-
-    const auto pred =
-        get_prediction(model, fit_and_indices.fit, test_dataset.features);
-    return metric(pred, test_dataset.targets);
+  return [&, indexer, model](const GroupKey &group, const ConditionalFit &fit) {
+    const auto indices = indexer.at(group);
+    const auto pred = get_prediction(model, fit, indices);
+    const auto truth = model.get_truth(indices);
+    return metric(pred, truth);
   };
 }
 
-template <typename ModelType, typename FeatureType, typename ConsensusMetric,
-          typename GroupKey>
-inline typename RansacFunctions<FitAndIndices<ModelType, FeatureType>,
-                                GroupKey>::ConsensusMetric
-get_gp_ransac_consensus_metric(const GroupIndexer<GroupKey> &indexer,
-                               const RegressionDataset<FeatureType> &dataset,
-                               const Eigen::MatrixXd &cov,
+template <typename ConsensusMetric, typename GroupKey>
+inline typename RansacFunctions<ConditionalFit, GroupKey>::ConsensusMetric
+get_gp_ransac_consensus_metric(const ConditionalGaussian &model,
+                               const GroupIndexer<GroupKey> &indexer,
                                const ConsensusMetric &metric) {
 
-  return [&, indexer, cov, dataset](const std::vector<GroupKey> &groups) {
-    const auto inds = indices_from_groups(indexer, groups);
-    ;
-    return metric(inds, dataset.targets, cov);
+  return [&, model, indexer](const std::vector<GroupKey> &groups) {
+    const auto indices = indices_from_groups(indexer, groups);
+    const auto prior = model.get_prior(indices);
+    const auto truth = model.get_truth(indices);
+    return metric(prior, truth);
   };
 }
 
 struct DifferentialEntropyConsensusMetric {
-  double operator()(const GroupIndices &indices, const MarginalDistribution &,
-                    const Eigen::MatrixXd &cov) const {
-    const auto consensus_cov = symmetric_subset(cov, indices);
-    return differential_entropy(consensus_cov);
+  double operator()(const JointDistribution &pred,
+                    const MarginalDistribution &truth) const {
+    Eigen::MatrixXd cov = pred.covariance;
+    cov += truth.covariance;
+    return differential_entropy(cov);
   }
 };
 
 struct FeatureCountConsensusMetric {
-
-  double operator()(const GroupIndices &indices, const MarginalDistribution &,
-                    const Eigen::MatrixXd &) const {
+  double operator()(const JointDistribution &prior,
+                    const MarginalDistribution &truth) const {
     // Negative because a lower metric is better.
-    return (-1.0 * static_cast<double>(indices.size()));
+    return (-1.0 * static_cast<double>(truth.size()));
   }
 };
 
 struct ChiSquaredConsensusMetric {
-  double operator()(const GroupIndices &indices,
-                    const MarginalDistribution &targets,
-                    const Eigen::MatrixXd &cov) const {
-    const auto consensus_prior = symmetric_subset(cov, indices);
-    const auto consensus_targets = subset(targets, indices);
-    return chi_squared_cdf(consensus_targets.mean, consensus_prior);
+  double operator()(const JointDistribution &prior,
+                    const MarginalDistribution &truth) const {
+    return chi_squared_cdf(prior, truth);
   }
 };
 
 struct ChiSquaredIsValidCandidateMetric {
-
-  template <typename FeatureType>
-  bool operator()(const GroupIndices &inds,
-                  const RegressionDataset<FeatureType> &dataset,
-                  const Eigen::MatrixXd &cov) const {
-    const auto train_dataset = subset(dataset, inds);
-    const auto train_cov = symmetric_subset(cov, inds);
-
-    const JointDistribution prior(Eigen::VectorXd::Zero(train_cov.rows()),
-                                  train_cov);
+  bool operator()(const JointDistribution &pred,
+                  const MarginalDistribution &truth) const {
     // These thresholds are under the assumption of a perfectly
     // representative prior.
-    const double probability_prior_exceeded =
-        chi_squared_cdf(prior, train_dataset.targets);
+    const double probability_prior_exceeded = chi_squared_cdf(pred, truth);
     const double skip_every_1000th_candidate = 0.999;
     return (probability_prior_exceeded < skip_every_1000th_candidate);
   };
 };
 
 struct AlwaysAcceptCandidateMetric {
-  template <typename FeatureType>
-  bool operator()(const GroupIndices &inds,
-                  const RegressionDataset<FeatureType> &dataset,
-                  const Eigen::MatrixXd &cov) const {
+  bool operator()(const JointDistribution &pred,
+                  const MarginalDistribution &truth) const {
     return true;
   }
 };
 
-template <typename ModelType, typename FeatureType, typename InlierMetric,
-          typename ConsensusMetric, typename IsValidCandidateMetric,
-          typename GroupKey>
-inline RansacFunctions<FitAndIndices<ModelType, FeatureType>, GroupKey>
-get_gp_ransac_functions(
-    const ModelType &model,
-    const RegressionDataset<FeatureType> &dataset_with_mean,
+template <typename InlierMetric, typename ConsensusMetric,
+          typename IsValidCandidateMetric, typename GroupKey>
+inline RansacFunctions<ConditionalFit, GroupKey> get_gp_ransac_functions(
+    const JointDistribution &prior, const MarginalDistribution &truth,
     const GroupIndexer<GroupKey> &indexer, const InlierMetric &inlier_metric,
     const ConsensusMetric &consensus_metric,
     const IsValidCandidateMetric &is_valid_candidate_metric) {
@@ -163,28 +121,22 @@ get_gp_ransac_functions(
   static_assert(is_prediction_metric<InlierMetric>::value,
                 "InlierMetric must be an PredictionMetric.");
 
-  RegressionDataset<FeatureType> dataset(dataset_with_mean);
-  model.get_mean().remove_from(dataset.features, &dataset.targets.mean);
-  const auto full_cov = model.compute_covariance(dataset.features);
+  const ConditionalGaussian model(prior, truth);
 
-  const auto fitter = get_gp_ransac_fitter<ModelType, FeatureType, GroupKey>(
-      dataset, indexer, full_cov);
+  const auto fitter = get_gp_ransac_fitter<GroupKey>(model, indexer);
 
   const auto inlier_metric_from_group =
-      get_gp_ransac_inlier_metric<ModelType, FeatureType, InlierMetric,
-                                  GroupKey>(dataset, indexer, full_cov, model,
-                                            inlier_metric);
+      get_gp_ransac_inlier_metric<InlierMetric, GroupKey>(model, indexer,
+                                                          inlier_metric);
 
   const auto consensus_metric_from_groups =
-      get_gp_ransac_consensus_metric<ModelType, FeatureType, ConsensusMetric,
-                                     GroupKey>(indexer, dataset, full_cov,
-                                               consensus_metric);
+      get_gp_ransac_consensus_metric<ConsensusMetric, GroupKey>(
+          model, indexer, consensus_metric);
 
-  const auto is_valid_candidate =
-      get_gp_ransac_is_valid_candidate<ModelType, FeatureType>(
-          dataset, indexer, full_cov, is_valid_candidate_metric);
+  const auto is_valid_candidate = get_gp_ransac_is_valid_candidate(
+      model, indexer, is_valid_candidate_metric);
 
-  return RansacFunctions<FitAndIndices<ModelType, FeatureType>, GroupKey>(
+  return RansacFunctions<ConditionalFit, GroupKey>(
       fitter, inlier_metric_from_group, consensus_metric_from_groups,
       is_valid_candidate);
 };
@@ -208,7 +160,8 @@ struct GaussianProcessRansacStrategy {
   auto operator()(const ModelType &model,
                   const RegressionDataset<FeatureType> &dataset) const {
     const auto indexer = get_indexer(dataset);
-    return get_gp_ransac_functions(model, dataset, indexer, inlier_metric_,
+    return get_gp_ransac_functions(model.prior(dataset.features),
+                                   dataset.targets, indexer, inlier_metric_,
                                    consensus_metric_, is_valid_candidate_);
   }
 

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -233,9 +233,10 @@ struct AdaptedRansacStrategy
     const auto indexer = get_indexer(converted);
     const FeatureCountConsensusMetric consensus_metric;
     const AlwaysAcceptCandidateMetric always_accept;
-    return get_gp_ransac_functions(model, converted, indexer,
-                                   this->inlier_metric_, consensus_metric,
-                                   always_accept);
+
+    return get_gp_ransac_functions(
+        model.prior(converted.features), converted.targets, indexer,
+        this->inlier_metric_, consensus_metric, always_accept);
   }
 };
 


### PR DESCRIPTION
This PR replaces a bunch of the logic in the `ransac_gp.hpp` methods which require indexing into matrices / datasets and producing fits / predictions in an efficient manner.  With this change most of that logic is passed off to the `ConditionalGaussian` model which also lets us remove a large number of template parameters and makes it easier to call these ransac methods with intermediate predictions (instead of requiring an unfit model).