### PR TITLE
Get Prediction Reference

### DIFF
--- a/include/albatross/src/core/prediction.hpp
+++ b/include/albatross/src/core/prediction.hpp
@@ -218,5 +218,12 @@ auto get_prediction(const ModelType &model, const FitType &fit,
   return Prediction<ModelType, FeatureType, FitType>(model, fit, features);
 }
 
+template <typename ModelType, typename FeatureType, typename FitType>
+auto get_prediction_reference(const ModelType &model, const FitType &fit,
+                              const std::vector<FeatureType> &features) {
+  return PredictionReference<ModelType, FeatureType, FitType>(model, fit,
+                                                              features);
+}
+
 } // namespace albatross
 #endif

--- a/include/albatross/src/models/ransac_gp.hpp
+++ b/include/albatross/src/models/ransac_gp.hpp
@@ -48,7 +48,7 @@ get_gp_ransac_inlier_metric(const ConditionalGaussian &model,
 
   return [&, indexer, model](const GroupKey &group, const ConditionalFit &fit) {
     const auto indices = indexer.at(group);
-    const auto pred = get_prediction(model, fit, indices);
+    const auto pred = get_prediction_reference(model, fit, indices);
     const auto truth = model.get_truth(indices);
     return metric(pred, truth);
   };


### PR DESCRIPTION
This PR fixes an issue in RANSAC in which a `ConditionalGaussian` model is created and then inside ransac the entire model is copied every time the inlier metric is evaluated.

More specifically, the `Prediction` class is used as a tool to inspect a model, fit and the query features to determine which sort of predictions the model is capable.  Notice the constructors for the `Prediction` class:
```
  Prediction(const PlainModelType &model, const PlainFitType &fit,
             const std::vector<FeatureType> &features)
      : model_(model), fit_(fit), features_(features) {}

  Prediction(PlainModelType &&model, PlainFitType &&fit,
             const std::vector<FeatureType> &features)
      : model_(std::move(model)), fit_(std::move(fit)), features_(features) {}
```
Basically, if you pass in rvalue references to the model and fit it'll avoid a copy and directly move those quantities into the `Prediction` class.  However, if you pass in lvalue references the quantities are copied.  What was happening in this case was the helper method `get_prediction` was passing in lvalue references.

To avoid this there is a helper class `PredictionReference` which makes sure it only stores references to the model and fit.  This PR adds an additional `get_prediction_reference` which utilizes that class.  Note that doing so comes with the additional responsibility of making sure the lifetime of the model and fit outlive the use of the `Prediction` class.  So I suppose this `get_prediction_reference` could be a bit dangerous, but I *think* in the ransac use case we're fine and also hopefully with the name `reference` in the function name it'll be clear to other users.