### PR TITLE
Stricter Composition Rules

### DIFF
--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -248,8 +248,8 @@ public:
    * this will return the sum of the two.
    */
   template <typename X, typename Y,
-            typename std::enable_if<(has_valid_caller<LHS, X, Y>::value &&
-                                     has_valid_caller<RHS, X, Y>::value),
+            typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
+                                     has_equivalent_caller<RHS, X, Y>::value),
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->lhs_(x, y) + this->rhs_(x, y);
@@ -259,8 +259,8 @@ public:
    * If only LHS has a valid call method we ignore R.
    */
   template <typename X, typename Y,
-            typename std::enable_if<(has_valid_caller<LHS, X, Y>::value &&
-                                     !has_valid_caller<RHS, X, Y>::value),
+            typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
+                                     !has_equivalent_caller<RHS, X, Y>::value),
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->lhs_(x, y);
@@ -270,8 +270,8 @@ public:
    * If only RHS has a valid call method we ignore L.
    */
   template <typename X, typename Y,
-            typename std::enable_if<(!has_valid_caller<LHS, X, Y>::value &&
-                                     has_valid_caller<RHS, X, Y>::value),
+            typename std::enable_if<(!has_equivalent_caller<LHS, X, Y>::value &&
+                                     has_equivalent_caller<RHS, X, Y>::value),
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->rhs_(x, y);
@@ -339,8 +339,8 @@ public:
    * this will return the product of the two.
    */
   template <typename X, typename Y,
-            typename std::enable_if<(has_valid_caller<LHS, X, Y>::value &&
-                                     has_valid_caller<RHS, X, Y>::value),
+            typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
+                                     has_equivalent_caller<RHS, X, Y>::value),
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     double output = this->lhs_(x, y);
@@ -354,8 +354,8 @@ public:
    * If only LHS has a valid call method we ignore R.
    */
   template <typename X, typename Y,
-            typename std::enable_if<(has_valid_caller<LHS, X, Y>::value &&
-                                     !has_valid_caller<RHS, X, Y>::value),
+            typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
+                                     !has_equivalent_caller<RHS, X, Y>::value),
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->lhs_(x, y);
@@ -365,8 +365,8 @@ public:
    * If only RHS has a valid call method we ignore L.
    */
   template <typename X, typename Y,
-            typename std::enable_if<(!has_valid_caller<LHS, X, Y>::value &&
-                                     has_valid_caller<RHS, X, Y>::value),
+            typename std::enable_if<(!has_equivalent_caller<LHS, X, Y>::value &&
+                                     has_equivalent_caller<RHS, X, Y>::value),
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->rhs_(x, y);

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -246,6 +246,24 @@ public:
   /*
    * If both LHS and RHS have a valid call method for the types X and Y
    * this will return the sum of the two.
+   *
+   * Note that we don't use has_valid_caller which is going to look for any
+   * of a large number of complicated composite types, we only care about
+   * directly equivalent calls (such as symmetric definitions, or the use
+   * of the Measurement<> wrapper, see traits.hpp). This is to avoid
+   * polution of the instantiated methods.  If, for example, we used
+   * has_valid_caller here summing two functions would result in the
+   * instantiation of methods such as:
+   *
+   *   double _call_impl(const LinearCombination<X> &x,
+   *                     const variant<X, Y> &y) const;
+   *
+   * which doesn't neccesarily breaking anything, but those sorts of
+   * equivalencies are meant to be managed by the CovarianceFunction::call
+   * method above. Instead we only want summing (and product etc ...)
+   * to instantiate the minimal number of _call_impl methods and we
+   * then consolidate any of the composite type management to the
+   * highest level calls.
    */
   template <typename X, typename Y,
             typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&

--- a/include/albatross/src/covariance_functions/scaling_function.hpp
+++ b/include/albatross/src/covariance_functions/scaling_function.hpp
@@ -145,8 +145,8 @@ public:
    * this will return the product of the two.
    */
   template <typename X, typename Y,
-            typename std::enable_if<(has_valid_caller<LHS, X, Y>::value &&
-                                     has_valid_caller<RHS, X, Y>::value),
+            typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
+                                     has_equivalent_caller<RHS, X, Y>::value),
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     double output = this->lhs_(x, y);
@@ -160,8 +160,8 @@ public:
    * If only RHS has a valid call method we ignore L.
    */
   template <typename X, typename Y,
-            typename std::enable_if<(!has_valid_caller<LHS, X, Y>::value &&
-                                     has_valid_caller<RHS, X, Y>::value),
+            typename std::enable_if<(!has_equivalent_caller<LHS, X, Y>::value &&
+                                     has_equivalent_caller<RHS, X, Y>::value),
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->rhs_(x, y);
@@ -207,8 +207,8 @@ public:
    * this will return the product of the two.
    */
   template <typename X, typename Y,
-            typename std::enable_if<(has_valid_caller<LHS, X, Y>::value &&
-                                     has_valid_caller<RHS, X, Y>::value),
+            typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
+                                     has_equivalent_caller<RHS, X, Y>::value),
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     double output = this->lhs_(x, y);
@@ -222,8 +222,8 @@ public:
    * If only LHS has a valid call method we ignore R.
    */
   template <typename X, typename Y,
-            typename std::enable_if<(has_valid_caller<LHS, X, Y>::value &&
-                                     !has_valid_caller<RHS, X, Y>::value),
+            typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
+                                     !has_equivalent_caller<RHS, X, Y>::value),
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->lhs_(x, y);

--- a/tests/test_covariance_function.cc
+++ b/tests/test_covariance_function.cc
@@ -191,6 +191,37 @@ TEST(test_covariance_function, test_caller_ordering) {
   EXPECT_EQ(cov(x, sum_of_two_ys), x_sum_of_two_ys);
 }
 
+TEST(test_covariance_function, test_linear_combo_variants) {
+  using ComboOfVariant = LinearCombination<variant<X, Y>>;
+  using ComplicatedFeature = variant<X, Y, variant<X, Y>, LinearCombination<Y>,
+                                     LinearCombination<variant<X, Y>>>;
+
+  const HasMultiple cov;
+
+  const ComplicatedFeature x = X();
+
+  const Y y;
+  const std::vector<Y> two_ys = {Y(), Y()};
+  const LinearCombination<Y> y_y(two_ys);
+
+  const std::vector<variant<X, Y>> vec_y_y = {Y(), Y()};
+  const ComboOfVariant vy_vy(vec_y_y);
+
+  const std::vector<variant<X, Y>> vec_y_x = {Y(), X()};
+  const ComboOfVariant vy_vx(vec_y_x);
+
+  const std::vector<variant<X, Y>> vec_x = {X()};
+  const ComboOfVariant vx(vec_x);
+
+  const double cov_x_y = cov(x, y);
+  const double cov_x_yy = 2 * cov(x, y);
+  const double cov_yy_xy = 2 * cov(y, x) + 2 * cov(y, y);
+
+  EXPECT_EQ(cov(vx, y), cov_x_y);
+  EXPECT_EQ(cov(x, y_y), cov_x_yy);
+  EXPECT_EQ(cov(vy_vy, vy_vx), cov_yy_xy);
+}
+
 TEST(test_covariance_function, test_linear_combinations) {
   HasMultiple cov_func;
   X x;

--- a/tests/test_gp.cc
+++ b/tests/test_gp.cc
@@ -452,4 +452,34 @@ TEST(test_gp, test_get_prior) {
   EXPECT_EQ(prior.mean, mean);
 }
 
+TEST(test_gp, test_predict_with_complicated_feature) {
+
+  MakeGaussianProcessWithMean gp_with_mean_case;
+
+  const auto dataset = gp_with_mean_case.get_dataset();
+  const auto model = gp_with_mean_case.get_model();
+
+  using ComplexType =
+      variant<double, Eigen::VectorXd,
+              LinearCombination<variant<double, Eigen::VectorXd>>>;
+
+  const auto prior = model.prior(dataset.features);
+
+  std::vector<variant<double, Eigen::VectorXd>> vec = {1.0, 2.0};
+  LinearCombination<variant<double, Eigen::VectorXd>> sum(vec);
+  std::vector<ComplexType> features = {1.0, 2.0, sum};
+
+  const auto pred = model.fit(dataset).predict(features).joint();
+
+  Eigen::Vector3d for_sum;
+  for_sum << 1., 1., 0;
+
+  const double expected_mean = for_sum.transpose() * pred.mean;
+  const double expected_variance =
+      for_sum.transpose() * pred.covariance * for_sum;
+
+  EXPECT_NEAR(expected_mean, pred.mean[2], 1e-6);
+  EXPECT_NEAR(expected_variance, pred.covariance(2, 2), 1e-6);
+}
+
 } // namespace albatross

--- a/tests/test_traits_covariance_functions.cc
+++ b/tests/test_traits_covariance_functions.cc
@@ -57,6 +57,39 @@ TEST(test_traits_covariance, test_has_valid_call_impl) {
   EXPECT_FALSE(bool(has_valid_call_impl<HasMultiple, Z, Z>::value));
 }
 
+TEST(test_traits_covariance, test_has_equivalent_caller) {
+  EXPECT_TRUE(bool(has_equivalent_caller<HasPublicCallImpl, X, Y>::value));
+  EXPECT_TRUE(bool(has_equivalent_caller<HasPublicCallImpl, Y, X>::value));
+  EXPECT_TRUE(bool(has_equivalent_caller<HasMultiple, X, X>::value));
+  EXPECT_TRUE(bool(has_equivalent_caller<HasMultiple, Y, Y>::value));
+  EXPECT_FALSE(bool(has_equivalent_caller<HasMultiple, Z, X>::value));
+  EXPECT_FALSE(bool(has_equivalent_caller<HasMultiple, Z, Y>::value));
+  EXPECT_FALSE(bool(has_equivalent_caller<HasMultiple, Z, Z>::value));
+
+  EXPECT_TRUE(
+      bool(has_equivalent_caller<HasPublicCallImpl, Measurement<X>, Y>::value));
+  EXPECT_TRUE(
+      bool(has_equivalent_caller<HasPublicCallImpl, Y, Measurement<X>>::value));
+  EXPECT_TRUE(bool(has_equivalent_caller<HasPublicCallImpl, Measurement<Y>,
+                                         Measurement<X>>::value));
+
+  EXPECT_TRUE(
+      bool(has_equivalent_caller<HasMultiple, Measurement<X>, Y>::value));
+  EXPECT_TRUE(
+      bool(has_equivalent_caller<HasMultiple, Y, Measurement<X>>::value));
+  EXPECT_TRUE(bool(has_equivalent_caller<HasMultiple, Measurement<Y>,
+                                         Measurement<X>>::value));
+
+  EXPECT_FALSE(
+      bool(has_equivalent_caller<HasMultiple, Measurement<Z>, X>::value));
+  EXPECT_FALSE(
+      bool(has_equivalent_caller<HasMultiple, Z, Measurement<Y>>::value));
+  EXPECT_FALSE(
+      bool(has_equivalent_caller<HasMultiple, Z, Measurement<Z>>::value));
+  EXPECT_FALSE(bool(has_equivalent_caller<HasMultiple, Measurement<Z>,
+                                          Measurement<Z>>::value));
+}
+
 /*
  * Here we test to make sure we can identify situations where
  * _call_impl( has been defined but not necessarily properly.


### PR DESCRIPTION
This PR handles a subtle unintended behavior in the templating logic which deals with sums, products and scalings of covariance functions. On master we end up defining far more templated methods than we technically need which can lead to some confusing results if you try to ask which methods are supported by a composition of covariance functions.  Examples should help.

Consider the case where you define two covariance functions,
```
class Foo : public CovarianceFunction<Foo> {
public:
  double _call_impl(const X &, const X &) const;
};

class Bar : public CovarianceFunction<Bar> {
public:
  double _call_impl(const X &, const X &) const;
};
```
Notice that they are each defined (only) for type `X`.  Now you can instantiate two and sum them,
```
Foo foo;
Bar bar;
const auto sum = foo + bar;
```
The expected outcome _ideally_ would be the equivalent of:
```
class Sum : public CovarianceFunction<Sum> {
public:
  double _call_impl(const X &a, const X &b) const {
    return foo(a, b) + sum(a, b);
  }
};
```
but on master you'd actually be able to evaluate `_call_impl` with composite types such as:
```
LinearCombination<X> combo;
variant<X, Y> variant;
sum._call_impl(combo, variant);
```
This isn't really a bug, we ultimately do want to be able to call `sum` with these types, but I don't think we want to define the `_call_impl` for these types and would rather leave it to the `CovarianceFunction::call` logic to realize you can do so.  In otherwords we want to be able to do:
```
sum(combo, variant);
```
but don't want to be able to do:
```
sum._call_impl(combo, variant);
```
(not that a user should never be using `_call_impl`, but even internal to albatross I don't think we want to be able to do so).
