### PR TITLE
Ability to Align Datasets With Custom Compare

### DIFF
--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -105,14 +105,15 @@ deduplicate(const RegressionDataset<FeatureType> &dataset) {
   return albatross::subset(dataset, unique_inds);
 }
 
-template <typename X>
-inline auto align_datasets(RegressionDataset<X> *x, RegressionDataset<X> *y) {
+template <typename X, typename EqualTo>
+inline auto align_datasets(RegressionDataset<X> *x, RegressionDataset<X> *y,
+                           EqualTo equal_to) {
 
   std::vector<std::size_t> x_inds;
   std::vector<std::size_t> y_inds;
   for (std::size_t i = 0; i < x->size(); ++i) {
     for (std::size_t j = 0; j < y->size(); ++j) {
-      if (x->features[i] == y->features[j]) {
+      if (equal_to(x->features[i], y->features[j])) {
         x_inds.push_back(i);
         y_inds.push_back(j);
         continue;
@@ -129,6 +130,11 @@ inline auto align_datasets(RegressionDataset<X> *x, RegressionDataset<X> *y) {
     *x = subset(*x, x_inds);
     *y = subset(*y, y_inds);
   }
+}
+
+template <typename X>
+inline auto align_datasets(RegressionDataset<X> *x, RegressionDataset<X> *y) {
+  return align_datasets(x, y, std::equal_to<X>());
 }
 
 template <typename X>

--- a/tests/test_core_dataset.cc
+++ b/tests/test_core_dataset.cc
@@ -63,6 +63,23 @@ TEST(test_dataset, test_align_datasets_a_in_b) {
   EXPECT_EQ(dataset_a.features, dataset_b.features);
 }
 
+TEST(test_dataset, test_align_datasets_a_in_b_custom_compare) {
+  std::vector<int> features_a = {0, 1, 2};
+  Eigen::VectorXd targets_a = Eigen::VectorXd::Random(features_a.size());
+  RegressionDataset<int> dataset_a(features_a, targets_a);
+
+  std::vector<int> features_b = {2, 3, 0, 1};
+  Eigen::VectorXd targets_b = Eigen::VectorXd::Random(features_b.size());
+  RegressionDataset<int> dataset_b(features_b, targets_b);
+
+  EXPECT_NE(dataset_a.features, dataset_b.features);
+  auto custom_compare = [](const auto &x, const auto &y) { return x == y; };
+
+  align_datasets(&dataset_a, &dataset_b, custom_compare);
+  EXPECT_EQ(dataset_a.size(), 3);
+  EXPECT_EQ(dataset_a.features, dataset_b.features);
+}
+
 TEST(test_dataset, test_align_datasets_a_in_b_unordered) {
   std::vector<int> features_a = {0, 2, 1};
   Eigen::VectorXd targets_a = Eigen::VectorXd::Random(features_a.size());


### PR DESCRIPTION
This adds an optional argument to `align_datasets(x, y)` which lets you define your own custom equality comparator.  For example, you might have two datasets which each represent data from different times.  If you want to align the two you then might do something like:
```
RegressionDataset<X> data_prev = dataset_from_previous_time();
RegressionDataset<X> data_next = dataset_from_next_time();

auto equal_except_for_time = [](const auto &x, const auto &y) {
  return x.not_time == y.not_time;
};

align_datasets(&data_prev, &data_next, equal_except_for_time);
```