### PR TITLE
Explicitly Store Intermediate Result in chi_squared_cdf

### DIFF
--- a/include/albatross/src/stats/chi_squared.hpp
+++ b/include/albatross/src/stats/chi_squared.hpp
@@ -63,8 +63,9 @@ inline double chi_squared_cdf(double x, double degrees_of_freedom) {
 
 inline double chi_squared_cdf(const Eigen::VectorXd &deviation,
                               const Eigen::MatrixXd &covariance) {
-  const double distance_squared =
-      covariance.llt().matrixL().solve(deviation).squaredNorm();
+  const Eigen::VectorXd normalized =
+      covariance.llt().matrixL().solve(deviation);
+  const double distance_squared = normalized.squaredNorm();
   const std::size_t n = static_cast<std::size_t>(deviation.size());
   return chi_squared_cdf(distance_squared, n);
 }


### PR DESCRIPTION
Clang tidy was complaining about an uninitialized variable which I tracked down to an intermediate Eigen storage.  Considering this code has been used quite a bit I doubt there is an actual issue but this change should keep clang tidy happy and produce the same result with pretty minimal overhead.  I don't quite understand how Eigen deals with these situations but it's possible they've optimized the use of the intermediate `Solve` type to never need to actually store `normalized` in which case forcing the intermediate result to an `Eigen::VectorXd` like I've done below will require some more storage, but the additional size `n` vector shouldn't be noticeable relative to the `n^2` of the covariance matrix.