### PR TITLE
Add with() method to group_by

### DIFF
--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -466,6 +466,36 @@ public:
     return output;
   }
 
+  template <typename SubsetableType,
+            typename std::enable_if<
+                details::is_subsetable<SubsetableType>::value, int>::type = 0>
+  Grouped<KeyType, std::pair<ValueType, SubsetableType>>
+  with(const SubsetableType &other) const {
+    assert(parent_.size() == other.size());
+    Grouped<KeyType, std::pair<ValueType, SubsetableType>> output;
+    for (const auto &key_indexer_pair : indexers()) {
+      output.emplace(
+          key_indexer_pair.first,
+          std::make_pair(albatross::subset(parent_, key_indexer_pair.second),
+                         albatross::subset(other, key_indexer_pair.second)));
+    }
+    return output;
+  }
+
+  template <template <typename...> class Map, typename AlreadyGroupedType>
+  Grouped<KeyType, std::pair<ValueType, AlreadyGroupedType>>
+  with(const Map<KeyType, AlreadyGroupedType> &other) const {
+    assert(other.size() == indexers().size());
+    Grouped<KeyType, std::pair<ValueType, AlreadyGroupedType>> output;
+    for (const auto &key_indexer_pair : indexers()) {
+      output.emplace(
+          key_indexer_pair.first,
+          std::make_pair(albatross::subset(parent_, key_indexer_pair.second),
+                         other.at(key_indexer_pair.first)));
+    }
+    return output;
+  }
+
   std::vector<KeyType> keys() const { return map_keys(indexers()); }
 
   std::size_t size() const { return indexers().size(); }

--- a/include/albatross/src/indexing/traits.hpp
+++ b/include/albatross/src/indexing/traits.hpp
@@ -191,6 +191,20 @@ struct group_by_traits<GroupBy<std::vector<FeatureType>, GrouperFunction>> {
   using GrouperType = GrouperFunction;
 };
 
+template <typename T> class is_subsetable {
+  template <typename C,
+            typename std::enable_if<
+                std::is_same<C, decltype(subset(std::declval<C>(),
+                                                std::declval<std::vector<
+                                                    std::size_t>>()))>::value,
+                int>::type = 0>
+  static std::true_type test(C *);
+  template <typename> static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
 } // namespace details
 
 } // namespace albatross

--- a/tests/test_group_by.cc
+++ b/tests/test_group_by.cc
@@ -12,6 +12,7 @@
 
 #include <albatross/Indexing>
 #include <gtest/gtest.h>
+#include <string.h>
 
 namespace albatross {
 
@@ -587,6 +588,54 @@ TEST(test_groupby, test_group_by_any_all) {
 
   EXPECT_FALSE(grouped.apply(greater_than_max_count).all());
   EXPECT_FALSE(grouped.apply(greater_than_max_count).any());
+}
+
+TEST(test_groupby, test_group_by_with_vector) {
+
+  const auto fib = fibonacci(20);
+
+  std::vector<std::string> strings;
+  for (const auto &x : fib) {
+    strings.push_back(std::to_string(x));
+  }
+
+  const auto grouped_with_strings =
+      group_by(fib, number_of_digits).with(strings);
+  EXPECT_GT(grouped_with_strings.size(), 0);
+  for (const auto &group : grouped_with_strings) {
+    const std::vector<double> &vector_of_doubles = group.second.first;
+    const std::vector<std::string> &vector_of_strings = group.second.second;
+    for (std::size_t i = 0; i < vector_of_doubles.size(); ++i) {
+      EXPECT_EQ(std::to_string(vector_of_doubles[i]), vector_of_strings[i]);
+    }
+  }
+}
+
+TEST(test_groupby, test_group_by_with_map) {
+
+  const auto fib = fibonacci(20);
+
+  auto to_strings = [](const std::vector<double> &xs) {
+    std::vector<std::string> strings;
+    for (const auto &x : xs) {
+      strings.push_back(std::to_string(x));
+    }
+    return strings;
+  };
+
+  const auto grouped = group_by(fib, number_of_digits);
+
+  const auto as_strings = grouped.apply(to_strings);
+  const auto with_strings = group_by(fib, number_of_digits).with(as_strings);
+
+  EXPECT_GT(with_strings.size(), 0);
+  for (const auto &group : with_strings) {
+    const std::vector<double> &vector_of_doubles = group.second.first;
+    const std::vector<std::string> &vector_of_strings = group.second.second;
+    for (std::size_t i = 0; i < vector_of_doubles.size(); ++i) {
+      EXPECT_EQ(std::to_string(vector_of_doubles[i]), vector_of_strings[i]);
+    }
+  }
 }
 
 } // namespace albatross

--- a/tests/test_group_by.cc
+++ b/tests/test_group_by.cc
@@ -626,7 +626,7 @@ TEST(test_groupby, test_group_by_with_map) {
   const auto grouped = group_by(fib, number_of_digits);
 
   const auto as_strings = grouped.apply(to_strings);
-  const auto with_strings = group_by(fib, number_of_digits).with(as_strings);
+  const auto with_strings = grouped.with(as_strings);
 
   EXPECT_GT(with_strings.size(), 0);
   for (const auto &group : with_strings) {

--- a/tests/test_group_by.cc
+++ b/tests/test_group_by.cc
@@ -614,18 +614,17 @@ TEST(test_groupby, test_group_by_with_vector) {
 TEST(test_groupby, test_group_by_with_map) {
 
   const auto fib = fibonacci(20);
+  const auto grouped = group_by(fib, number_of_digits);
 
-  auto to_strings = [](const std::vector<double> &xs) {
+  auto doubles_to_strings = [](const std::vector<double> &xs) {
     std::vector<std::string> strings;
     for (const auto &x : xs) {
       strings.push_back(std::to_string(x));
     }
     return strings;
   };
+  const auto as_strings = grouped.apply(doubles_to_strings);
 
-  const auto grouped = group_by(fib, number_of_digits);
-
-  const auto as_strings = grouped.apply(to_strings);
   const auto with_strings = grouped.with(as_strings);
 
   EXPECT_GT(with_strings.size(), 0);

--- a/tests/test_indexing.cc
+++ b/tests/test_indexing.cc
@@ -332,4 +332,10 @@ TEST(test_indexing, test_matrix_symmetric_subset) {
   EXPECT_EQ(symmetric_subset(x, idx), expected);
 }
 
+TEST(test_indexing, test_is_subsetable) {
+  EXPECT_TRUE(bool(details::is_subsetable<std::vector<int>>::value));
+  EXPECT_TRUE(bool(details::is_subsetable<RegressionDataset<int>>::value));
+  EXPECT_FALSE(bool(details::is_subsetable<std::map<int, int>>::value));
+}
+
 } // namespace albatross


### PR DESCRIPTION
The `group_by` methods provide a way to take a vector-like quantity (`std::vector`, `albatross::RegressionDataset<>`) and split them apart then perform further manipulation (`.apply(f)`, `.filter(f)`).  For example, you may have a dataset consisting of information about specific people and you may want to compute the average by gender.  In albatross that can already be accomplished:
```
auto get_gender = [](const auto &x) {
  return x.gender;
}
auto compute_mean = [](const auto &one_gender) {
  return mean(one_gender);
};
people.group_by(get_gender).apply(compute_mean);
```

One common pattern that has arisen is the need to access other information within the apply function.  For example, you may have auxiliary information such as age which isn't stored in the `people` dataset, but which you'd also like available inside the apply function.  Previous to this change you could instead use `index_apply` but then it's up to you to apply the appropriate subsets:
```
std::vector<double> ages = get_ages();

auto compute_means = [&](const auto &indices) {
  const auto group_ages = subset(ages, indices);
  const auto group_people = subset(people, indices);
  return means_by_age(group_people, group_ages);
}

people.group_by(get_gender).index_apply(compute_means);
```

With this change you can instead of:

```
auto compute_means = [&](const auto &data_and_ages) {
  return means_by_age(data_and_ages.first, data_and_ages.second);
}

people.group_by(get_gender).with(ages).apply(compute_means);
```
Similarly, if you already have an existing grouped quantity that you'd like to join with, you can now do:
```
auto compute_with = [&](const auto &data_and_life_expactancy) {
  return calculate_something(data_and_life_expactancy.first, data_and_life_expactancy.second);
}

const auto life_expectancy_by_gender = some_other_function();
people.group_by(get_gender).with(life_expectancy_by_gender).apply(compute_with);
```
