### PR TITLE
Fix randint_without_replacement indices

### DIFF
--- a/include/albatross/src/utils/random_utils.hpp
+++ b/include/albatross/src/utils/random_utils.hpp
@@ -27,9 +27,9 @@ randint_without_replacement(std::size_t n, std::size_t low, std::size_t high,
     assert(false);
   }
 
-  if (n == (high - low + 1)) {
+  if (n == n_choices) {
     std::vector<std::size_t> all_inds(n);
-    std::iota(all_inds.begin(), all_inds.end(), 0);
+    std::iota(all_inds.begin(), all_inds.end(), low);
     return all_inds;
   }
 
@@ -38,8 +38,8 @@ randint_without_replacement(std::size_t n, std::size_t low, std::size_t high,
     // points it'll be faster to randomly sample which points we
     // should throw out than which ones we should keep.
     const auto to_throw_out =
-        randint_without_replacement(n_choices - n, low, high, gen);
-    auto to_keep = indices_complement(to_throw_out, high - low);
+        randint_without_replacement(n_choices - n, 0, n_choices - 1, gen);
+    auto to_keep = indices_complement(to_throw_out, n_choices);
 
     if (low != 0) {
       for (auto &el : to_keep) {

--- a/tests/test_random_utils.cc
+++ b/tests/test_random_utils.cc
@@ -25,11 +25,9 @@ TEST(test_random_utils, randint_without_replacement) {
 
   for (int i = 0; i < iterations; i++) {
     for (int n = 0; n <= k + 1; n++) {
-      std::cout << n << " " << i << " " << i + k << std::endl;
       const auto inds = randint_without_replacement(n, i, i + k, gen);
       EXPECT_EQ(inds.size(), n);
       for (const auto &j : inds) {
-        std::cout << "   " << j << std::endl;
         EXPECT_LE(j, i + k);
         EXPECT_GE(j, i);
       }

--- a/tests/test_random_utils.cc
+++ b/tests/test_random_utils.cc
@@ -24,9 +24,12 @@ TEST(test_random_utils, randint_without_replacement) {
   std::default_random_engine gen;
 
   for (int i = 0; i < iterations; i++) {
-    for (int n = 0; n <= k; n++) {
+    for (int n = 0; n <= k + 1; n++) {
+      std::cout << n << " " << i << " " << i+k << std::endl;
       const auto inds = randint_without_replacement(n, i, i + k, gen);
+      EXPECT_EQ(inds.size(), n);
       for (const auto &j : inds) {
+        std::cout << "   " << j << std::endl;
         EXPECT_LE(j, i + k);
         EXPECT_GE(j, i);
       }

--- a/tests/test_random_utils.cc
+++ b/tests/test_random_utils.cc
@@ -25,7 +25,7 @@ TEST(test_random_utils, randint_without_replacement) {
 
   for (int i = 0; i < iterations; i++) {
     for (int n = 0; n <= k + 1; n++) {
-      std::cout << n << " " << i << " " << i+k << std::endl;
+      std::cout << n << " " << i << " " << i + k << std::endl;
       const auto inds = randint_without_replacement(n, i, i + k, gen);
       EXPECT_EQ(inds.size(), n);
       for (const auto &j : inds) {


### PR DESCRIPTION
Fixes a set of three independent bugs in the `randint_without_replacement` function.
```
inline std::vector<std::size_t>
randint_without_replacement(std::size_t n, std::size_t low, std::size_t high,
                            std::default_random_engine &gen) {
```

1) When `low > 0`,  when `n == n_choices`, the `std::iota` started at `0`, returning the indices`[0, ... ,n-1]` and not `[low, ... ,high]`

2) When `low > 0` and  `n > n_choices/2` , the reciprocal problem of omitting n indices is solved, with the result sent to `indices_complement` https://github.com/swift-nav/albatross/blob/cbe68c412725f7fdb9e83a6e80e553bf3cdc207d/include/albatross/src/indexing/subset.hpp#L190
`indices_complement` assumes the input indices are between `[0,n-1]`, but they were called in the range `[low,high]`. When a set difference is performed between [0,n-1] and subset([low,high] many issues can occur, such as the range [0,min(low,n)-1] being always returned. This was then being "corrected" by adding `low` to each element, restoring to the called range albiet wrong behavior.

3) When  `n > n_choices/2`, an off-by-one in the argument `size` passed to `indices_complement` made the largest valid index excluded from the set_difference. If the largest valid index would've been randomly selected by `randint_without_replacement`, it would be dropped from the returned vector, making the vector one smaller than requested.  This off by one returned vector size when requesting a large majority of indices is the error I encountered during development. When expanding the unit test, I encountered (1) and (2) as independent errors.


Test print statements are temporary to show prior and new behavior in CI.

