### PR TITLE
Add leave_one_out_conditional method

### DIFF
--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -152,8 +152,10 @@ leave_one_out_conditional(const JointDistribution &prior,
   // all others.
   //
   // For details see Equation 5.12 of Gaussian Processes for Machine Learning
-  Eigen::SerializableLDLT ldlt(prior.covariance +
-                               Eigen::MatrixXd(truth.covariance));
+
+  Eigen::MatrixXd covariance = prior.covariance;
+  covariance += truth.covariance;
+  Eigen::SerializableLDLT ldlt(covariance.ldlt());
   const Eigen::VectorXd loo_variance = leave_one_out_conditional_variance(ldlt);
   const Eigen::VectorXd deviation = truth.mean - prior.mean;
   Eigen::VectorXd loo_mean = ldlt.solve(deviation);

--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -152,11 +152,8 @@ leave_one_out_conditional(const JointDistribution &prior,
   // all others.
   //
   // For details see Equation 5.12 of Gaussian Processes for Machine Learning
-
-  Eigen::MatrixXd covariance = prior.covariance;
-  covariance += truth.covariance;
-
-  Eigen::SerializableLDLT ldlt(covariance);
+  Eigen::SerializableLDLT ldlt(prior.covariance +
+                               Eigen::MatrixXd(truth.covariance));
   const Eigen::VectorXd loo_variance = leave_one_out_conditional_variance(ldlt);
   const Eigen::VectorXd deviation = truth.mean - prior.mean;
   Eigen::VectorXd loo_mean = ldlt.solve(deviation);

--- a/include/albatross/src/models/ransac_gp.hpp
+++ b/include/albatross/src/models/ransac_gp.hpp
@@ -128,6 +128,8 @@ inline RansacFunctions<ConditionalFit, GroupKey> get_gp_ransac_functions(
   static_assert(is_prediction_metric<InlierMetric>::value,
                 "InlierMetric must be an PredictionMetric.");
 
+  assert(prior.size() == truth.size());
+
   const ConditionalGaussian model(prior, truth);
 
   const auto fitter = get_gp_ransac_fitter<GroupKey>(model, indexer);

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -169,6 +169,26 @@ TEST(test_crossvalidation, test_leave_one_out_conditional_variance) {
   EXPECT_LE((loo_marginal.covariance.diagonal() - loo_variance).norm(), 1e-8);
 }
 
+TEST(test_crossvalidation, test_leave_one_out_conditional) {
+  const auto dataset = make_toy_linear_data();
+
+  auto model = MakeGaussianProcess().get_model();
+
+  LeaveOneOutGrouper loo;
+  const auto loo_marginal =
+      model.cross_validate().predict(dataset, loo).marginal();
+
+  const auto meas = as_measurements(dataset.features);
+  Eigen::MatrixXd cov = model.get_covariance()(meas, meas);
+  JointDistribution prior(Eigen::VectorXd::Zero(cov.rows()), cov);
+  const auto actual = leave_one_out_conditional(prior, dataset.targets);
+
+  EXPECT_LE((loo_marginal.mean - actual.mean).norm(), 1e-6);
+  EXPECT_LE((loo_marginal.covariance.diagonal() - actual.covariance.diagonal())
+                .norm(),
+            1e-6);
+}
+
 class MakeLargeGaussianProcess {
 public:
   auto get_model() const {


### PR DESCRIPTION
This PR adds a convenience methods for computing the leave one out cross validated predictions given a prior distribution and truth.  The leave one out predictions are already available when starting with a Gaussian process:
```
  auto model = MakeGaussianProcess().get_model();
  LeaveOneOutGrouper loo;
  const auto loo_marginal = model.cross_validate().predict(dataset, loo).marginal();
```
But sometimes it's useful to be able to do the same sort of computations using a posterior distribution.  For example, you might fit a model to some set of data, make a posterior prediction of a held out set and then want the leave one out predictions starting with the posterior,
```
const JointDistribution posterior = model.fit(large_dataset).predict(held_out.features).joint();
const MarginalDistribiont loo_posterior = leave_one_out_conditional(posterior, held_out.targets);
```