### PR TITLE
Move Gaussian pdf computations out of NLL

### DIFF
--- a/include/albatross/GP
+++ b/include/albatross/GP
@@ -14,6 +14,7 @@
 #define ALBATROSS_GP_H
 
 #include "Core"
+#include "Stats"
 #include "CovarianceFunctions"
 
 #include <albatross/src/evaluation/likelihood.hpp>

--- a/include/albatross/Stats
+++ b/include/albatross/Stats
@@ -13,6 +13,7 @@
 #ifndef ALBATROSS_STATS_H
 #define ALBATROSS_STATS_H
 
+#include <albatross/src/stats/gaussian.hpp>
 #include <albatross/src/stats/gauss_legendre.hpp>
 #include <albatross/src/stats/incomplete_gamma.hpp>
 #include <albatross/src/stats/chi_squared.hpp>

--- a/include/albatross/src/evaluation/likelihood.hpp
+++ b/include/albatross/src/evaluation/likelihood.hpp
@@ -20,11 +20,7 @@ namespace albatross {
  */
 static inline double negative_log_likelihood(double deviation,
                                              double variance) {
-  double nll = deviation;
-  nll *= nll;
-  nll /= (2 * variance);
-  nll += 0.5 * log(2 * M_PI * variance);
-  return nll;
+  return -albatross::gaussian::log_pdf(deviation, variance);
 }
 
 static inline double log_sum(const Eigen::VectorXd &x) {

--- a/include/albatross/src/stats/gaussian.hpp
+++ b/include/albatross/src/stats/gaussian.hpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2021 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+#ifndef ALBATROSS_STATS_GAUSSIAN_HPP_
+#define ALBATROSS_STATS_GAUSSIAN_HPP_
+
+namespace albatross {
+
+namespace gaussian {
+
+static inline double log_pdf(double deviation, double variance) {
+  double ll = -deviation * deviation / (2 * variance);
+  ll -= 0.5 * std::log(2 * M_PI * variance);
+  return ll;
+}
+
+static inline double pdf(double deviation, double variance) {
+  return std::exp(-(deviation * deviation) / (2 * variance)) /
+         std::sqrt(2 * M_PI * variance);
+}
+
+} // namespace gaussian
+
+} // namespace albatross
+
+#endif /* ALBATROSS_STATS_GAUSSIAN_HPP_ */

--- a/tests/test_stats.cc
+++ b/tests/test_stats.cc
@@ -20,6 +20,33 @@
 
 namespace albatross {
 
+TEST(test_stats, test_gaussian_pdf) {
+
+  // These examples were generated in python using scipy.stats.norm.pdf
+  std::vector<double> test_xs = {
+      -1.49529605, -0.35674996, -1.19464126, 0.7431096,   0.94945083,
+      -0.06465424, -0.36805315, -1.38905131, -1.56751365, 1.8271551};
+  std::vector<double> test_variances = {
+      3.39311978, 0.55516885, 0.72540077, 0.05034394, 0.16184329,
+      2.31795834, 0.00988035, 0.11177149, 0.77043322, 2.84884525};
+  std::vector<double> expected = {
+      1.55783121e-01, 4.77438315e-01, 1.75146437e-01, 7.38065599e-03,
+      6.12161951e-02, 2.61797595e-01, 4.23016986e-03, 2.12923882e-04,
+      9.22586650e-02, 1.31554532e-01};
+
+  for (std::size_t i = 0; i < test_xs.size(); ++i) {
+    EXPECT_NEAR(gaussian::pdf(test_xs[i], test_variances[i]), expected[i],
+                1e-6);
+    EXPECT_NEAR(gaussian::log_pdf(test_xs[i], test_variances[i]),
+                std::log(expected[i]), 1e-6);
+  }
+
+  EXPECT_LT(gaussian::pdf(-100., 1.), 1e-12);
+  EXPECT_LT(gaussian::pdf(100., 1.), 1e-12);
+  EXPECT_LT(gaussian::pdf(1., 1e-6), 1e-12);
+  EXPECT_LT(gaussian::pdf(1e12, 1e8), 1e-12);
+}
+
 TEST(test_stats, test_chi_squared) {
 
   EXPECT_LT(fabs(chi_squared_cdf(3.84, 1) - 0.95), 1e-4);


### PR DESCRIPTION
I found myself doing things like this:
```
double p = std::exp(-negative_log_likelihood(m, v));
```
to evaluate the pdf of a Gaussian distribution which is clearly a bit convoluted.  This PR breaks out the univariate gaussian pdf computations into their own file and namespace.