### PR TITLE
Add upper bound to PositiveGaussianPrior

### DIFF
--- a/include/albatross/src/core/priors.hpp
+++ b/include/albatross/src/core/priors.hpp
@@ -152,6 +152,8 @@ public:
 
   double lower_bound() const override { return 0.; }
 
+  double upper_bound() const override { return 10. * sigma_; }
+
   std::string get_name() const override {
     std::ostringstream oss;
     oss << "positive_gaussian[" << mu_ << "," << sigma_ << "]";


### PR DESCRIPTION
At the moment the `PositiveGaussianPrior` doesn't have an upper bound, here we set it to be 10 sigma.  The motivation is that during tuning these bounds are often used to define the search space and without an explicit upper bound the [default](https://github.com/swift-nav/albatross/blob/master/include/albatross/src/core/priors.hpp#L35) of infinity is used, resulting in a lot of wasted time searching extremely unlikely parameter values.