### PR TITLE
Allow for Empty Predictions.

### DIFF
--- a/include/albatross/src/core/prediction.hpp
+++ b/include/albatross/src/core/prediction.hpp
@@ -133,6 +133,9 @@ public:
   Eigen::VectorXd mean() const {
     static_assert(std::is_same<DummyType, FeatureType>::value,
                   "never do prediction.mean<T>()");
+    if (features_.size() == 0) {
+      return Eigen::VectorXd(0);
+    }
     return MeanPredictor()._mean(model_, fit_, features_);
   }
 
@@ -152,6 +155,9 @@ public:
   MarginalDistribution marginal() const {
     static_assert(std::is_same<DummyType, FeatureType>::value,
                   "never do prediction.mean<T>()");
+    if (features_.size() == 0) {
+      return MarginalDistribution();
+    }
     return MarginalPredictor()._marginal(model_, fit_, features_);
   }
 
@@ -172,6 +178,9 @@ public:
   JointDistribution joint() const {
     static_assert(std::is_same<DummyType, FeatureType>::value,
                   "never do prediction.mean<T>()");
+    if (features_.size() == 0) {
+      return JointDistribution();
+    }
     return JointPredictor()._joint(model_, fit_, features_);
   }
 

--- a/tests/test_prediction.cc
+++ b/tests/test_prediction.cc
@@ -42,6 +42,9 @@ TEST(test_prediction, test_mean_only) {
   const auto prediction = fit_model.predict(xs);
   auto mean = prediction.mean();
   EXPECT_TRUE(bool(std::is_same<Eigen::VectorXd, decltype(mean)>::value));
+
+  std::vector<X> empty = {};
+  EXPECT_EQ(fit_model.predict(empty).mean().size(), 0);
 }
 
 class MarginalOnlyModel : public ModelBase<MarginalOnlyModel> {
@@ -75,6 +78,9 @@ TEST(test_prediction, test_marginal_only) {
   auto marginal = prediction.marginal();
   EXPECT_TRUE(
       bool(std::is_same<MarginalDistribution, decltype(marginal)>::value));
+
+  std::vector<X> empty = {};
+  EXPECT_EQ(fit_model.predict(empty).marginal().size(), 0);
 }
 
 class JointOnlyModel : public ModelBase<JointOnlyModel> {
@@ -113,6 +119,9 @@ TEST(test_prediction, test_joint_only) {
 
   auto joint = prediction.joint();
   EXPECT_TRUE(bool(std::is_same<JointDistribution, decltype(joint)>::value));
+
+  std::vector<X> empty = {};
+  EXPECT_EQ(fit_model.predict(empty).joint().size(), 0);
 }
 
 } // namespace albatross


### PR DESCRIPTION
This PR allows you do call:
```
std::vector<Foo> foo = {};
model.fit(dataset).predict(foo).joint();
```
without a hard failure.  The result will be an empty version of whichever predict type you've designated.