### PR TITLE
Add Nugget Covariance Function

### DIFF
--- a/include/albatross/CovarianceFunctions
+++ b/include/albatross/CovarianceFunctions
@@ -31,6 +31,7 @@
 #include <albatross/src/covariance_functions/linear_combination.hpp>
 #include <albatross/src/covariance_functions/distance_metrics.hpp>
 #include <albatross/src/covariance_functions/noise.hpp>
+#include <albatross/src/covariance_functions/nugget.hpp>
 #include <albatross/src/covariance_functions/polynomials.hpp>
 #include <albatross/src/covariance_functions/radial.hpp>
 #include <albatross/src/covariance_functions/scaling_function.hpp>

--- a/include/albatross/src/covariance_functions/noise.hpp
+++ b/include/albatross/src/covariance_functions/noise.hpp
@@ -14,6 +14,7 @@
 #define ALBATROSS_COVARIANCE_FUNCTIONS_NOISE_H
 
 constexpr double default_sigma_noise = 0.1;
+constexpr double default_nugget_noise = 1e-8;
 
 namespace albatross {
 
@@ -45,6 +46,26 @@ public:
     }
   }
 };
+
+class Nugget : public CovarianceFunction<Nugget> {
+public:
+  ALBATROSS_DECLARE_PARAMS(nugget_sigma);
+
+  std::string get_name() const { return "nugget"; }
+
+  Nugget() { nugget_sigma = {default_nugget_noise, FixedPrior()}; };
+
+  template <typename X,
+            typename std::enable_if_t<is_basic_type<X>::value, int> = 0>
+  double _call_impl(const X &x, const X &y) const {
+    if (x == y) {
+      return nugget_sigma.value * nugget_sigma.value;
+    } else {
+      return 0.;
+    }
+  }
+};
+
 } // namespace albatross
 
 #endif

--- a/include/albatross/src/covariance_functions/noise.hpp
+++ b/include/albatross/src/covariance_functions/noise.hpp
@@ -14,7 +14,6 @@
 #define ALBATROSS_COVARIANCE_FUNCTIONS_NOISE_H
 
 constexpr double default_sigma_noise = 0.1;
-constexpr double default_nugget_noise = 1e-8;
 
 namespace albatross {
 
@@ -41,25 +40,6 @@ public:
   double _call_impl(const Observed &x, const Observed &y) const {
     if (x == y) {
       return sigma_independent_noise.value * sigma_independent_noise.value;
-    } else {
-      return 0.;
-    }
-  }
-};
-
-class Nugget : public CovarianceFunction<Nugget> {
-public:
-  ALBATROSS_DECLARE_PARAMS(nugget_sigma);
-
-  std::string get_name() const { return "nugget"; }
-
-  Nugget() { nugget_sigma = {default_nugget_noise, FixedPrior()}; };
-
-  template <typename X,
-            typename std::enable_if_t<is_basic_type<X>::value, int> = 0>
-  double _call_impl(const X &x, const X &y) const {
-    if (x == y) {
-      return nugget_sigma.value * nugget_sigma.value;
     } else {
       return 0.;
     }

--- a/include/albatross/src/covariance_functions/nugget.hpp
+++ b/include/albatross/src/covariance_functions/nugget.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_COVARIANCE_FUNCTIONS_NUGGET_H
+#define ALBATROSS_COVARIANCE_FUNCTIONS_NUGGET_H
+
+constexpr double default_nugget_noise = 1e-8;
+
+namespace albatross {
+
+/*
+ * A nugget applies a small amount of noise to all feature types
+ * with the intention of preserving positive definite matrices
+ * even in the case where some of the features involved are
+ * perfectly correlated. This difference slightly from IndependentNoise
+ * which applies noise only to a specific FeatureType.  Here
+ * we apply it to any "basic" FeatureType (where basic is meant
+ * to mean we don't apply it to composite types (such as LinearCombination)
+ * which should instead have a nugget applied to each of the
+ * sub features which make up the composite.
+ */
+
+class Nugget : public CovarianceFunction<Nugget> {
+public:
+  ALBATROSS_DECLARE_PARAMS(nugget_sigma);
+
+  std::string get_name() const { return "nugget"; }
+
+  Nugget() { nugget_sigma = {default_nugget_noise, FixedPrior()}; };
+
+  template <typename X,
+            typename std::enable_if_t<is_basic_type<X>::value, int> = 0>
+  double _call_impl(const X &x, const X &y) const {
+    if (x == y) {
+      return nugget_sigma.value * nugget_sigma.value;
+    } else {
+      return 0.;
+    }
+  }
+};
+
+} // namespace albatross
+
+#endif

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -226,6 +226,25 @@ struct has_valid_variant_mean_caller<U, Caller, variant<A, Ts...>,
       has_valid_variant_mean_caller<U, Caller, variant<Ts...>>::value;
 };
 
+/*
+ * Sometimes we need to distinguish between raw types for which we would
+ * explicitly write covariance function _call_impl methods and wrapped
+ * types which get handled by the callers.hpp logic.  For example, if
+ * you write a covariance function with _call_impl(X, X) you don't need
+ * to also write one which handles LinearCombination<X> types, that is
+ * handled by default inside the caller logic. Here we add a trait to
+ * be able to distinguish between a basic type and a composite type.
+ */
+template <typename X> struct is_basic_type : std::true_type {};
+
+template <typename X>
+struct is_basic_type<LinearCombination<X>> : std::false_type {};
+
+template <typename X> struct is_basic_type<Measurement<X>> : std::false_type {};
+
+template <typename... Ts>
+struct is_basic_type<variant<Ts...>> : std::false_type {};
+
 } // namespace albatross
 
 #endif

--- a/tests/test_traits_covariance_functions.cc
+++ b/tests/test_traits_covariance_functions.cc
@@ -71,6 +71,22 @@ TEST(test_traits_covariance, test_has_possible_call_impl) {
   EXPECT_TRUE(bool(has_possible_call_impl<HasMultiple, Z, Z>::value));
 }
 
+TEST(test_traits_covariance, test_is_basic_type) {
+
+  struct Foo {};
+
+  EXPECT_TRUE(bool(is_basic_type<int>::value));
+  EXPECT_TRUE(bool(is_basic_type<double>::value));
+  EXPECT_TRUE(bool(is_basic_type<Foo>::value));
+
+  EXPECT_FALSE(bool(is_basic_type<variant<int>>::value));
+  EXPECT_FALSE(bool(is_basic_type<variant<int, double, Foo>>::value));
+  EXPECT_FALSE(bool(is_basic_type<LinearCombination<int>>::value));
+  EXPECT_FALSE(bool(is_basic_type<LinearCombination<Foo>>::value));
+  EXPECT_FALSE(bool(is_basic_type<Measurement<int>>::value));
+  EXPECT_FALSE(bool(is_basic_type<Measurement<Foo>>::value));
+}
+
 TEST(test_traits_covariance, test_has_invalid_call_impl) {
   EXPECT_FALSE(bool(has_invalid_call_impl<HasPublicCallImpl, X, Y>::value));
   EXPECT_FALSE(bool(has_invalid_call_impl<HasPublicCallImpl, Y, X>::value));


### PR DESCRIPTION
We've used this `Nugget` covariance function in packages which depend on albatross, but it seems like it should live directly in albatross.

The only real difference between this and the `IndependentNoise<X>` covariance function is that the nugget applies across the board to all features, while the `IndpendentNoise<X>` only evaluates non-zero for `X`.