### PR TITLE
Remove copy of covariance matrix in LOO conditional calculation

### DIFF
--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -153,9 +153,8 @@ leave_one_out_conditional(const JointDistribution &prior,
   //
   // For details see Equation 5.12 of Gaussian Processes for Machine Learning
 
-  Eigen::MatrixXd covariance = prior.covariance;
-  covariance += truth.covariance;
-  Eigen::SerializableLDLT ldlt(covariance.ldlt());
+  const Eigen::SerializableLDLT ldlt(prior.covariance +
+                                     truth.covariance.diagonal());
   const Eigen::VectorXd loo_variance = leave_one_out_conditional_variance(ldlt);
   const Eigen::VectorXd deviation = truth.mean - prior.mean;
   Eigen::VectorXd loo_mean = ldlt.solve(deviation);


### PR DESCRIPTION
See [this answer](https://github.com/swift-nav/albatross/pull/319/files/53468b92dc2cdf856e9c2995c0e286c899affe94#r861503228) on the original PR.  I spent way too much time figuring this out . . .