### PR TITLE
Improve Assertion Handling

### DIFF
--- a/include/albatross/src/cereal/eigen.hpp
+++ b/include/albatross/src/cereal/eigen.hpp
@@ -62,7 +62,7 @@ inline void load(Archive &ar, Eigen::Matrix<_Scalar, _Rows, _Cols> &m,
   const std::string decompressed =
       gzip::decompress(payload.data(), payload.size());
 
-  assert(size_in_bytes == decompressed.size());
+  ALBATROSS_ASSERT(size_in_bytes == decompressed.size());
 
   std::vector<_Scalar> decoded_data(size);
   std::memcpy(decoded_data.data(), decompressed.data(), size_in_bytes);
@@ -128,10 +128,10 @@ inline void load_lower_triangle(Archive &archive,
   double b = 1;
   double c = -2. * static_cast<double>(data.size());
   double rows_as_double = (std::sqrt(b * b - 4 * a * c) - b) / (2 * a);
-  assert(rows_as_double -
-                 static_cast<Eigen::Index>(std::lround(rows_as_double)) ==
-             0. &&
-         "inferred a non integer number of rows");
+  ALBATROSS_ASSERT(
+      rows_as_double - static_cast<Eigen::Index>(std::lround(rows_as_double)) ==
+          0. &&
+      "inferred a non integer number of rows");
   Eigen::Index rows = static_cast<Eigen::Index>(std::lround(rows_as_double));
 
   v.resize(rows, rows);

--- a/include/albatross/src/cereal/variant.hpp
+++ b/include/albatross/src/cereal/variant.hpp
@@ -29,7 +29,7 @@ template <int N, class Variant, class... Args, class Archive,
           typename std::enable_if_t<
               N == albatross::variant_size<Variant>::value, int> = 0>
 void load_variant(Archive &, int, Variant &) {
-  assert(false); // load_variant received an out of bounds index.
+  ALBATROSS_ASSERT(false); // load_variant received an out of bounds index.
 }
 
 template <int N, class Variant, class H, class... T, class Archive,
@@ -84,7 +84,7 @@ inline void load(Archive &archive, variant<VariantTypes...> &v,
   if (version > 0) {
     std::string which_typeid;
     archive(cereal::make_nvp("which_typeid", which_typeid));
-    assert(which < static_cast<int>(sizeof...(VariantTypes)));
+    ALBATROSS_ASSERT(which < static_cast<int>(sizeof...(VariantTypes)));
   }
   mapbox_variant_detail::load_variant<0, variant<VariantTypes...>,
                                       VariantTypes...>(archive, which, v);

--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -36,8 +36,8 @@ template <typename FeatureType> struct RegressionDataset {
       : features(features_), targets(targets_) {
     // If the two inputs aren't the same size they clearly aren't
     // consistent.
-    assert(static_cast<int>(features.size()) ==
-           static_cast<int>(targets.size()));
+    ALBATROSS_ASSERT(static_cast<int>(features.size()) ==
+                     static_cast<int>(targets.size()));
   }
 
   RegressionDataset(const std::vector<FeatureType> &features_,
@@ -120,7 +120,7 @@ inline auto align_datasets(RegressionDataset<X> *x, RegressionDataset<X> *y) {
     }
   }
 
-  assert(x_inds.size() == y_inds.size());
+  ALBATROSS_ASSERT(x_inds.size() == y_inds.size());
 
   if (x_inds.size() == 0) {
     *x = RegressionDataset<X>();

--- a/include/albatross/src/core/distribution.hpp
+++ b/include/albatross/src/core/distribution.hpp
@@ -89,12 +89,12 @@ struct MarginalDistribution : public DistributionBase<MarginalDistribution> {
   };
 
   void assert_valid() const {
-    assert(mean.size() == covariance.rows());
-    assert(mean.size() == covariance.cols());
+    ALBATROSS_ASSERT(mean.size() == covariance.rows());
+    ALBATROSS_ASSERT(mean.size() == covariance.cols());
   }
 
   double get_diagonal(Eigen::Index i) const {
-    assert(i >= 0 && i < covariance.rows());
+    ALBATROSS_ASSERT(i >= 0 && i < covariance.rows());
     return covariance.diagonal()[i];
   }
 
@@ -154,16 +154,16 @@ struct JointDistribution : public DistributionBase<JointDistribution> {
   JointDistribution(const Eigen::VectorXd &mean_,
                     const Eigen::MatrixXd &covariance_)
       : Base(mean_), covariance(covariance_) {
-    assert(mean_.size() == covariance_.rows());
+    ALBATROSS_ASSERT(mean_.size() == covariance_.rows());
   };
 
   void assert_valid() const {
-    assert(mean.size() == covariance.rows());
-    assert(mean.size() == covariance.cols());
+    ALBATROSS_ASSERT(mean.size() == covariance.rows());
+    ALBATROSS_ASSERT(mean.size() == covariance.cols());
   }
 
   double get_diagonal(Eigen::Index i) const {
-    assert(i >= 0 && i < covariance.rows());
+    ALBATROSS_ASSERT(i >= 0 && i < covariance.rows());
     return covariance.diagonal()[i];
   }
 

--- a/include/albatross/src/core/parameter_handling_mixin.hpp
+++ b/include/albatross/src/core/parameter_handling_mixin.hpp
@@ -128,13 +128,13 @@ inline TunableParameters get_tunable_parameters(const ParameterStore &params) {
         std::cout << "INVALID PARAMETER: " << pair.first
                   << " expected to be greater than " << lb << " but is: " << v
                   << std::endl;
-        assert(false);
+        ALBATROSS_ASSERT(false);
       }
       if (v > ub) {
         std::cout << "INVALID PARAMETER: " << pair.first
                   << " expected to be less than " << ub << " but is: " << v
                   << std::endl;
-        assert(false);
+        ALBATROSS_ASSERT(false);
       }
 
       bool use_log_scale = pair.second.prior.is_log_scale();
@@ -190,7 +190,7 @@ set_tunable_params_values(const ParameterStore &params,
     }
   }
   // Make sure we used all the parameters that were passed in.
-  assert(x.size() == i);
+  ALBATROSS_ASSERT(x.size() == i);
   return output;
 }
 
@@ -220,7 +220,7 @@ public:
     if (!map_contains(current_params, key)) {
       std::cerr << "Error: Key `" << key << "` not found in parameters: "
                 << pretty_params(current_params);
-      assert(false);
+      ALBATROSS_ASSERT(false);
     }
   }
 

--- a/include/albatross/src/core/parameter_macros.hpp
+++ b/include/albatross/src/core/parameter_macros.hpp
@@ -76,7 +76,7 @@
  *     } else if {
  *     ...
  *     } else {
- *       assert(false);
+ *       ALBATROSS_ASSERT(false);
  *     }
  *   }
  */
@@ -90,7 +90,7 @@
   if (_cond(x)) {                                                              \
     _action(x);                                                                \
   } else {                                                                     \
-    assert(false);                                                             \
+    ALBATROSS_ASSERT(false);                                                   \
   };
 #define _build_if_2(_cond, _action, x, ...)                                    \
   if (_cond(x)) {                                                              \

--- a/include/albatross/src/core/priors.hpp
+++ b/include/albatross/src/core/priors.hpp
@@ -77,7 +77,7 @@ class UniformPrior : public Prior {
 public:
   UniformPrior(double lower = 0., double upper = 1.)
       : lower_(lower), upper_(upper) {
-    assert(upper_ > lower_);
+    ALBATROSS_ASSERT(upper_ > lower_);
   };
 
   std::string get_name() const override {
@@ -105,8 +105,8 @@ class LogScaleUniformPrior : public UniformPrior {
 public:
   LogScaleUniformPrior(double lower = 1e-12, double upper = 1.e12)
       : UniformPrior(lower, upper) {
-    assert(upper_ > 0.);
-    assert(lower_ > 0.);
+    ALBATROSS_ASSERT(upper_ > 0.);
+    ALBATROSS_ASSERT(lower_ > 0.);
   };
 
   std::string get_name() const override {

--- a/include/albatross/src/covariance_functions/call_trace.hpp
+++ b/include/albatross/src/covariance_functions/call_trace.hpp
@@ -22,8 +22,8 @@ struct CallAndValue {
   std::string value;
 
   void add_operator(const char c) {
-    assert(call_name.size() >= 3);
-    assert(value.size() >= 3);
+    ALBATROSS_ASSERT(call_name.size() >= 3);
+    ALBATROSS_ASSERT(value.size() >= 3);
     call_name[2] = c;
     value[2] = c;
   }

--- a/include/albatross/src/covariance_functions/linear_combination.hpp
+++ b/include/albatross/src/covariance_functions/linear_combination.hpp
@@ -30,7 +30,8 @@ template <typename X> struct LinearCombination {
   LinearCombination(const std::vector<X> &values_,
                     const Eigen::VectorXd &coefficients_)
       : values(values_), coefficients(coefficients_) {
-    assert(values_.size() == static_cast<std::size_t>(coefficients_.size()));
+    ALBATROSS_ASSERT(values_.size() ==
+                     static_cast<std::size_t>(coefficients_.size()));
   };
 
   bool operator==(const LinearCombination &other) const {

--- a/include/albatross/src/covariance_functions/mean_function.hpp
+++ b/include/albatross/src/covariance_functions/mean_function.hpp
@@ -92,7 +92,7 @@ public:
       return;
     }
     const Eigen::VectorXd mean = this->operator()(features);
-    assert(mean.size() == target->size());
+    ALBATROSS_ASSERT(mean.size() == target->size());
     *target += mean;
   }
 
@@ -104,7 +104,7 @@ public:
       return;
     }
     const Eigen::VectorXd mean = this->operator()(features);
-    assert(mean.size() == target->size());
+    ALBATROSS_ASSERT(mean.size() == target->size());
     *target -= mean;
   }
 

--- a/include/albatross/src/covariance_functions/radial.hpp
+++ b/include/albatross/src/covariance_functions/radial.hpp
@@ -24,7 +24,7 @@ inline double squared_exponential_covariance(double distance,
   if (length_scale <= 0.) {
     return 0.;
   }
-  assert(distance >= 0.);
+  ALBATROSS_ASSERT(distance >= 0.);
   return sigma * sigma * exp(-pow(distance / length_scale, 2));
 }
 
@@ -91,7 +91,7 @@ inline double exponential_covariance(double distance, double length_scale,
   if (length_scale <= 0.) {
     return 0.;
   }
-  assert(distance >= 0.);
+  ALBATROSS_ASSERT(distance >= 0.);
   return sigma * sigma * exp(-fabs(distance / length_scale));
 }
 

--- a/include/albatross/src/details/error_handling.hpp
+++ b/include/albatross/src/details/error_handling.hpp
@@ -13,6 +13,37 @@
 #ifndef INCLUDE_ALBATROSS_SRC_DETAILS_ERROR_HANDLING_HPP_
 #define INCLUDE_ALBATROSS_SRC_DETAILS_ERROR_HANDLING_HPP_
 
+/*
+ * The fact that assert() behaves differently in debug and release mode can
+ * cause a number of headaches.  For example, if you do something like:
+ *
+ *   assert(function_with_side_effects());
+ *
+ * that function call will have side effects during debug, but not release.
+ * Alternatively you may want to instead do:
+ *
+ *   const bool success = function_with_side_effects();
+ *   assert(success);
+ *
+ * but that will results in compiler complaints about unused variables.
+ *
+ * Here we use a workaround proposed here:
+ *
+ * https://web.archive.org/web/20201129200055/http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/
+ *
+ * in which we define a separate macro which always evaluates (in even release
+ * mode) and avoids the unused variable problem if you want to go that route.
+ */
+#ifdef NDEBUG
+#define ALBATROSS_ASSERT(x)                                                    \
+  do {                                                                         \
+    (void)sizeof(x);                                                           \
+  } while (0)
+#else
+#include <assert.h>
+#define ALBATROSS_ASSERT(x) assert((x))
+#endif
+
 namespace albatross {
 
 #define ALBATROSS_FAIL(dummy, msg)                                             \

--- a/include/albatross/src/details/error_handling.hpp
+++ b/include/albatross/src/details/error_handling.hpp
@@ -37,7 +37,7 @@
 #ifdef NDEBUG
 #define ALBATROSS_ASSERT(x)                                                    \
   do {                                                                         \
-    (void)sizeof(x);                                                           \
+    (void)(x);                                                                 \
   } while (0)
 #else
 #include <assert.h>

--- a/include/albatross/src/eigen/serializable_ldlt.hpp
+++ b/include/albatross/src/eigen/serializable_ldlt.hpp
@@ -147,7 +147,7 @@ public:
     // D^-1/2 L^-1 P
     inverse_cholesky = diagonal_sqrt_inverse() * inverse_cholesky;
 
-    assert(!inverse_cholesky.hasNaN());
+    ALBATROSS_ASSERT(!inverse_cholesky.hasNaN());
 
     std::vector<Eigen::MatrixXd> output;
     for (const auto &block_indices : blocks) {
@@ -176,8 +176,8 @@ public:
     Eigen::VectorXd inv_diag(n);
     const auto blocks = inverse_blocks(block_indices);
     for (std::size_t i = 0; i < size_n; i++) {
-      assert(blocks[i].rows() == 1);
-      assert(blocks[i].cols() == 1);
+      ALBATROSS_ASSERT(blocks[i].rows() == 1);
+      ALBATROSS_ASSERT(blocks[i].cols() == 1);
       inv_diag[i] = blocks[i](0, 0);
     }
 

--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -60,7 +60,7 @@ template <typename GroupKey>
 inline Eigen::VectorXd
 concatenate_mean_predictions(const GroupIndexer<GroupKey> &indexer,
                              const Grouped<GroupKey, Eigen::VectorXd> &means) {
-  assert(indexer.size() == means.size());
+  ALBATROSS_ASSERT(indexer.size() == means.size());
 
   Eigen::Index n =
       static_cast<Eigen::Index>(dataset_size_from_indexer(indexer));
@@ -68,12 +68,12 @@ concatenate_mean_predictions(const GroupIndexer<GroupKey> &indexer,
   Eigen::Index number_filled = 0;
   // Put all the predicted means back in order.
   for (const auto &pair : indexer) {
-    assert(means.at(pair.first).size() ==
-           static_cast<Eigen::Index>(pair.second.size()));
+    ALBATROSS_ASSERT(means.at(pair.first).size() ==
+                     static_cast<Eigen::Index>(pair.second.size()));
     set_subset(means.at(pair.first), pair.second, &pred);
     number_filled += static_cast<Eigen::Index>(pair.second.size());
   }
-  assert(number_filled == n);
+  ALBATROSS_ASSERT(number_filled == n);
   return pred;
 }
 
@@ -82,7 +82,7 @@ template <typename DistributionType, typename GroupKey,
 inline MarginalDistribution concatenate_marginal_predictions(
     const GroupIndexer<GroupKey> &indexer,
     const PredictionContainer<GroupKey, DistributionType> &preds) {
-  assert(indexer.size() == preds.size());
+  ALBATROSS_ASSERT(indexer.size() == preds.size());
 
   Eigen::Index n =
       static_cast<Eigen::Index>(dataset_size_from_indexer(indexer));
@@ -91,13 +91,13 @@ inline MarginalDistribution concatenate_marginal_predictions(
   Eigen::Index number_filled = 0;
   // Put all the predicted means back in order.
   for (const auto &pair : indexer) {
-    assert(preds.at(pair.first).size() == pair.second.size());
+    ALBATROSS_ASSERT(preds.at(pair.first).size() == pair.second.size());
     set_subset(preds.at(pair.first).mean, pair.second, &mean);
     set_subset(preds.at(pair.first).covariance.diagonal(), pair.second,
                &variance);
     number_filled += static_cast<Eigen::Index>(pair.second.size());
   }
-  assert(number_filled == n);
+  ALBATROSS_ASSERT(number_filled == n);
   return MarginalDistribution(mean, variance.asDiagonal());
 }
 
@@ -111,8 +111,8 @@ Eigen::VectorXd cross_validated_scores(
 
   const auto score_one_group = [&](const GroupKey &key,
                                    const RegressionFold<FeatureType> &fold) {
-    assert(static_cast<std::size_t>(fold.test_dataset.size()) ==
-           static_cast<std::size_t>(predictions.at(key).size()));
+    ALBATROSS_ASSERT(static_cast<std::size_t>(fold.test_dataset.size()) ==
+                     static_cast<std::size_t>(predictions.at(key).size()));
     return metric(predictions.at(key), fold.test_dataset.targets);
   };
 

--- a/include/albatross/src/evaluation/folds.hpp
+++ b/include/albatross/src/evaluation/folds.hpp
@@ -47,9 +47,10 @@ create_fold(const GroupIndices &test_indices,
       subset(dataset.features, test_indices);
   MarginalDistribution test_targets = subset(dataset.targets, test_indices);
 
-  assert(train_features.size() == train_targets.size());
-  assert(test_features.size() == test_targets.size());
-  assert(test_targets.size() + train_targets.size() == dataset.size());
+  ALBATROSS_ASSERT(train_features.size() == train_targets.size());
+  ALBATROSS_ASSERT(test_features.size() == test_targets.size());
+  ALBATROSS_ASSERT(test_targets.size() + train_targets.size() ==
+                   dataset.size());
 
   const RegressionDataset<FeatureType> train_split(train_features,
                                                    train_targets);
@@ -84,7 +85,7 @@ inline GroupIndexer<GroupKey>
 group_indexer_from_folds(const std::map<GroupKey, FeatureType> &folds) {
   GroupIndexer<GroupKey> output;
   for (const auto &fold : folds) {
-    assert(!map_contains(output, fold.first));
+    ALBATROSS_ASSERT(!map_contains(output, fold.first));
     output[fold.first] = fold.second.test_indices;
   }
   return output;
@@ -126,17 +127,17 @@ dataset_size_from_indexer(const GroupIndexer<GroupKey> &indexer) {
   for (const auto &pair : indexer) {
     count += pair.second.size();
   };
-  assert(count == unique_inds.size());
+  ALBATROSS_ASSERT(count == unique_inds.size());
 
   // Make sure the minimum was zero
   std::size_t zero = *std::min_element(unique_inds.begin(), unique_inds.end());
   if (zero != 0) {
-    assert(false);
+    ALBATROSS_ASSERT(false);
   }
 
   // And the maximum agrees with the size;
   std::size_t n = *std::max_element(unique_inds.begin(), unique_inds.end());
-  assert(unique_inds.size() == n + 1);
+  ALBATROSS_ASSERT(unique_inds.size() == n + 1);
 
   return n + 1;
 }

--- a/include/albatross/src/evaluation/likelihood.hpp
+++ b/include/albatross/src/evaluation/likelihood.hpp
@@ -53,8 +53,8 @@ negative_log_likelihood(const Eigen::VectorXd &deviation,
 static inline double
 negative_log_likelihood(const Eigen::VectorXd &deviation,
                         const Eigen::MatrixXd &covariance) {
-  assert(deviation.size() == covariance.rows());
-  assert(covariance.cols() == covariance.rows());
+  ALBATROSS_ASSERT(deviation.size() == covariance.rows());
+  ALBATROSS_ASSERT(covariance.cols() == covariance.rows());
   if (deviation.size() == 1) {
     // Looks like we have a univariate distribution, skipping
     // all the matrix decomposition steps should speed this up.
@@ -75,7 +75,7 @@ static inline double
 negative_log_likelihood(const Eigen::VectorXd &deviation,
                         const Eigen::DiagonalMatrix<_Scalar, SizeAtCompileTime>
                             &diagonal_covariance) {
-  assert(deviation.size() == diagonal_covariance.diagonal().size());
+  ALBATROSS_ASSERT(deviation.size() == diagonal_covariance.diagonal().size());
   const auto variances = diagonal_covariance.diagonal();
   double nll = 0.;
   for (Eigen::Index i = 0; i < deviation.size(); i++) {

--- a/include/albatross/src/graph/minimum_spanning_tree.hpp
+++ b/include/albatross/src/graph/minimum_spanning_tree.hpp
@@ -223,7 +223,7 @@ private:
   VertexWithTreeID &find_vertex_or_assert(const VertexType &x) {
     auto is_x = [&x](const auto &p) { return p.v == x; };
     const auto iter = std::find_if(vertices_.begin(), vertices_.end(), is_x);
-    assert(iter != vertices_.end());
+    ALBATROSS_ASSERT(iter != vertices_.end());
     return *iter;
   }
 

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -276,7 +276,7 @@ Eigen::VectorXd combine(const Map<KeyType, double> &groups) {
     output[i] = x;
     ++i;
   }
-  assert(i == output.size());
+  ALBATROSS_ASSERT(i == output.size());
   return output;
 }
 
@@ -294,7 +294,7 @@ Eigen::VectorXd combine(const Map<KeyType, Eigen::VectorXd> &groups) {
       i += x.size();
     }
   }
-  assert(i == output.size());
+  ALBATROSS_ASSERT(i == output.size());
   return output;
 }
 
@@ -471,7 +471,7 @@ public:
                 details::is_subsetable<SubsetableType>::value, int>::type = 0>
   Grouped<KeyType, std::pair<ValueType, SubsetableType>>
   with(const SubsetableType &other) const {
-    assert(parent_.size() == other.size());
+    ALBATROSS_ASSERT(parent_.size() == other.size());
     Grouped<KeyType, std::pair<ValueType, SubsetableType>> output;
     for (const auto &key_indexer_pair : indexers()) {
       output.emplace(
@@ -485,7 +485,7 @@ public:
   template <template <typename...> class Map, typename AlreadyGroupedType>
   Grouped<KeyType, std::pair<ValueType, AlreadyGroupedType>>
   with(const Map<KeyType, AlreadyGroupedType> &other) const {
-    assert(other.size() == indexers().size());
+    ALBATROSS_ASSERT(other.size() == indexers().size());
     Grouped<KeyType, std::pair<ValueType, AlreadyGroupedType>> output;
     for (const auto &key_indexer_pair : indexers()) {
       output.emplace(

--- a/include/albatross/src/indexing/subset.hpp
+++ b/include/albatross/src/indexing/subset.hpp
@@ -23,8 +23,9 @@ inline std::vector<X> subset(const std::vector<X> &v,
                              const std::vector<SizeType> &indices) {
   std::vector<X> out(indices.size());
   for (std::size_t i = 0; i < static_cast<std::size_t>(indices.size()); i++) {
-    assert(indices[i] >= 0 && "Invalid indices provided to subset");
-    assert(indices[i] < v.size() && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(indices[i] >= 0 && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(indices[i] < v.size() &&
+                     "Invalid indices provided to subset");
     out[i] = v[static_cast<std::size_t>(indices[i])];
   }
   return out;
@@ -39,8 +40,8 @@ inline Eigen::VectorXd subset(const Eigen::VectorXd &v,
   Eigen::VectorXd out(static_cast<Eigen::Index>(indices.size()));
   for (std::size_t i = 0; i < indices.size(); i++) {
     const Eigen::Index ind_i = static_cast<Eigen::Index>(indices[i]);
-    assert(ind_i >= 0 && "Invalid indices provided to subset");
-    assert(ind_i < v.size() && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(ind_i >= 0 && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(ind_i < v.size() && "Invalid indices provided to subset");
     out[static_cast<Eigen::Index>(i)] = v[ind_i];
   }
   return out;
@@ -56,8 +57,9 @@ inline Eigen::MatrixXd subset_cols(const Eigen::MatrixXd &v,
   for (std::size_t i = 0; i < col_indices.size(); i++) {
     auto ii = static_cast<Eigen::Index>(i);
     auto col_index = static_cast<Eigen::Index>(col_indices[i]);
-    assert(col_index >= 0 && "Invalid indices provided to subset");
-    assert(col_index < v.cols() && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(col_index >= 0 && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(col_index < v.cols() &&
+                     "Invalid indices provided to subset");
     out.col(ii) = v.col(col_index);
   }
   return out;
@@ -73,8 +75,9 @@ inline Eigen::MatrixXd subset_rows(const Eigen::MatrixXd &v,
   for (std::size_t i = 0; i < row_indices.size(); i++) {
     auto ii = static_cast<Eigen::Index>(i);
     auto row_index = static_cast<Eigen::Index>(row_indices[i]);
-    assert(row_index >= 0 && "Invalid indices provided to subset");
-    assert(row_index < v.rows() && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(row_index >= 0 && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(row_index < v.rows() &&
+                     "Invalid indices provided to subset");
     out.row(ii) = v.row(row_index);
   }
   return out;
@@ -95,10 +98,12 @@ inline Eigen::MatrixXd subset(const Eigen::MatrixXd &v,
       auto jj = static_cast<Eigen::Index>(j);
       auto row_index = static_cast<Eigen::Index>(row_indices[i]);
       auto col_index = static_cast<Eigen::Index>(col_indices[j]);
-      assert(row_index >= 0 && "Invalid indices provided to subset");
-      assert(row_index < v.rows() && "Invalid indices provided to subset");
-      assert(col_index >= 0 && "Invalid indices provided to subset");
-      assert(col_index < v.cols() && "Invalid indices provided to subset");
+      ALBATROSS_ASSERT(row_index >= 0 && "Invalid indices provided to subset");
+      ALBATROSS_ASSERT(row_index < v.rows() &&
+                       "Invalid indices provided to subset");
+      ALBATROSS_ASSERT(col_index >= 0 && "Invalid indices provided to subset");
+      ALBATROSS_ASSERT(col_index < v.cols() &&
+                       "Invalid indices provided to subset");
       out(ii, jj) = v(row_index, col_index);
     }
   }
@@ -112,7 +117,7 @@ inline Eigen::MatrixXd subset(const Eigen::MatrixXd &v,
 template <typename SizeType>
 inline Eigen::MatrixXd symmetric_subset(const Eigen::MatrixXd &v,
                                         const std::vector<SizeType> &indices) {
-  assert(v.rows() == v.cols());
+  ALBATROSS_ASSERT(v.rows() == v.cols());
   return subset(v, indices, indices);
 }
 
@@ -136,11 +141,12 @@ template <typename SizeType>
 inline void set_subset(const Eigen::VectorXd &from,
                        const std::vector<SizeType> &indices,
                        Eigen::VectorXd *to) {
-  assert(static_cast<Eigen::Index>(indices.size()) == from.size());
+  ALBATROSS_ASSERT(static_cast<Eigen::Index>(indices.size()) == from.size());
   for (std::size_t i = 0; i < indices.size(); ++i) {
     const Eigen::Index ind_i = static_cast<Eigen::Index>(indices[i]);
-    assert(ind_i >= 0 && "Invalid indices provided to subset");
-    assert(ind_i < to->size() && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(ind_i >= 0 && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(ind_i < to->size() &&
+                     "Invalid indices provided to subset");
     (*to)[ind_i] = from[static_cast<Eigen::Index>(i)];
   }
 }
@@ -155,11 +161,13 @@ template <typename SizeType, typename Scalar, int Size>
 inline void set_subset(const Eigen::DiagonalMatrix<Scalar, Size> &from,
                        const std::vector<SizeType> &indices,
                        Eigen::DiagonalMatrix<Scalar, Size> *to) {
-  assert(static_cast<Eigen::Index>(indices.size()) == from.diagonal().size());
+  ALBATROSS_ASSERT(static_cast<Eigen::Index>(indices.size()) ==
+                   from.diagonal().size());
   for (std::size_t i = 0; i < indices.size(); i++) {
     const Eigen::Index ind_i = static_cast<Eigen::Index>(indices[i]);
-    assert(ind_i >= 0 && "Invalid indices provided to subset");
-    assert(ind_i < to->size() && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(ind_i >= 0 && "Invalid indices provided to subset");
+    ALBATROSS_ASSERT(ind_i < to->size() &&
+                     "Invalid indices provided to subset");
     to->diagonal()[ind_i] = from.diagonal()[static_cast<Eigen::Index>(i)];
   }
 }

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -65,7 +65,7 @@ struct Fit<GPFit<CovarianceRepresentation, FeatureType>> {
     train_features = features;
     Eigen::MatrixXd cov(train_cov);
     cov += targets.covariance;
-    assert(!cov.hasNaN());
+    ALBATROSS_ASSERT(!cov.hasNaN());
     train_covariance = CovarianceRepresentation(cov);
     information = train_covariance.solve(targets.mean);
   }

--- a/include/albatross/src/models/least_squares.hpp
+++ b/include/albatross/src/models/least_squares.hpp
@@ -55,7 +55,7 @@ public:
                     const MarginalDistribution &targets) const {
     // The way this is currently implemented we assume all targets have the same
     // variance (or zero variance).
-    assert(all_same_value(targets.covariance.diagonal()));
+    ALBATROSS_ASSERT(all_same_value(targets.covariance.diagonal()));
     // Build the design matrix
     int m = static_cast<int>(features.size());
     int n = static_cast<int>(features[0].size());

--- a/include/albatross/src/models/patchwork_gp.hpp
+++ b/include/albatross/src/models/patchwork_gp.hpp
@@ -223,7 +223,7 @@ public:
       return ReturnType(*this, PatchworkFitType(fit_models));
     }
 
-    assert(boundary_features.size() > 0);
+    ALBATROSS_ASSERT(boundary_features.size() > 0);
 
     // The following variable names are meant to approximately match the
     // notation used in Equation 5 (and the following matrices).  The

--- a/include/albatross/src/models/ransac.hpp
+++ b/include/albatross/src/models/ransac.hpp
@@ -80,7 +80,7 @@ inline std::string to_string(const ransac_return_code_t &return_code) {
   case RANSAC_RETURN_CODE_FAILURE:
     return "failure";
   default:
-    assert(false);
+    ALBATROSS_ASSERT(false);
     return "unknown return code";
   }
 }
@@ -418,7 +418,7 @@ struct Fit<RansacFit<ModelType, StrategyType, FeatureType, GroupKey>> {
   }
 
   const FitModelType &get_fit_model_or_assert() const {
-    assert(maybe_empty_fit_model.template is<FitModelType>());
+    ALBATROSS_ASSERT(maybe_empty_fit_model.template is<FitModelType>());
     return maybe_empty_fit_model.template get<FitModelType>();
   }
 
@@ -500,7 +500,7 @@ public:
                             PredictTypeIdentity<PredictType> &&) const {
     // If RANSAC failed it's up to the user to determine that from the output of
     // fit and deal with it appropriately.
-    assert(ransac_fit_.has_fit_model());
+    ALBATROSS_ASSERT(ransac_fit_.has_fit_model());
     return ransac_fit_.get_fit_model_or_assert()
         .predict(features)
         .template get<PredictType>();

--- a/include/albatross/src/models/ransac_gp.hpp
+++ b/include/albatross/src/models/ransac_gp.hpp
@@ -128,7 +128,7 @@ inline RansacFunctions<ConditionalFit, GroupKey> get_gp_ransac_functions(
   static_assert(is_prediction_metric<InlierMetric>::value,
                 "InlierMetric must be an PredictionMetric.");
 
-  assert(prior.size() == truth.size());
+  ALBATROSS_ASSERT(prior.size() == truth.size());
 
   const ConditionalGaussian model(prior, truth);
 

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -90,7 +90,7 @@ template <typename FeatureType> struct Fit<SparseGPFit<FeatureType>> {
         information(information_) {}
 
   void shift_mean(const Eigen::VectorXd &mean_shift) {
-    assert(mean_shift.size() == information.size());
+    ALBATROSS_ASSERT(mean_shift.size() == information.size());
     information += train_covariance.solve(mean_shift);
   }
 
@@ -286,7 +286,7 @@ public:
       inducing_nugget_ = param;
     } else {
       std::cerr << "Unknown param: " << name << std::endl;
-      assert(false);
+      ALBATROSS_ASSERT(false);
     }
   }
 
@@ -307,7 +307,7 @@ public:
     const Eigen::Index k = old_fit.sigma_R.cols();
     Eigen::MatrixXd B = Eigen::MatrixXd::Zero(n_old + n_new, k);
 
-    assert(n_old == k);
+    ALBATROSS_ASSERT(n_old == k);
 
     // Form:
     //   B = |R_old P_old^T| = |Q_1| R P^T
@@ -322,7 +322,7 @@ public:
     // Form:
     //   y_aug = |R_old P_old^T v_old|
     //           |A^{-1/2} y         |
-    assert(old_fit.information.size() == n_old);
+    ALBATROSS_ASSERT(old_fit.information.size() == n_old);
     Eigen::VectorXd y_augmented(n_old + n_new);
     for (Eigen::Index i = 0; i < old_fit.permutation_indices.size(); ++i) {
       y_augmented[i] =
@@ -373,7 +373,7 @@ public:
     // Determine the set of inducing points, u.
     const auto u =
         inducing_point_strategy_(this->covariance_function_, features);
-    assert(u.size() > 0 && "Empty inducing points!");
+    ALBATROSS_ASSERT(u.size() > 0 && "Empty inducing points!");
 
     BlockDiagonalLDLT A_ldlt;
     Eigen::SerializableLDLT K_uu_ldlt;
@@ -619,10 +619,10 @@ private:
       BlockDiagonalLDLT *A_ldlt, Eigen::SerializableLDLT *K_uu_ldlt,
       Eigen::MatrixXd *K_fu, Eigen::VectorXd *y) const {
 
-    assert(A_ldlt != nullptr);
-    assert(K_uu_ldlt != nullptr);
-    assert(K_fu != nullptr);
-    assert(y != nullptr);
+    ALBATROSS_ASSERT(A_ldlt != nullptr);
+    ALBATROSS_ASSERT(K_uu_ldlt != nullptr);
+    ALBATROSS_ASSERT(K_fu != nullptr);
+    ALBATROSS_ASSERT(y != nullptr);
 
     const auto indexer =
         group_by(out_of_order_features, independent_group_function_).indexers();

--- a/include/albatross/src/samplers/ensemble.hpp
+++ b/include/albatross/src/samplers/ensemble.hpp
@@ -24,7 +24,7 @@ inline auto split_indices(std::size_t n, std::size_t k) {
 inline std::size_t random_complement(std::size_t n, std::size_t i,
                                      std::default_random_engine &gen) {
   // Draws a random integer between 0 and n - 1 excluding i.
-  assert(n > 1);
+  ALBATROSS_ASSERT(n > 1);
   std::uniform_int_distribution<std::size_t> uniform_int(0, n - 1);
   std::size_t output;
   while (true) {
@@ -37,7 +37,7 @@ inline std::size_t random_complement(std::size_t n, std::size_t i,
 
 void assert_valid_states(const EnsembleSamplerState &ensembles) {
   for (std::size_t i = 0; i < ensembles.size(); ++i) {
-    assert(std::isfinite(ensembles[i].log_prob));
+    ALBATROSS_ASSERT(std::isfinite(ensembles[i].log_prob));
   }
 }
 

--- a/include/albatross/src/samplers/initialization.hpp
+++ b/include/albatross/src/samplers/initialization.hpp
@@ -47,12 +47,12 @@ initial_params_from_csv(std::istream &ss) {
   std::string line;
   double iteration = 0;
 
-  assert(std::getline(ss, line));
+  ALBATROSS_ASSERT(std::getline(ss, line));
   const std::vector<std::string> columns = split_string(line, ',');
 
-  assert(columns[0] == "iteration");
-  assert(columns[1] == "log_probability");
-  assert(columns[2] == "ensemble_index");
+  ALBATROSS_ASSERT(columns[0] == "iteration");
+  ALBATROSS_ASSERT(columns[1] == "log_probability");
+  ALBATROSS_ASSERT(columns[2] == "ensemble_index");
 
   while (std::getline(ss, line)) {
     const std::vector<double> values = parse_line(line);
@@ -64,7 +64,7 @@ initial_params_from_csv(std::istream &ss) {
     }
 
     std::map<std::string, double> param_values;
-    assert(values.size() == columns.size());
+    ALBATROSS_ASSERT(values.size() == columns.size());
     // Skip the first three columns which contain metadata
     for (std::size_t i = 3; i < columns.size(); ++i) {
       param_values[columns[i]] = values[i];
@@ -83,7 +83,7 @@ initial_params_from_csv(const ParameterStore &param_store, std::istream &ss) {
 
   std::vector<std::vector<double>> output;
   for (const auto &value_map : all_params) {
-    assert(value_map.size() == param_store.size());
+    ALBATROSS_ASSERT(value_map.size() == param_store.size());
     ParameterStore params(param_store);
     for (const auto &value_pair : value_map) {
       params[value_pair.first].value = ensure_value_within_bounds(
@@ -139,7 +139,8 @@ ensure_finite_initial_state(ComputeLogProb &&compute_log_prob,
       output.push_back(state);
     }
   }
-  assert(output.size() > 2 && "Need at least two finite initial states");
+  ALBATROSS_ASSERT(output.size() > 2 &&
+                   "Need at least two finite initial states");
 
   std::uniform_real_distribution<double> uniform_real(0.0, 1.0);
 

--- a/include/albatross/src/stats/incomplete_gamma.hpp
+++ b/include/albatross/src/stats/incomplete_gamma.hpp
@@ -35,13 +35,13 @@ constexpr double INCOMPLETE_GAMMA_EQUALITY_TRESHOLD = 1e-12;
 
 inline double incomplete_gamma_quadrature_inp_vals(double lb, double ub,
                                                    std::size_t counter) {
-  assert(counter < gauss_legendre_50_points.size());
+  ALBATROSS_ASSERT(counter < gauss_legendre_50_points.size());
   return (ub - lb) * 0.5 * gauss_legendre_50_points[counter] + 0.5 * (ub + lb);
 }
 
 inline double incomplete_gamma_quadrature_weight_vals(double lb, double ub,
                                                       std::size_t counter) {
-  assert(counter < gauss_legendre_50_weights.size());
+  ALBATROSS_ASSERT(counter < gauss_legendre_50_weights.size());
   return (ub - lb) * 0.5 * gauss_legendre_50_weights[counter];
 }
 

--- a/include/albatross/src/tune/tune.hpp
+++ b/include/albatross/src/tune/tune.hpp
@@ -94,7 +94,8 @@ inline ParameterStore run_optimizer(const ParameterStore &params,
 
   auto x = get_tunable_parameters(params).values;
 
-  assert(static_cast<std::size_t>(optimizer.get_dimension()) == x.size());
+  ALBATROSS_ASSERT(static_cast<std::size_t>(optimizer.get_dimension()) ==
+                   x.size());
 
   double minf;
   nlopt::result result = optimizer.optimize(x, minf);
@@ -146,7 +147,7 @@ struct GenericTuner {
       if (!params_are_valid(params)) {
         this->output_stream << "Invalid Parameters:" << std::endl;
         this->output_stream << pretty_param_details(params) << std::endl;
-        assert(false);
+        ALBATROSS_ASSERT(false);
       }
 
       double metric = objective(params);

--- a/include/albatross/src/utils/block_utils.hpp
+++ b/include/albatross/src/utils/block_utils.hpp
@@ -57,11 +57,11 @@ inline Eigen::MatrixXd block_accumulate(const Grouped<GroupKey, X> &lhs,
                    typename invoke_result<ApplyFunction, X, Y>::type>::value,
       "apply_function needs to return an Eigen::MatrixXd type");
 
-  assert(lhs.size() == rhs.size());
-  assert(lhs.size() > 0);
+  ALBATROSS_ASSERT(lhs.size() == rhs.size());
+  ALBATROSS_ASSERT(lhs.size() > 0);
 
   auto one_group = [&](const GroupKey &key) {
-    assert(map_contains(lhs, key) && map_contains(rhs, key));
+    ALBATROSS_ASSERT(map_contains(lhs, key) && map_contains(rhs, key));
     return apply_function(lhs.at(key), rhs.at(key));
   };
 
@@ -144,7 +144,7 @@ inline Grouped<GroupKey, Eigen::MatrixXd>
 block_subtract(const Grouped<GroupKey, Eigen::MatrixXd> &lhs,
                const Grouped<GroupKey, Eigen::MatrixXd> &rhs) {
 
-  assert(lhs.size() == rhs.size());
+  ALBATROSS_ASSERT(lhs.size() == rhs.size());
   auto matrix_subtract = [&](const auto &key_i, const auto &rhs_i) {
     return (lhs.at(key_i) - rhs_i).eval();
   };
@@ -287,7 +287,7 @@ template <typename Solver> struct BlockSymmetric {
 template <class _Scalar, int _Rows, int _Cols>
 inline Eigen::Matrix<_Scalar, _Rows, _Cols> BlockDiagonalLDLT::solve(
     const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
-  assert(cols() == rhs.rows());
+  ALBATROSS_ASSERT(cols() == rhs.rows());
   Eigen::Index i = 0;
   Eigen::Matrix<_Scalar, _Rows, _Cols> output(rows(), rhs.cols());
   for (const auto &b : blocks) {
@@ -301,7 +301,7 @@ inline Eigen::Matrix<_Scalar, _Rows, _Cols> BlockDiagonalLDLT::solve(
 template <class _Scalar, int _Rows, int _Cols>
 inline Eigen::Matrix<_Scalar, _Rows, _Cols> BlockDiagonalLDLT::sqrt_solve(
     const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
-  assert(cols() == rhs.rows());
+  ALBATROSS_ASSERT(cols() == rhs.rows());
   Eigen::Index i = 0;
   Eigen::Matrix<_Scalar, _Rows, _Cols> output(rows(), rhs.cols());
   for (const auto &b : blocks) {
@@ -321,7 +321,7 @@ BlockDiagonalLDLT::block_to_row_map() const {
     block_to_row[i] = row;
     row += blocks[i].rows();
   }
-  assert(row == cols());
+  ALBATROSS_ASSERT(row == cols());
 
   return block_to_row;
 }
@@ -329,7 +329,7 @@ BlockDiagonalLDLT::block_to_row_map() const {
 template <class _Scalar, int _Rows, int _Cols>
 inline Eigen::Matrix<_Scalar, _Rows, _Cols> BlockDiagonalLDLT::async_solve(
     const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
-  assert(cols() == rhs.rows());
+  ALBATROSS_ASSERT(cols() == rhs.rows());
   Eigen::Matrix<_Scalar, _Rows, _Cols> output(rows(), rhs.cols());
   auto solve_and_fill_one_block = [&](const size_t i, const Eigen::Index row) {
     const auto rhs_chunk = rhs.block(row, 0, blocks[i].rows(), rhs.cols());
@@ -344,7 +344,7 @@ inline Eigen::Matrix<_Scalar, _Rows, _Cols> BlockDiagonalLDLT::async_solve(
 template <class _Scalar, int _Rows, int _Cols>
 inline Eigen::Matrix<_Scalar, _Rows, _Cols> BlockDiagonalLDLT::async_sqrt_solve(
     const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
-  assert(cols() == rhs.rows());
+  ALBATROSS_ASSERT(cols() == rhs.rows());
   Eigen::Matrix<_Scalar, _Rows, _Cols> output(rows(), rhs.cols());
 
   auto solve_and_fill_one_block = [&](const size_t i, const Eigen::Index row) {
@@ -389,7 +389,7 @@ template <class _Scalar, int _Rows, int _Cols>
 inline Eigen::Matrix<_Scalar, _Rows, _Cols>
 BlockTriangularView<MatrixType, Mode>::solve(
     const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
-  assert(cols() == rhs.rows());
+  ALBATROSS_ASSERT(cols() == rhs.rows());
   Eigen::Index i = 0;
   Eigen::Matrix<_Scalar, _Rows, _Cols> output(rows(), rhs.cols());
   for (const auto &b : blocks) {
@@ -405,7 +405,7 @@ template <class _Scalar, int _Rows, int _Cols>
 inline Eigen::Matrix<_Scalar, _Rows, _Cols>
     BlockTriangularView<MatrixType, Mode>::
     operator*(const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
-  assert(cols() == rhs.rows());
+  ALBATROSS_ASSERT(cols() == rhs.rows());
   Eigen::Index i = 0;
   Eigen::Matrix<_Scalar, _Rows, _Cols> output =
       Eigen::Matrix<_Scalar, _Rows, _Cols>::Zero(rows(), rhs.cols());
@@ -456,7 +456,7 @@ inline Eigen::MatrixXd BlockTriangularView<MatrixType, Mode>::toDense() const {
 template <class _Scalar, int _Rows, int _Cols>
 inline Eigen::Matrix<_Scalar, _Rows, _Cols> BlockDiagonal::
 operator*(const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
-  assert(cols() == rhs.rows());
+  ALBATROSS_ASSERT(cols() == rhs.rows());
   Eigen::Index i = 0;
   Eigen::Matrix<_Scalar, _Rows, _Cols> output =
       Eigen::Matrix<_Scalar, _Rows, _Cols>::Zero(rows(), rhs.cols());
@@ -469,12 +469,12 @@ operator*(const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
 }
 
 inline BlockDiagonal BlockDiagonal::operator-(const BlockDiagonal &rhs) const {
-  assert(cols() == rhs.rows());
-  assert(blocks.size() == rhs.blocks.size());
+  ALBATROSS_ASSERT(cols() == rhs.rows());
+  ALBATROSS_ASSERT(blocks.size() == rhs.blocks.size());
 
   BlockDiagonal output;
   for (std::size_t i = 0; i < blocks.size(); ++i) {
-    assert(blocks[i].size() == rhs.blocks[i].size());
+    ALBATROSS_ASSERT(blocks[i].size() == rhs.blocks[i].size());
     output.blocks.emplace_back(blocks[i] - rhs.blocks[i]);
   }
   return output;
@@ -494,7 +494,7 @@ inline Eigen::MatrixXd BlockDiagonal::toDense() const {
 }
 
 inline Eigen::VectorXd BlockDiagonal::diagonal() const {
-  assert(rows() == cols());
+  ALBATROSS_ASSERT(rows() == cols());
   Eigen::VectorXd output(rows());
 
   Eigen::Index i = 0;
@@ -540,7 +540,7 @@ inline Eigen::Matrix<_Scalar, _Rows, _Cols> BlockSymmetric<Solver>::solve(
     const Eigen::Matrix<_Scalar, _Rows, _Cols> &rhs) const {
   // https://en.wikipedia.org/wiki/Block_matrix#Block_matrix_inversion
   Eigen::Index n = A.rows() + S.rows();
-  assert(rhs.rows() == n);
+  ALBATROSS_ASSERT(rhs.rows() == n);
 
   const Eigen::MatrixXd rhs_a = rhs.topRows(A.rows());
   const Eigen::MatrixXd rhs_b = rhs.bottomRows(S.rows());

--- a/include/albatross/src/utils/csv_utils.hpp
+++ b/include/albatross/src/utils/csv_utils.hpp
@@ -146,8 +146,8 @@ template <typename FeatureType, typename DistributionType>
 inline std::map<std::string, std::string>
 to_map(const RegressionDataset<FeatureType> &dataset,
        const DistributionBase<DistributionType> &predictions, std::size_t i) {
-  assert(dataset.targets.size() == predictions.size());
-  assert(i < dataset.features.size() && i >= 0);
+  ALBATROSS_ASSERT(dataset.targets.size() == predictions.size());
+  ALBATROSS_ASSERT(i < dataset.features.size() && i >= 0);
   const auto ei = static_cast<Eigen::Index>(i);
 
   double target_variance = dataset.targets.get_diagonal(ei);
@@ -248,7 +248,7 @@ write_to_csv(std::ostream &stream,
              const std::vector<DistributionType> &predictions) {
   const auto columns = get_column_names(datasets[0], predictions[0]);
   write_header(stream, columns);
-  assert(datasets.size() == predictions.size());
+  ALBATROSS_ASSERT(datasets.size() == predictions.size());
   for (std::size_t i = 0; i < datasets.size(); i++) {
     write_to_csv(stream, datasets[i], predictions[i], columns);
   }

--- a/include/albatross/src/utils/eigen_utils.hpp
+++ b/include/albatross/src/utils/eigen_utils.hpp
@@ -91,7 +91,7 @@ inline auto vertical_stack(
   const Eigen::Index cols = blocks[0].cols();
   for (const auto &block : blocks) {
     rows += block.rows();
-    assert(block.cols() == cols);
+    ALBATROSS_ASSERT(block.cols() == cols);
   }
 
   using MatrixType = Eigen::Matrix<_Scalar, Eigen::Dynamic, _Cols>;

--- a/include/albatross/src/utils/map_utils.hpp
+++ b/include/albatross/src/utils/map_utils.hpp
@@ -83,7 +83,7 @@ Map<K, V> map_join_strict(const Map<K, V> &m, const Map<K, V> &other) {
   for (const auto &pair : m) {
     if (join.find(pair.first) != join.end()) {
       // duplicate key found in map_join.
-      assert(false && "duplicate key found");
+      ALBATROSS_ASSERT(false && "duplicate key found");
     }
     join[pair.first] = pair.second;
   }

--- a/include/albatross/src/utils/random_utils.hpp
+++ b/include/albatross/src/utils/random_utils.hpp
@@ -24,7 +24,7 @@ randint_without_replacement(std::size_t n, std::size_t low, std::size_t high,
   if (n > n_choices) {
     std::cout << "ERROR: n (" << n << ") is larger than n_choices ("
               << n_choices << ")" << std::endl;
-    assert(false);
+    ALBATROSS_ASSERT(false);
   }
 
   if (n == n_choices) {
@@ -127,8 +127,8 @@ random_multivariate_normal(const Eigen::VectorXd &mean,
                            const Eigen::MatrixXd &cov,
                            std::default_random_engine &gen) {
   std::normal_distribution<double> dist;
-  assert(mean.size() == cov.rows());
-  assert(cov.rows() == cov.cols());
+  ALBATROSS_ASSERT(mean.size() == cov.rows());
+  ALBATROSS_ASSERT(cov.rows() == cov.cols());
 
   Eigen::VectorXd sample(mean.size());
   gaussian_fill(sample, gen);

--- a/include/albatross/src/utils/vector_utils.hpp
+++ b/include/albatross/src/utils/vector_utils.hpp
@@ -16,7 +16,7 @@
 namespace albatross {
 
 inline std::size_t safe_cast_to_size_t(double x) {
-  assert(x < std::numeric_limits<std::size_t>::max());
+  ALBATROSS_ASSERT(x < std::numeric_limits<std::size_t>::max());
   return static_cast<std::size_t>(x);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(albatross_unit_tests
   test_csv_utils.cc
   test_distance_metrics.cc
   test_eigen_utils.cc
+  test_error_handling.cc
   test_evaluate.cc
   test_gp.cc
   test_group_by.cc

--- a/tests/test_error_handling.cc
+++ b/tests/test_error_handling.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/Common>
+
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+bool add_one(int *x) {
+  (*x) += 1;
+  return true;
+}
+
+TEST(test_error_handling, test_assert_evaluates) {
+  int x = 0;
+  ALBATROSS_ASSERT(add_one(&x));
+  EXPECT_EQ(x, 1);
+}
+
+} // namespace albatross


### PR DESCRIPTION
The use of `assert` can be complicated.  The macro is disabled in release mode which can cause a discrepancy between what gets evaluated in debug mode and release mode.  This can also lead to compilation errors in release mode when the only use of a variable is in any assert statement (so when it get's disabled the variable appears unused).

Here we introduce a new macro which follows the advice in: https://web.archive.org/web/20201129200055/http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/.

The new macro makes sure even in release mode an expression will get evaluated and avoids the unused variable problem.