### PR TITLE
Ransac Threshold Changes

### DIFF
--- a/include/albatross/src/models/ransac.hpp
+++ b/include/albatross/src/models/ransac.hpp
@@ -226,7 +226,7 @@ ransac(const RansacFunctions<FitType, GroupKey> &ransac_functions,
       if (!contains_group(iteration.candidates, possible_inlier)) {
         double metric_value =
             ransac_functions.inlier_metric(possible_inlier, fit);
-        const bool accepted = metric_value < inlier_threshold;
+        const bool accepted = metric_value <= inlier_threshold;
         if (accepted) {
           iteration.inliers.insert({possible_inlier, metric_value});
         } else {

--- a/include/albatross/src/models/ransac_gp.hpp
+++ b/include/albatross/src/models/ransac_gp.hpp
@@ -15,6 +15,8 @@
 
 namespace albatross {
 
+constexpr double DEFAULT_CHI_SQUARED_THRESHOLD = 0.999;
+
 template <typename GroupKey>
 inline typename RansacFunctions<ConditionalFit, GroupKey>::FitterFunc
 get_gp_ransac_fitter(const ConditionalGaussian &model,
@@ -92,7 +94,8 @@ struct ChiSquaredConsensusMetric {
 
 struct ChiSquaredIsValidCandidateMetric {
 
-  ChiSquaredIsValidCandidateMetric(double chi_squared_treshold = 0.999)
+  ChiSquaredIsValidCandidateMetric(
+      double chi_squared_treshold = DEFAULT_CHI_SQUARED_THRESHOLD)
       : chi_squared_threshold_(chi_squared_treshold) {}
 
   bool operator()(const JointDistribution &pred,

--- a/include/albatross/src/models/ransac_gp.hpp
+++ b/include/albatross/src/models/ransac_gp.hpp
@@ -91,14 +91,20 @@ struct ChiSquaredConsensusMetric {
 };
 
 struct ChiSquaredIsValidCandidateMetric {
+
+  ChiSquaredIsValidCandidateMetric(double chi_squared_treshold = 0.999)
+      : chi_squared_threshold_(chi_squared_treshold) {}
+
   bool operator()(const JointDistribution &pred,
                   const MarginalDistribution &truth) const {
     // These thresholds are under the assumption of a perfectly
     // representative prior.
     const double probability_prior_exceeded = chi_squared_cdf(pred, truth);
-    const double skip_every_1000th_candidate = 0.999;
-    return (probability_prior_exceeded < skip_every_1000th_candidate);
+    return (probability_prior_exceeded <= chi_squared_threshold_);
   };
+
+private:
+  double chi_squared_threshold_;
 };
 
 struct AlwaysAcceptCandidateMetric {

--- a/include/albatross/src/stats/chi_squared.hpp
+++ b/include/albatross/src/stats/chi_squared.hpp
@@ -63,7 +63,7 @@ inline double chi_squared_cdf(double x, double degrees_of_freedom) {
 
 inline double chi_squared_cdf(const Eigen::VectorXd &deviation,
                               const Eigen::MatrixXd &covariance) {
-  double distance_squared =
+  const double distance_squared =
       covariance.llt().matrixL().solve(deviation).squaredNorm();
   std::size_t n = static_cast<std::size_t>(deviation.size());
   return chi_squared_cdf(distance_squared, n);

--- a/include/albatross/src/stats/chi_squared.hpp
+++ b/include/albatross/src/stats/chi_squared.hpp
@@ -65,7 +65,7 @@ inline double chi_squared_cdf(const Eigen::VectorXd &deviation,
                               const Eigen::MatrixXd &covariance) {
   const double distance_squared =
       covariance.llt().matrixL().solve(deviation).squaredNorm();
-  std::size_t n = static_cast<std::size_t>(deviation.size());
+  const std::size_t n = static_cast<std::size_t>(deviation.size());
   return chi_squared_cdf(distance_squared, n);
 }
 


### PR DESCRIPTION
This PR fixes what (I think) is a bug in the determination of inliers.  On master we consider a candidate group an inlier if `inlier_metric < threshold` but I think it should be `inlier_metric <= threshold`.  This came up in some experiments in which I would set the threshold for the chi squared percentile metric to `1` thinking that would continue to RANSAC but would never flag any outliers, but I would still occasionally remove outliers.

Similarly the chi squared valid candidate metric was using less than (and had a hardcoded threshold).  I made the threshold configurable.