### PR TITLE
Include Common in Utils

### DIFF
--- a/include/albatross/utils/AsyncUtils
+++ b/include/albatross/utils/AsyncUtils
@@ -16,6 +16,7 @@
 #include <future>
 #include <mutex>
 
+#include "../Common"
 #include "../src/utils/async_utils.hpp"
 
 #endif

--- a/include/albatross/utils/LinalgUtils
+++ b/include/albatross/utils/LinalgUtils
@@ -13,6 +13,7 @@
 #ifndef ALBATROSS_UTILS_LINALG_UTILS_H
 #define ALBATROSS_UTILS_LINALG_UTILS_H
 
+#include "../Common"
 #include "../src/utils/linalg_utils.hpp"
 
 #endif

--- a/include/albatross/utils/MapUtils
+++ b/include/albatross/utils/MapUtils
@@ -13,6 +13,7 @@
 #ifndef ALBATROSS_UTILS_MAP_UTILS_H
 #define ALBATROSS_UTILS_MAP_UTILS_H
 
+#include "../Common"
 #include "../src/utils/map_utils.hpp"
 
 #endif

--- a/include/albatross/utils/VariantUtils
+++ b/include/albatross/utils/VariantUtils
@@ -13,6 +13,7 @@
 #ifndef ALBATROSS_UTILS_VARIANT_UTILS_H
 #define ALBATROSS_UTILS_VARIANT_UTILS_H
 
+#include "../Common"
 #include "../src/utils/variant_utils.hpp"
 
 #endif


### PR DESCRIPTION
Some of the utility includes don't `#include <albatross/Common>` which pulls in some required functionality like the `ALBATROSS_ASSERT` macro, this PR makes sure the appropriate headers are included.