### PR TITLE
[DO NOT MERGE] Use SPQR for sparse GP solves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ target_link_libraries(albatross
     fast-csv
     gzip-hpp
     variant
+    spqr
+    cholmod
     )
 
 set(albatross_COMPILE_OPTIONS

--- a/include/albatross/SparseGP
+++ b/include/albatross/SparseGP
@@ -18,6 +18,7 @@
 
 #include <albatross/src/utils/block_utils.hpp>
 #include <albatross/src/utils/eigen_utils.hpp>
+#include <albatross/src/eigen/sparse_cod.hpp>
 #include <albatross/src/models/sparse_gp.hpp>
 
 #endif

--- a/include/albatross/src/cereal/gp.hpp
+++ b/include/albatross/src/cereal/gp.hpp
@@ -41,8 +41,10 @@ inline void serialize(Archive &archive, Fit<SparseGPFit<FeatureType>> &fit,
   archive(cereal::make_nvp("information", fit.information));
   archive(cereal::make_nvp("train_covariance", fit.train_covariance));
   archive(cereal::make_nvp("train_features", fit.train_features));
-  archive(cereal::make_nvp("sigma_R", fit.sigma_R));
-  archive(cereal::make_nvp("permutation_indices", fit.permutation_indices));
+  archive(cereal::make_nvp("sigma_R", albatross::get_R(*fit.solver)));
+  archive(
+      cereal::make_nvp("permutation_indices",
+                       albatross::get_column_permutation_indices(*fit.solver)));
 }
 
 template <typename Archive, typename CovFunc, typename MeanFunc,

--- a/include/albatross/src/eigen/sparse_cod.hpp
+++ b/include/albatross/src/eigen/sparse_cod.hpp
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2022 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_EIGEN_SPARSE_COD_H
+#define ALBATROSS_EIGEN_SPARSE_COD_H
+
+namespace Eigen {
+
+namespace internal {
+
+// This struct exists for settings that should be applied to both SPQR
+// solves used by the COD object.
+struct spqr_config {
+  int ordering;
+  int nthreads;
+  double pivot_threshold;
+};
+
+inline void spqr_setup(SPQR<SparseMatrix<double>> *spqr,
+                       const spqr_config &config) {
+  spqr->setSPQROrdering(config.ordering);
+  spqr->cholmodCommon()->SPQR_nthreads = config.nthreads;
+  spqr->setPivotThreshold(config.pivot_threshold);
+}
+
+inline spqr_config make_deficient_solve_config(
+    const spqr_config &initial_config) {
+  auto config = initial_config;
+  config.pivot_threshold = 0;
+  return config;
+}
+
+}  // namespace internal
+
+class SparseCOD : public SparseSolverBase<SparseCOD> {
+ public:
+  // Our typedefs
+  using SparseQR = SPQR<SparseMatrix<double>>;
+  using SparsePermutationMatrix =
+      PermutationMatrix<Dynamic, Dynamic, SparseQR::StorageIndex>;
+
+  // Eigen typedefs
+  using Scalar = SparseQR::Scalar;
+  using RealScalar = SparseQR::RealScalar;
+  using StorageIndex = SparseQR::StorageIndex;
+  using MatrixType = SparseQR::MatrixType;
+  using PermutationType = SparseQR::PermutationType;
+
+  SparseCOD() = default;
+  explicit SparseCOD(const internal::spqr_config &config)
+      : m_isInitialized{false} {
+    configure(config);
+  }
+
+  explicit SparseCOD(const MatrixType &A) : m_isInitialized{true} {
+    compute(A);
+  }
+
+  SparseCOD(const MatrixType &A, const internal::spqr_config &config)
+      : m_isInitialized{true} {
+    configure(config);
+    compute(A);
+  }
+
+  void configure(const internal::spqr_config &config) {
+    internal::spqr_setup(&spqr1, config);
+    internal::spqr_setup(&spqr2, internal::make_deficient_solve_config(config));
+  }
+
+  void compute(const MatrixType &A) {
+    spqr1.compute(A);
+    if (rank_deficient()) {
+      // After we have decomposed A, we QR-factorize the transpose of
+      // the upper-trapezoidal [R S].
+      //
+      // __NB__: I'm not sure about the efficiency ramifications of
+      // transposing a sparse RS factor.  But it is at most cols() *
+      // cols(), so hopefully the impact is not too bad.
+      spqr2.compute(get_sparse_RS(spqr1).transpose());
+    }
+  }
+
+  Index cols() const {
+    eigen_assert(m_isInitialized &&
+                 "The COD should be computed first; call compute()");
+    return spqr1.cols();
+  }
+
+  Index rows() const {
+    eigen_assert(m_isInitialized &&
+                 "The COD should be computed first; call compute()");
+    return spqr1.rows();
+  }
+
+  // Return the SPQR-estimated rank of A.  According to the
+  // __IMPORTANT PRECONDITION__ detailed before _solve_impl(), this
+  // should be the actual rank of A.
+  Index rank() const {
+    eigen_assert(m_isInitialized &&
+                 "The COD should be computed first; call compute()");
+    return spqr1.rank();
+  }
+
+  // Return the rank-deficiency of the problem, i.e. min(rows(A), cols(A)) -
+  // rank(A).  For fully-determined problems, this should be 0.
+  Index deficiency() const { return std::min(rows(), cols()) - rank(); }
+
+  bool rank_deficient() const { return deficiency() > 0; }
+
+  ComputationInfo info() const {
+    eigen_assert(m_isInitialized &&
+                 "The COD should be computed first; call compute()");
+    if (spqr1.info() != Success) {
+      return spqr1.info();
+    }
+    if (rank_deficient()) {
+      return spqr2.info();
+    }
+    return Success;
+  }
+
+  // L \in \mathbb{R}^{r x r}, r = rank(A)
+  //
+  // Also referred to as T in [1]
+  MatrixType matrixL() const {
+    eigen_assert(m_isInitialized &&
+                 "The COD should be computed first; call compute()");
+    return spqr2.matrixR()
+        .topLeftCorner(spqr1.rank(), spqr1.rank())
+        .triangularView<Upper>()
+        .transpose();
+  }
+
+  MatrixXd matrixLDense() const {
+    eigen_assert(m_isInitialized &&
+                 "The COD should be computed first; call compute()");
+    return MatrixXd(matrixL());
+  }
+
+  // Solve Ax = b using the /sparse complete orthogonal decomposition/
+  // (COD).  b may have multiple columns.
+  //
+  // Computing the minimum-norm solution to an underdetermined linear
+  // system using the SVD is not practical for large systems, and
+  // sparsity does not help.  Fortunately we can compute the
+  // minimum-norm solution using the QR decomposition, which can be done
+  // efficiently by leveraging sparsity.
+  //
+  // This code computes the COD by using sparse QR solves, more
+  // efficiently computing the minimum-norm solution of large, sparse
+  // underdetermined linear systems.  The method used is described in
+  // [1].
+  //
+  // __IMPORTANT PRECONDITION__:
+  //
+  //  - The specified pivot threshold must be low enough that the SPQR
+  //    estimate of rank(A) is accurate.  This is unlike the SPQR_COD
+  //    algorithm given in [1], which performs subspace iteration to
+  //    accurately determine rank(A).  If you are confident that SPQR
+  //    will estimate the correct numerical rank for your system, you
+  //    may use this code to avoid the additional work of subspace
+  //    iteration.
+  //
+  // Here is a summary of the COD approach to forming the pseudoinverse
+  // A+ of A:
+  //
+  //     A = Q1 ( P2 [L 0; 0 0] Q2^T ) P1^T
+  //              ^^^^^^^^^^^^^^^^^^
+  //                      R
+  //
+  //     R^T = Q2 [L^T 0; 0 0] P'2^T
+  //
+  //     P2 = blkdiag([P'2 I])
+  //
+  //     A+ = P1 Q2 [L^{-1} 0; 0 0] P2^T Q1^T
+  //
+  // The only term that must be inverted is the lower-triangular `L`
+  // submatrix, and this can be stably and quickly applied to the
+  // right-hand side using triangular substitution.
+  //
+  // [1]
+  // https://people.engr.tamu.edu/davis/publications_files/Reliable_Calculation_of_Numerical_Rank_Null_Space_Bases_Pseudoinverse_Solutions_and_Basic_Solutions_using_SuiteSparseQR.pdf
+  template <typename Rhs, typename Dest>
+  void _solve_impl(const MatrixBase<Rhs> &b, MatrixBase<Dest> &dest) const {
+    eigen_assert(m_isInitialized &&
+                 "The COD should be computed first; call compute()");
+    eigen_assert(b.rows() == rows());
+    if (!rank_deficient()) {
+      // In the full-rank case, just use the outer QR solver to do the
+      // right thing.
+      spqr1._solve_impl(b, dest);
+      return;
+    }
+
+    // Expand P'2 into P2 by appending identity
+    //
+    // Compute the first orthogonal transform c = P2^T * Q1^T * b
+    //
+    // Subsitution solve for the top of z, then pad out the bottom with
+    // zeros (in the null space)
+    MatrixXd z(cols(), b.cols());
+    z.topRows(rank()) = matrixL().triangularView<Lower>().solve(
+        (expandP2(rows()).transpose() * (spqr1.matrixQ().transpose() * b))
+            .topRows(rank()));
+    z.bottomRows(deficiency()) = MatrixXd::Zero(deficiency(), b.cols());
+
+    // Compute the second orthogonal transform P1 * Q2 * z
+    //
+    // __NB__: it's necessary to call the explicit dense matrix
+    // constructor here, or Eigen will be confused and give an assert
+    // about wrong dimensions.
+    dest = spqr1.colsPermutation() * MatrixXd(spqr2.matrixQ() * z);
+  }
+
+  // Returns the outer permutation matrix, corresponding to the one
+  // returned by SPQR(A).colsPermutation().
+  SparsePermutationMatrix colsPermutation() const {
+    eigen_assert(m_isInitialized &&
+                 "The COD should be computed first; call compute()");
+    return spqr1.colsPermutation();
+  }
+
+  PermutationMatrix<Dynamic, Dynamic> colsPermutationDense() const {
+    PermutationMatrix<Dynamic, Dynamic> Pout;
+    Pout.indices() = colsPermutation().indices().cast<int>();
+    return Pout;
+  }
+
+  // Compute R^-T P1^T rhs
+  //
+  // In the rank-deficient case:
+  //
+  //   R^T P2 = Q2 [L 0; 0 0]
+  //
+  //   R^-T = P2 [L^-1 0; 0 0] Q2^T
+  //
+  // so we want P2 z, where
+  //
+  //   z = [L^-1 0; 0 0] Q2^T P1^T rhs
+  MatrixXd Rsolve(const MatrixXd &rhs) {
+    if (!rank_deficient()) {
+      return spqr1.matrixR()
+          .topLeftCorner(rank(), rank())
+          .triangularView<Upper>()
+          .solve(spqr1.colsPermutation() * rhs);
+    }
+
+    Eigen::MatrixXd z(cols(), rhs.cols());
+    z.topRows(rank()) = matrixL().triangularView<Lower>().solve(
+        spqr2.matrixQ().transpose() *
+        Eigen::MatrixXd(spqr1.colsPermutation() * rhs));
+    z.bottomRows(deficiency()) =
+        Eigen::MatrixXd::Zero(deficiency(), rhs.cols());
+    return expandP2(cols()) * z;
+  }
+
+ private:
+  // Expand P'2 (the permutation from the inner QR solve) by appending
+  // identity
+  inline SparsePermutationMatrix expandP2(Index size) const {
+    assert(size >= spqr2.cols());
+    SparsePermutationMatrix P2(size);
+    P2.setIdentity();
+    P2.indices().head(spqr2.cols()) = spqr2.colsPermutation().indices();
+    return P2;
+  }
+
+  inline MatrixType get_sparse_RS(const SparseQR &spqr) const {
+    return spqr.matrixR()
+        .topLeftCorner(spqr.rank(), spqr.cols())
+        .triangularView<Upper>();
+  }
+
+  // We must hold onto these entire objects, because we cannot use the
+  // `Q` factors after they are destructed.  Using SPQR, you can only
+  // get an expression for `Q` and multiply by it; you cannot convert
+  // it to a sparse or dense matrix.
+  SparseQR spqr1;
+  SparseQR spqr2;
+  bool m_isInitialized;
+};
+
+}  // namespace Eigen
+
+#endif // ALBATROSS_EIGEN_SPARSE_COD_H

--- a/include/albatross/src/utils/condition.hpp
+++ b/include/albatross/src/utils/condition.hpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2022 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_UTILS_CONDITION_HPP_
+#define ALBATROSS_UTILS_CONDITION_HPP_
+
+// Unless otherwise stated, the functions in this file are derived
+// from
+//
+//   A Survey of Condition Number Estimation for Triangular Matrices
+//   N J Higham, 1987
+//
+//   http://eprints.ma.man.ac.uk/695/1/high87t.pdf
+//
+// All references to equation and algorithm numbers point to that
+// document.
+//
+// Condition number estimates based on triangular matrices accept
+// `Eigen::TriangularView`s for safety.  The matrix type being viewed
+// is templated mainly to avoid dealing with the const-ness of the
+// nested expression(s).
+
+namespace albatross {
+
+// Estimate the condition number of A based on its upper-triangular
+// factor R.
+//
+// Empirically, this method typically underestimates the true
+// condition number (as measured by the ratio of extremal singular
+// values computed by the full SVD).
+//
+// https://en.wikipedia.org/wiki/Condition_number
+//
+// > If || . || is the matrix norm induced by the L^\inf (vector) norm
+// > and A is lower triangular non-singular (i.e. a i i /= 0 for all
+// > i), then
+// > 
+// >    \kappa(A) >= max_i(|a_{ii}|) / min_i(|a_{ii}|) 
+// > 
+// > recalling that the eigenvalues of any triangular matrix are
+// > simply the diagonal entries.
+// > 
+// > The condition number computed with this norm is generally larger
+// > than the condition number computed relative to the Euclidean
+// > norm, but it can be evaluated more easily (and this is often the
+// > only practicably computable condition number, when the problem to
+// > solve involves a non-linear algebra[clarification needed], for
+// > example when approximating irrational and transcendental
+// > functions or numbers with numerical methods).
+//
+// https://eigen.tuxfamily.org/dox/group__TutorialReductionsVisitorsBroadcasting.html#TutorialReductionsVisitorsBroadcastingReductionsNorm
+template <typename MatrixType>
+inline double estimate_condition_number(
+     const Eigen::TriangularView<MatrixType, Eigen::Upper> &R) {
+  return R.nestedExpression().diagonal().array().abs().maxCoeff() /
+    R.nestedExpression().diagonal().array().abs().minCoeff();
+}
+
+// Algorthm 2.1: Upper-bound |R^{-1}|_\inf using the comparison matrix
+// M.
+//
+// Cost: n^2 / 2 flops
+template <typename MatrixType>
+double upper_bound_R_inv_inf(const Eigen::TriangularView<MatrixType, Eigen::Upper> &R) {
+  Eigen::VectorXd z(R.rows());
+  const Eigen::Index R_last = R.rows() - 1;
+  z.coeffRef(R_last) = 1 / std::abs(R.coeff(R_last, R_last));
+  for (Eigen::Index i = R_last - 1; i >= 0; --i) {
+    const Eigen::Index jsize = R_last - i;
+    assert(jsize > 0 && jsize < R.rows());
+    const double s =
+        1 + Eigen::MatrixXd(R).row(i).tail(jsize).array().abs().matrix().dot(
+                z.tail(jsize));
+    z(i) = s / std::abs(R.coeff(i, i));
+  }
+  return z.maxCoeff();
+}
+
+// Algorithm 2.1: Upper-bound |R^{-1}|_\inf using the comparison matrix
+// M, modified to compute the 1-norm.  Page 579:
+//
+// > Algorithm 2.2 evaluates the \inf-norm of W(T)^{-1}, and the
+// > 1-norm can be evaluated by applying a "lower triangular" version
+// > of the algorithm to T^T (since |A|_1 = |A^T|_\inf).
+//
+// Cost: n^2 / 2 flops
+template <typename MatrixType>
+double upper_bound_R_inv_1(const Eigen::TriangularView<MatrixType, Eigen::Lower> &R) {
+  Eigen::VectorXd z(R.rows());
+  z.coeffRef(0) = 1 / std::abs(R.coeff(0, 0));
+  for (Eigen::Index i = 1; i < R.rows(); ++i) {
+    const double s =
+        1 +
+        Eigen::MatrixXd(R).row(i).tail(i).array().abs().matrix().dot(z.head(i));
+    z(i) = s / std::abs(R.coeff(i, i));
+  }
+  return z.maxCoeff();
+}
+
+// The operator 2-norm requires computing the singular values, but
+// we can upper-bound the operator 2-norm using Equation 1.6:
+//
+// |R|_2 <= sqrt(|R|_1 |R|_\inf)
+template <typename MatrixType>
+double upper_bound_R_2(const Eigen::TriangularView<MatrixType, Eigen::Upper> &R) {
+  const auto Rdense = Eigen::MatrixXd(R);
+  return std::sqrt(Rdense.cwiseAbs().rowwise().sum().maxCoeff() *
+                   Rdense.cwiseAbs().colwise().sum().maxCoeff());
+}
+  
+// Equation 2.4, upper-bounding the 2-norm of the inverse of
+// upper-triangular matrix using \inf-norm and 1-norm
+template <typename MatrixType>
+double upper_bound_R_inv_2(const Eigen::TriangularView<MatrixType, Eigen::Upper> &R) {
+  return std::sqrt(upper_bound_R_inv_inf(R) * upper_bound_R_inv_1(R.transpose()));
+}
+
+// Computes an upper bound on the condition number of A given its
+// upper-triangular factor R.
+//
+// Empirically, this upper bound is quite loose and may approach the
+// square of the true condition number (as measured by the ratio of
+// extremal singular values computed by the full SVD).
+template <typename MatrixType>
+double upper_bound_condition_number(
+       const Eigen::TriangularView<MatrixType, Eigen::Upper> &R) {
+  // Definition of condition number
+  return upper_bound_R_2(R) * upper_bound_R_inv_2(R);
+}
+
+// Compute \kappa_2, the 2-norm condition number of A, given its SVD.
+template <typename MatrixType>
+double condition_number(const Eigen::JacobiSVD<MatrixType> &svd) {
+  return svd.singularValues()(0) /
+    svd.singularValues()(svd.singularValues().size() - 1);
+}
+
+} // namespace albatross
+
+#endif /* ALBATROSS_UTILS_CONDITION_HPP_ */

--- a/include/albatross/utils/LinalgUtils
+++ b/include/albatross/utils/LinalgUtils
@@ -15,5 +15,6 @@
 
 #include "../Common"
 #include "../src/utils/linalg_utils.hpp"
+#include "../src/utils/condition.hpp"
 
 #endif


### PR DESCRIPTION
On a few hundred typical problems ~8000x1000 with a fill of ~0.3, I observed a median speedup of over 5x when using a single thread.  4 threads gave a speedup of over 7x.