### PR TITLE
Dense/Sparse Matrix by Distribution Multiplication

### DIFF
--- a/include/albatross/Common
+++ b/include/albatross/Common
@@ -18,6 +18,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Dense>
+#include <Eigen/Sparse>
 
 #include <mapbox/variant.hpp>
 

--- a/include/albatross/Distribution
+++ b/include/albatross/Distribution
@@ -16,5 +16,7 @@
 #include "Common"
 
 #include <albatross/src/core/distribution.hpp>
+#include <albatross/src/eigen/serializable_ldlt.hpp>
+#include <albatross/src/core/transformed_distribution.hpp>
 
 #endif

--- a/include/albatross/src/core/distribution.hpp
+++ b/include/albatross/src/core/distribution.hpp
@@ -60,6 +60,7 @@ struct is_distribution : public std::is_base_of<DistributionBase<T>, T> {};
 struct MarginalDistribution : public DistributionBase<MarginalDistribution> {
 
   using Base = DistributionBase<MarginalDistribution>;
+  using CovarianceType = DiagonalMatrixXd;
 
   MarginalDistribution(){};
 
@@ -102,10 +103,6 @@ struct MarginalDistribution : public DistributionBase<MarginalDistribution> {
     return (mean == other.mean && covariance == other.covariance);
   }
 
-  JointDistribution operator*(const Eigen::MatrixXd &mat) const;
-
-  JointDistribution operator*(const Eigen::VectorXd &mat) const;
-
   MarginalDistribution operator+(const MarginalDistribution &other) const {
     return MarginalDistribution(
         mean + other.mean, covariance.diagonal() + other.covariance.diagonal());
@@ -135,12 +132,13 @@ struct MarginalDistribution : public DistributionBase<MarginalDistribution> {
                           &covariance.diagonal());
   }
 
-  DiagonalMatrixXd covariance;
+  CovarianceType covariance;
 };
 
 struct JointDistribution : public DistributionBase<JointDistribution> {
 
   using Base = DistributionBase<JointDistribution>;
+  using CovarianceType = Eigen::MatrixXd;
 
   JointDistribution(){};
 
@@ -169,14 +167,6 @@ struct JointDistribution : public DistributionBase<JointDistribution> {
 
   bool operator==(const JointDistribution &other) const {
     return (mean == other.mean && covariance == other.covariance);
-  }
-
-  JointDistribution operator*(const Eigen::MatrixXd &mat) const {
-    return JointDistribution(mat * mean, mat * covariance * mat.transpose());
-  }
-
-  JointDistribution operator*(const Eigen::VectorXd &vector) const {
-    return JointDistribution(vector.dot(mean), vector.dot(covariance * vector));
   }
 
   JointDistribution operator*(double scale) const {
@@ -215,18 +205,8 @@ struct JointDistribution : public DistributionBase<JointDistribution> {
     return MarginalDistribution(mean, covariance.diagonal());
   }
 
-  Eigen::MatrixXd covariance;
+  CovarianceType covariance;
 };
-
-inline JointDistribution
-MarginalDistribution::operator*(const Eigen::MatrixXd &mat) const {
-  return JointDistribution(mat * mean, mat * covariance * mat.transpose());
-}
-
-inline JointDistribution
-MarginalDistribution::operator*(const Eigen::VectorXd &vector) const {
-  return JointDistribution(vector.dot(mean), vector.dot(covariance * vector));
-}
 
 template <typename SizeType, typename DistributionType>
 inline DistributionType subset(const DistributionBase<DistributionType> &dist,

--- a/include/albatross/src/core/transformed_distribution.hpp
+++ b/include/albatross/src/core/transformed_distribution.hpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2022 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CORE_TRANSFORMED_DISTRIBUTION_H
+#define ALBATROSS_CORE_TRANSFORMED_DISTRIBUTION_H
+
+// Make it possible to premultiply matrices by distributions. There are a few
+// things a user might want as a result, on one hand an arbitrary matrix by a
+// distribution (marginal or joint) should result in a joint distribution.  In
+// otherwords even if you start with independent variables (marginal)
+// multiplying by a matrix will likely introduce correlations (joint).
+// Considering only this case it would be tempting to write a multiplication
+// operator which looks like:
+//
+//   JointDistribution operator*(const MatrixType &lhs,
+//                               const MarginalDistrbution &rhs);
+//
+// However, if the user knows the result will stay independent, or if they
+// don't care about the resulting correlations, they may only want the
+// marginal distribution.  Here we add a TransformedDistribution helper
+// class which makes the multiplication lazy and leaves it up to the
+// user to decide what they want, enabling operations like:
+//
+//   MarginalDistribution x = (matrix * dist).marginal();
+//   JointDistribution x = (matrix * dist).joint();
+namespace albatross {
+
+namespace details {
+
+template <typename X> inline auto diagonal_wrapper(X &x) {
+  return Eigen::DiagonalWrapper<X>(x);
+}
+
+template <typename MatrixType, typename DiagType>
+inline Eigen::MatrixXd
+product_sqrt(const Eigen::MatrixBase<MatrixType> &matrix,
+             const Eigen::DiagonalBase<DiagType> &diag_matrix) {
+
+  return matrix.derived() *
+         diagonal_wrapper(diag_matrix.diagonal().array().sqrt().eval());
+}
+
+template <typename Lhs, typename Rhs>
+inline Eigen::MatrixXd product_sqrt(const Eigen::MatrixBase<Lhs> &lhs,
+                                    const Eigen::MatrixBase<Rhs> &rhs) {
+  return lhs.derived() *
+         Eigen::SerializableLDLT(rhs).sqrt_transpose().transpose();
+}
+
+template <typename MatrixType, typename DiagType>
+inline Eigen::MatrixXd
+product_sqrt(const Eigen::SparseMatrixBase<MatrixType> &matrix,
+             const Eigen::DiagonalBase<DiagType> &diag_matrix) {
+  return matrix.derived() *
+         diagonal_wrapper(diag_matrix.diagonal().array().sqrt().eval());
+}
+
+template <typename SparseType, typename MatrixType>
+inline Eigen::MatrixXd
+product_sqrt(const Eigen::SparseMatrixBase<SparseType> &lhs,
+             const Eigen::MatrixBase<MatrixType> &rhs) {
+  return lhs.derived() *
+         Eigen::SerializableLDLT(rhs).sqrt_transpose().transpose();
+}
+
+template <typename MatrixType, typename DistributionType>
+struct TransformedDistribution {
+
+  TransformedDistribution(
+      const Eigen::MatrixBase<MatrixType> &matrix,
+      const albatross::DistributionBase<DistributionType> &distribution)
+      : mean(matrix.derived() * distribution.mean),
+        covariance_product(matrix.derived(),
+                           distribution.derived().covariance) {}
+
+  TransformedDistribution(
+      const Eigen::SparseMatrixBase<MatrixType> &matrix,
+      const albatross::DistributionBase<DistributionType> &distribution)
+      : mean(matrix.derived() * distribution.mean),
+        covariance_product(matrix.derived(),
+                           distribution.derived().covariance) {}
+
+  MarginalDistribution marginal() const {
+    const auto partial_variance =
+        product_sqrt(covariance_product.lhs(), covariance_product.rhs());
+    const Eigen::VectorXd variance =
+        partial_variance.array().square().rowwise().sum();
+    return MarginalDistribution(mean, variance);
+  }
+
+  JointDistribution joint() const {
+    const auto partial_variance =
+        product_sqrt(covariance_product.lhs(), covariance_product.rhs());
+    return JointDistribution(mean,
+                             partial_variance * partial_variance.transpose());
+  }
+
+  operator MarginalDistribution() const { return marginal(); }
+
+  operator JointDistribution() const { return joint(); }
+
+  Eigen::VectorXd mean;
+  Eigen::Product<MatrixType, typename DistributionType::CovarianceType>
+      covariance_product;
+};
+
+} // namespace details
+
+} // namespace albatross
+
+template <typename MatrixType, typename DistributionType>
+inline auto
+operator*(const Eigen::MatrixBase<MatrixType> &matrix,
+          const albatross::DistributionBase<DistributionType> &distribution) {
+  return albatross::details::TransformedDistribution<MatrixType,
+                                                     DistributionType>(
+      matrix, distribution);
+}
+
+template <typename MatrixType, typename DistributionType>
+inline auto
+operator*(const Eigen::SparseMatrixBase<MatrixType> &matrix,
+          const albatross::DistributionBase<DistributionType> &distribution) {
+  return albatross::details::TransformedDistribution<MatrixType,
+                                                     DistributionType>(
+      matrix, distribution);
+}
+
+#endif

--- a/tests/test_core_distribution.cc
+++ b/tests/test_core_distribution.cc
@@ -55,7 +55,6 @@ TYPED_TEST_P(DistributionTest, test_multiply_with_matrix_joint) {
   const auto dist = test_case.create();
 
   Eigen::MatrixXd mat = Eigen::MatrixXd::Random(dist.size() - 1, dist.size());
-  mat = Eigen::MatrixXd::Identity(dist.size(), dist.size());
 
   const auto transformed_distribution = (mat * dist).joint();
   const JointDistribution alternate = mat * dist;


### PR DESCRIPTION
This adds the ability to lazily multiply a matrix by a distribution, then decide whether you'd like the result to be a joint distribution or a marginal distribution (in which case the laziness lets you save computations).  They syntax looks like this,

```
MarginalDistribution transformed = (matrix * distribution).marginal();
JointDistribution transformed = (matrix * distribution).joint();
```

It also enables multiplication with sparse matrices. In a future PR I'd like to use this to be able to do sparse transformations of datasets:

```
RegressionDataset<LinearCombination<X>> transformed = T * x_dataset;
```

which would make it a lot easier to build a single transformation and apply it not only to a dataset (which internally has a MarginalDistribution) but also to any corresponding predictions, for example:

```
compute_likelihood(diff_operator * dataset.targets,
                   diff_operator * model.predict(dataset.features).joint())
```