### PR TITLE
Convenience method for leave one out variance.

### DIFF
--- a/include/albatross/Evaluation
+++ b/include/albatross/Evaluation
@@ -20,6 +20,7 @@
 #include <albatross/src/evaluation/likelihood.hpp>
 #include <albatross/src/evaluation/differential_entropy.hpp>
 #include <albatross/src/covariance_functions/traits.hpp>
+#include <albatross/src/eigen/serializable_ldlt.hpp>
 #include <albatross/src/evaluation/traits.hpp>
 #include <albatross/src/evaluation/folds.hpp>
 #include <albatross/src/evaluation/prediction_metrics.hpp>

--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -131,6 +131,12 @@ cross_validated_scores(const PredictionMetric<Eigen::VectorXd> &metric,
   return cross_validated_scores(metric, folds, predictions.apply(get_mean));
 }
 
+inline Eigen::VectorXd leave_one_out_conditional_variance(const Eigen::MatrixXd &covariance) {
+  // The leave one out variance will be the inverse of the diagonal of the inverse of covariance
+  // (that's a mouthful!) For details see Equation 5.12 of Gaussian Processes for Machine Learning
+  return Eigen::SerializableLDLT(covariance).inverse_diagonal().array().inverse();
+}
+
 } // namespace albatross
 
 #endif

--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -131,10 +131,15 @@ cross_validated_scores(const PredictionMetric<Eigen::VectorXd> &metric,
   return cross_validated_scores(metric, folds, predictions.apply(get_mean));
 }
 
-inline Eigen::VectorXd leave_one_out_conditional_variance(const Eigen::MatrixXd &covariance) {
-  // The leave one out variance will be the inverse of the diagonal of the inverse of covariance
-  // (that's a mouthful!) For details see Equation 5.12 of Gaussian Processes for Machine Learning
-  return Eigen::SerializableLDLT(covariance).inverse_diagonal().array().inverse();
+inline Eigen::VectorXd
+leave_one_out_conditional_variance(const Eigen::MatrixXd &covariance) {
+  // The leave one out variance will be the inverse of the diagonal of the
+  // inverse of covariance (that's a mouthful!) For details see Equation 5.12 of
+  // Gaussian Processes for Machine Learning
+  return Eigen::SerializableLDLT(covariance)
+      .inverse_diagonal()
+      .array()
+      .inverse();
 }
 
 } // namespace albatross

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -166,11 +166,6 @@ TEST(test_crossvalidation, test_leave_one_out_conditional_variance) {
   Eigen::MatrixXd cov = model.get_covariance()(meas, meas);
   cov.diagonal() = cov.diagonal() + dataset.targets.covariance.diagonal();
   const Eigen::VectorXd loo_variance = leave_one_out_conditional_variance(cov);
-
-  const Eigen::SerializableLDLT ldlt(cov);
-  const Eigen::Index n = cov.rows();
-  const Eigen::MatrixXd inv = ldlt.solve(Eigen::MatrixXd::Identity(n, n));
-
   EXPECT_LE((loo_marginal.covariance.diagonal() - loo_variance).norm(), 1e-8);
 }
 

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -153,6 +153,27 @@ TEST(test_crossvalidation, test_heteroscedastic) {
   EXPECT_LE(scores.mean(), scores_without_variance.mean());
 }
 
+TEST(test_crossvalidation, test_leave_one_out_conditional_variance) {
+  const auto dataset = make_toy_linear_data();
+
+  auto model = MakeGaussianProcess().get_model();
+
+  LeaveOneOutGrouper loo;
+  const auto loo_marginal =
+      model.cross_validate().predict(dataset, loo).marginal();
+
+  const auto meas = as_measurements(dataset.features);
+  Eigen::MatrixXd cov = model.get_covariance()(meas, meas);
+  cov.diagonal() = cov.diagonal() + dataset.targets.covariance.diagonal();
+  const Eigen::VectorXd loo_variance = leave_one_out_conditional_variance(cov);
+
+  const Eigen::SerializableLDLT ldlt(cov);
+  const Eigen::Index n = cov.rows();
+  const Eigen::MatrixXd inv = ldlt.solve(Eigen::MatrixXd::Identity(n, n));
+
+  EXPECT_LE((loo_marginal.covariance.diagonal() - loo_variance).norm(), 1e-8);
+}
+
 class MakeLargeGaussianProcess {
 public:
   auto get_model() const {


### PR DESCRIPTION
This PR adds a method for computing only the variance of a leave one out cross validated prediction. There are already methods for starting with a model and computing things like the leave one out mean and marginal distributions. However, these methods require a model and sometimes all you have is a covariance. This method gives you a way of starting with a covariance matrix and determining how much of each variable is unpredictable. One use case for this would be filtering (ie, reducing to only a set of variables which are mutually explainable).

Here we add a method: `leave_one_out_conditional_variance` which when called with a covariance matrix:
```
const auto var = leave_one_out_conditional_variance(cov);
```
is the equivalent of iteratively solving for the variance when you remove one row/col at a time:
```
Eigen::VectorXd var(cov.rows());
for (Eigen::Index i = 0; i < cov.rows(); ++i) {
  const auto not_i = get_all_but_ith_row_and_col(cov, i);
  const auto cross = get_ith_row_excluding_diag(cov, i);
  var[i] = cov(i, i) - cross * not_i.ldlt().solve(cross.transpose());
}
```
The iterative approach takes O(n^4) time while, thanks to a linear algebra trick, `leave_one_out_conditional_variance` will be O(n^3).