### PR TITLE
Add greedy_tune

### DIFF
--- a/include/albatross/Tune
+++ b/include/albatross/Tune
@@ -20,6 +20,7 @@
 
 #include <albatross/src/tune/finite_difference.hpp>
 #include <albatross/src/tune/tuning_metrics.hpp>
+#include <albatross/src/tune/greedy_tuner.hpp>
 #include <albatross/src/tune/tune.hpp>
 
 #endif

--- a/include/albatross/src/tune/greedy_tuner.hpp
+++ b/include/albatross/src/tune/greedy_tuner.hpp
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2021 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef ALBATROSS_SRC_TUNE_GREEDY_TUNER_HPP_
+#define ALBATROSS_SRC_TUNE_GREEDY_TUNER_HPP_
+
+namespace albatross {
+
+/*
+ * The greedy_tune method is an alternative to the other tuning approaches
+ * in albatross.  It was designed for coarse tuning of computationally
+ * complex objective functions.  The method uses multi-threading to drive
+ * a relatively simple tuning approach which works by:
+ *
+ *   - Picking one of the parameters.
+ *   - Using the range defined by the prior to produce new guesses.
+ *   - Evaluating the objective at all the guesses (one guess per thread).
+ *   - Picking the best parameter value.
+ *   - Repeating for the next parameter.
+ *
+ * There are almost certainly no global convergence guarantees with
+ * this algorithm, but in practice it seems to do a good job of coarsely
+ * tuning the objective.  One strategy would be to start with an iteration
+ * of this greedy approach and follow up with one of the methods in tune.hpp
+ */
+
+namespace details {
+
+inline std::vector<double> query_ratios(std::size_t n) {
+  const double log_min = -5.;
+  const double log_max = -0.1;
+  if (n == 1) {
+    return {log_min};
+  }
+
+  const double step = (log_max - log_min) / (n - 1);
+  std::vector<double> output;
+  for (std::size_t i = 0; i < n; ++i) {
+    output.push_back(std::pow(10, log_min + i * step));
+  }
+
+  return output;
+}
+
+inline std::vector<double> get_queries(double value, double low, double high,
+                                       std::size_t n) {
+
+  if (std::isinf(high)) {
+    high = 1e8;
+  }
+  if (std::isinf(low)) {
+    low = -1e8;
+  }
+
+  const double low_range = value - low;
+  const double high_range = high - value;
+
+  std::vector<double> queries;
+
+  if (value == low) {
+    // only search higher since we're at the lower bound
+    const auto ratios = query_ratios(2 * n);
+    for (std::size_t i = 0; i < ratios.size(); ++i) {
+      queries.push_back(value + high_range * ratios[i]);
+    }
+  } else if (value == high) {
+    // only search lower since we're at the upper bound
+    const auto ratios = query_ratios(2 * n);
+    for (std::size_t i = 0; i < ratios.size(); ++i) {
+      queries.push_back(value - low_range * ratios[ratios.size() - 1 - i]);
+    }
+  } else {
+    // search in both directions
+    const auto ratios = query_ratios(n);
+    for (std::size_t i = 0; i < ratios.size(); ++i) {
+      queries.push_back(value - low_range * ratios[ratios.size() - 1 - i]);
+    }
+    for (std::size_t i = 0; i < ratios.size(); ++i) {
+      queries.push_back(value + high_range * ratios[i]);
+    }
+  }
+
+  return queries;
+}
+
+inline ParameterStore set_tunable_param(const ParameterStore &params,
+                                        std::size_t i, double val) {
+  auto perturbed = get_tunable_parameters(params);
+  perturbed.values[i] = val;
+  return set_tunable_params_values(params, perturbed.values, true);
+};
+} // namespace details
+
+template <typename Function>
+inline ParameterStore
+greedy_tune(Function evaluate_function, const ParameterStore &params,
+            std::size_t n_threads = 8, std::size_t n_iterations = 10,
+            bool use_async = true, std::ostream *os = &std::cout) {
+
+  static_assert(
+      has_call_operator<Function, ParameterStore>::value,
+      "evaluate_function must have a single ParameterStore argument.");
+
+  assert(n_threads % 2 == 0); // n_threads must be even;
+  const std::size_t n_queries = n_threads / 2;
+
+  albatross::TunableParameters tunable = get_tunable_parameters(params);
+
+  if (os) {
+    (*os) << "Will be tuning the following:" << std::endl;
+    for (std::size_t i = 0; i < tunable.names.size(); ++i) {
+      (*os) << "    " << tunable.names[i] << "    [ ";
+      const auto queries =
+          details::get_queries(tunable.values[i], tunable.lower_bounds[i],
+                               tunable.upper_bounds[i], n_queries);
+      for (const auto &v : queries) {
+        (*os)
+            << details::set_tunable_param(params, i, v)[tunable.names[i]].value
+            << ", ";
+      }
+      (*os) << " ]" << std::endl;
+    }
+    (*os) << "Initial params:" << std::endl;
+    (*os) << albatross::pretty_params(params) << std::endl;
+  }
+
+  double best_value = HUGE_VAL;
+  ParameterStore best_params(params);
+
+  for (std::size_t iter = 0; iter < n_iterations; ++iter) {
+    for (std::size_t i = 0; i < tunable.names.size(); ++i) {
+
+      tunable = get_tunable_parameters(best_params);
+      auto values =
+          details::get_queries(tunable.values[i], tunable.lower_bounds[i],
+                               tunable.upper_bounds[i], n_queries);
+      if (iter == 0 && i == 0) {
+        // on the very first iteration we need to include the initial params
+        values.push_back(tunable.values[i]);
+      }
+
+      const auto get_params = [&](double v) {
+        return details::set_tunable_param(best_params, i, v);
+      };
+
+      const auto params = apply(values, get_params);
+
+      if (os) {
+        (*os) << "NEXT ATTEMPTS: " << tunable.names[i] << " : ";
+        for (const auto &p : params) {
+          (*os) << p.at(tunable.names[i]).value << ",";
+        }
+        (*os) << std::endl;
+      }
+
+      auto evaluate = [&]() {
+        if (use_async) {
+          return async_apply(params, evaluate_function);
+        } else {
+          return apply(params, evaluate_function);
+        }
+      };
+
+      const auto evaluations = evaluate();
+
+      if (os) {
+        (*os) << "EVALUATIONS: " << std::endl;
+      }
+      for (std::size_t j = 0; j < params.size(); ++j) {
+        if (os) {
+          (*os) << "    " << tunable.names[i] << " = "
+                << params[j].at(tunable.names[i]).value << "   :   "
+                << evaluations[j];
+        }
+        if (evaluations[j] < best_value) {
+          best_params = params[j];
+          best_value = evaluations[j];
+          if (os) {
+            (*os) << "   BEST SO FAR";
+          }
+        }
+        if (os) {
+          (*os) << std::endl;
+        }
+      }
+
+      if (os) {
+        (*os) << "===============" << std::endl;
+        (*os) << "BEST_VALUE : " << best_value << std::endl;
+        (*os) << albatross::pretty_params(best_params) << std::endl;
+        (*os) << "===============" << std::endl;
+      }
+    }
+  }
+  return best_params;
+}
+
+} // namespace albatross
+
+#endif /* ALBATROSS_SRC_TUNE_GREEDY_TUNER_HPP_ */

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -251,12 +251,16 @@ TEST_F(TestTuneQuadratic, test_greedy_tune) {
     const auto params_result =
         greedy_tune(mahalanobis_distance_params, params, n_threads,
                     n_iterations, use_async, &output_stream);
-    auto param_vector = get_tunable_parameters(params_result).values;
-    const Eigen::Map<Eigen::VectorXd> eigen_param_output(
-        &param_vector[0], static_cast<Eigen::Index>(param_vector.size()));
 
-    std::cout << output_stream.str() << std::endl;
-    EXPECT_LE((eigen_param_output - truth).array().abs().maxCoeff(), 0.1);
+    auto to_eigen = [](const auto &p) {
+      auto param_vector = get_tunable_parameters(p).values;
+      const Eigen::VectorXd output = Eigen::Map<Eigen::VectorXd>(
+          &param_vector[0], static_cast<Eigen::Index>(param_vector.size()));
+      return output;
+    };
+
+    EXPECT_GT((to_eigen(params) - truth).array().abs().maxCoeff(), 0.1);
+    EXPECT_LE((to_eigen(params_result) - truth).array().abs().maxCoeff(), 0.1);
   };
 
   test_tuner();


### PR DESCRIPTION
This PR adds a new tuning utility `greedy_tune` which uses multi-threading and a very simple optimization technique to get a rough guess at optimal parameters.  It isn't really designed to provide a full replacement for other tuning methods in `albatross` but is instead a way to efficiently get a good "decent" set of parameters.

The algorithm works as follows:

Given a set of `n` parameters and an objective function `f`:

1. pick the first parameter
2. propose `k` guesses for the parameter value based on lower/upper bounds from the prior.
3. asynchronously evaluate the objective at those `k` guesses.
4. choose the value which minimized the objective
5. pick the next parameter and repeat (from step 2).

I've found this method is particularly useful when the objective function takes a very long time (hours) to evaluate.