### PR TITLE
Add methods to fill a covariance matrix by group with async

### DIFF
--- a/include/albatross/Indexing
+++ b/include/albatross/Indexing
@@ -23,5 +23,6 @@
 #include "utils/AsyncUtils"
 
 #include <albatross/src/indexing/group_by.hpp>
+#include <albatross/src/indexing/covariance.hpp>
 
 #endif

--- a/include/albatross/src/indexing/covariance.hpp
+++ b/include/albatross/src/indexing/covariance.hpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2022 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_INDEXING_COVARIANCE_H
+#define ALBATROSS_INDEXING_COVARIANCE_H
+
+namespace albatross {
+
+namespace details {
+
+template <typename CovFuncCaller, typename X, typename Y>
+inline void fill_covariance_subset(CovFuncCaller caller,
+                                   const std::vector<X> &xs,
+                                   const std::vector<std::size_t> &x_inds,
+                                   const std::vector<Y> &ys,
+                                   const std::vector<std::size_t> &y_inds,
+                                   Eigen::MatrixXd *C) {
+  static_assert(is_invocable<CovFuncCaller, X, Y>::value,
+                "caller does not support the required arguments");
+  static_assert(is_invocable_with_result<CovFuncCaller, double, X, Y>::value,
+                "caller does not return a double");
+  Eigen::Index m = static_cast<Eigen::Index>(xs.size());
+  Eigen::Index n = static_cast<Eigen::Index>(ys.size());
+
+  Eigen::Index i, j, ci, cj;
+  std::size_t si, sj;
+  for (i = 0; i < m; i++) {
+    si = static_cast<std::size_t>(i);
+    ci = static_cast<Eigen::Index>(x_inds[si]);
+    for (j = 0; j < n; j++) {
+      sj = static_cast<std::size_t>(j);
+      cj = static_cast<Eigen::Index>(y_inds[sj]);
+      (*C)(ci, cj) = caller(xs[si], ys[sj]);
+    }
+  }
+}
+
+template <typename CovFuncCaller, typename X>
+inline void fill_covariance_subset(CovFuncCaller caller,
+                                   const std::vector<X> &xs,
+                                   const std::vector<std::size_t> &x_inds,
+                                   Eigen::MatrixXd *C) {
+  static_assert(is_invocable<CovFuncCaller, X, X>::value,
+                "caller does not support the required arguments");
+  static_assert(is_invocable_with_result<CovFuncCaller, double, X, X>::value,
+                "caller does not return a double");
+  Eigen::Index n = static_cast<Eigen::Index>(xs.size());
+
+  Eigen::Index i, j, ci, cj;
+  std::size_t si, sj;
+  for (i = 0; i < n; i++) {
+    si = static_cast<std::size_t>(i);
+    ci = static_cast<Eigen::Index>(x_inds[si]);
+    for (j = 0; j <= i; j++) {
+      sj = static_cast<std::size_t>(j);
+      cj = static_cast<Eigen::Index>(x_inds[sj]);
+      (*C)(ci, cj) = caller(xs[si], xs[sj]);
+      (*C)(cj, ci) = (*C)(ci, cj);
+    }
+  }
+}
+
+} // namespace details
+
+template <
+    typename CovFuncCaller, typename Grouper, typename X, typename Y,
+    typename std::enable_if_t<details::is_valid_grouper<Grouper, X>::value &&
+                                  details::is_valid_grouper<Grouper, Y>::value,
+                              int> = 0>
+inline Eigen::MatrixXd compute_covariance_by_group(CovFuncCaller caller,
+                                                   Grouper grouper,
+                                                   const std::vector<X> &xs,
+                                                   const std::vector<Y> &ys) {
+  Eigen::MatrixXd C(xs.size(), ys.size());
+  const auto y_indexers = group_by(ys, grouper).indexers();
+
+  auto fill_block = [&caller, &xs, &ys, &C](const auto &x_inds,
+                                            const auto &y_inds) {
+    details::fill_covariance_subset(caller, subset(xs, x_inds), x_inds,
+                                    subset(ys, y_inds), y_inds, &C);
+  };
+
+  auto fill_row = [&](const auto &x_key, const auto &x_inds) {
+    for (const auto &y_pair : y_indexers) {
+      fill_block(x_inds, y_pair.second);
+    }
+  };
+
+  const auto x_indexers = group_by(xs, grouper).indexers();
+  async_apply(x_indexers, fill_row);
+  return C;
+}
+
+template <typename CovFuncCaller, typename Grouper, typename X,
+          typename std::enable_if_t<
+              details::is_valid_grouper<Grouper, X>::value, int> = 0>
+inline Eigen::MatrixXd compute_covariance_by_group(CovFuncCaller caller,
+                                                   Grouper grouper,
+                                                   const std::vector<X> &xs) {
+  Eigen::MatrixXd C(xs.size(), xs.size());
+  const auto x_indexers = group_by(xs, grouper).indexers();
+
+  auto fill_row = [&](const auto &x_key, const auto &x_inds) {
+    for (const auto &y_pair : x_indexers) {
+      const auto &y_inds = y_pair.second;
+      if (x_key < y_pair.first) {
+        // Lower triangle case, fill then copy
+        details::fill_covariance_subset(caller, subset(xs, x_inds), x_inds,
+                                        subset(xs, y_inds), y_inds, &C);
+        for (const auto &x_ind : x_inds) {
+          for (const auto &y_ind : y_inds) {
+            C(y_ind, x_ind) = C(x_ind, y_ind);
+          }
+        }
+      } else if (x_key == y_pair.first) {
+        // Diagonal case, fill both triangles directly
+        details::fill_covariance_subset(caller, subset(xs, x_inds), x_inds, &C);
+      }
+    }
+  };
+
+  async_apply(x_indexers, fill_row);
+
+  return C;
+}
+
+} // namespace albatross
+
+#endif

--- a/include/albatross/src/indexing/subset.hpp
+++ b/include/albatross/src/indexing/subset.hpp
@@ -152,7 +152,7 @@ inline void set_subset(const Eigen::VectorXd &from,
 }
 
 /*
- * Set a subset of an Eigen::Vector.  If this worked it'd be
+ * Set a subset of an Eigen::DiagonalMatrix.  If this worked it'd be
  * the equivalent of:
  *
  *     to[indices] = from;

--- a/tests/test_covariance_functions.cc
+++ b/tests/test_covariance_functions.cc
@@ -13,8 +13,10 @@
 
 #include <albatross/Core>
 #include <albatross/CovarianceFunctions>
+#include <albatross/Indexing>
 
 #include "test_covariance_utils.h"
+#include "test_models.h"
 
 namespace albatross {
 
@@ -206,6 +208,34 @@ TYPED_TEST(TestDoubleCovarianceFunctions, works_with_eigen) {
   assert(C.cols() == x_size);
   // Make sure C is positive definite.
   C.inverse();
+}
+
+TYPED_TEST(TestDoubleCovarianceFunctions, compute_covariance_by_group) {
+  const std::vector<double> features = {0., 1., 2., 4., 5., 7., 11., 15., 21.};
+
+  LeaveOneIntervalOut grouper;
+
+  const Eigen::MatrixXd by_group =
+      compute_covariance_by_group(this->covariance_function, grouper, features);
+
+  Eigen::MatrixXd expected = this->covariance_function(features);
+
+  EXPECT_EQ(by_group, expected);
+}
+
+TYPED_TEST(TestDoubleCovarianceFunctions,
+           compute_covariance_by_group_assymetric) {
+  const std::vector<double> xs = {0., 1., 2., 4., 5., 7., 11., 15., 21.};
+  const std::vector<double> ys = {0.5, 1.5, 2.5, 5.5, 7., 11.5, 15., 21.5};
+
+  LeaveOneIntervalOut grouper;
+
+  const Eigen::MatrixXd by_group =
+      compute_covariance_by_group(this->covariance_function, grouper, xs, ys);
+
+  Eigen::MatrixXd expected = this->covariance_function(xs, ys);
+
+  EXPECT_EQ(by_group, expected);
 }
 
 TYPED_TEST(TestDoubleCovarianceFunctions, can_set_params) {

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -445,4 +445,13 @@ void expect_predict_variants_inconsistent(const PredictionType &pred) {
   }
 }
 
+inline long int get_group(const double &f) {
+  return static_cast<double>(floor(f / 5.));
+}
+
+struct LeaveOneIntervalOut {
+
+  long int operator()(const double &f) const { return get_group(f); }
+};
+
 } // namespace albatross

--- a/tests/test_samplers.cc
+++ b/tests/test_samplers.cc
@@ -137,14 +137,6 @@ TEST(test_samplers, test_samplers_gp) {
   EXPECT_GT(oss->str().size(), 1);
 }
 
-inline long int get_group(const double &f) {
-  return static_cast<double>(floor(f / 5.));
-}
-
-struct LeaveOneIntervalOut {
-  long int operator()(const double &f) const { return get_group(f); }
-};
-
 TEST(test_samplers, test_samplers_sparse_gp) {
   const double a = 3.14;
   const double b = sqrt(2.);

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -19,15 +19,6 @@
 
 namespace albatross {
 
-inline long int get_group(const double &f) {
-  return static_cast<double>(floor(f / 5.));
-}
-
-struct LeaveOneIntervalOut {
-
-  long int operator()(const double &f) const { return get_group(f); }
-};
-
 template <typename GrouperFunction>
 class SparseGaussianProcessTest : public ::testing::Test {
 public:


### PR DESCRIPTION
This adds a method `compute_covariance_by_group` which lets you fill a [cross] covariance by group in parallel, meaning you provide a group which divides data into chunks, then these chunks get filled asynchronously.

Probably there could be some optimization to be done around making sure your filling contiguous chunks, but the more general approach here (groups don't need to be ordered) was done in anticipation of making the groups meaningful in the sense that some pairs of groups may be known to be zero.  So in a future change we could provide a `Grouper` which also has a `is_zero(group_a, group_b)` method which lets us avoid computations of chunks all together.