### PR TITLE
Chi Squared Bug in Limits

### DIFF
--- a/include/albatross/src/stats/chi_squared.hpp
+++ b/include/albatross/src/stats/chi_squared.hpp
@@ -26,7 +26,7 @@ namespace albatross {
 
 namespace details {
 
-inline double chi_squared_cdf_unsafe(double x, std::size_t degrees_of_freedom) {
+inline double chi_squared_cdf_unsafe(double x, double degrees_of_freedom) {
   return incomplete_gamma(0.5 * degrees_of_freedom, 0.5 * x);
 }
 

--- a/include/albatross/src/stats/incomplete_gamma.hpp
+++ b/include/albatross/src/stats/incomplete_gamma.hpp
@@ -31,6 +31,7 @@ namespace albatross {
 namespace details {
 
 constexpr std::size_t INCOMPLETE_GAMMA_RECURSSION_LIMIT = 54;
+constexpr double INCOMPLETE_GAMMA_EQUALITY_TRESHOLD = 1e-12;
 
 inline double incomplete_gamma_quadrature_inp_vals(double lb, double ub,
                                                    std::size_t counter) {
@@ -136,8 +137,7 @@ inline double incomplete_gamma_continuous_fraction(double a, double z) {
   // When `a` get's really really large the numerator (and in turn the
   // denominator) can hit zero which would turn into a NAN but we want
   // to treat it as evaluating at infinity which should yield 1.
-  if (std::numeric_limits<double>::epsilon() > numerator &&
-      std::numeric_limits<double>::epsilon() > denominator) {
+  if (denominator - numerator < INCOMPLETE_GAMMA_EQUALITY_TRESHOLD) {
     return 1.;
   }
   return numerator / denominator;

--- a/tests/test_stats.cc
+++ b/tests/test_stats.cc
@@ -135,7 +135,23 @@ TEST(test_stats, test_chi_squared_cdf_monotonic) {
   for (std::size_t i = 0; i < iterations; ++i) {
     double scale = i / 5.;
     double cdf = chi_squared_cdf(scale * sample, covariance);
-    EXPECT_LT(previous, cdf);
+    EXPECT_LE(previous, cdf);
+    previous = cdf;
+  }
+}
+
+TEST(test_stats, test_chi_squared_cdf_monotonic_1d) {
+  std::size_t iterations = 500;
+  double previous = -std::numeric_limits<double>::epsilon();
+  // Evaluate the cdf with one dimension iteratively increasing to a
+  // value equivalent to 50 standard deviations from the mean. We
+  // explicitly test that high because of known instabilities in the
+  // tails of the incomplete gamma function.
+  for (std::size_t i = 0; i < iterations; ++i) {
+    double x = i / 50.;
+    double cdf = chi_squared_cdf(x * x, 1);
+    EXPECT_LE(previous, cdf);
+    previous = cdf;
   }
 }
 


### PR DESCRIPTION
I discovered a few cases where the chi squared cdf function was numerically unstable.  In particular when evaluating the function for very large `x` (so when asking how far in the tails an extremely large outlier is) the `chi_squared_cdf` should be returning `1` but was returning erratic values:

![image](https://user-images.githubusercontent.com/514053/165861021-d94dcded-2ca4-40f2-aa72-78f51cc41f4c.png)

The chi squared cdf relies heavily on the incomplete gamma function and it turns out these instabilities were happening when we start dividing really small values by other really small values.  The denominator in the incomplete gamma is approximating through continuous fractions and small inaccuracies can cause the denominator to be slightly larger than it should be which causes the drops.  Here for example are the numerator and denominator (on log scale) separately.  Notice that for large values of `z` the two are always very nearly identical.

![image](https://user-images.githubusercontent.com/514053/165860881-68795c06-3102-46d9-96af-baf37366791e.png)

If you look at the difference between the numerator and denominator you can see it becomes very unstable:

![image](https://user-images.githubusercontent.com/514053/165862390-1cfa3be0-dcac-4071-957f-0be524be117b.png)

We had some tresholds for when to treat the incomplete gamma as `1`, but those thresholds were on the absolute values of the numerator and denominator and I think it makes more sense to be have them on the difference between the two.