### PR TITLE
Move stream overloads into albatross namespace

### DIFF
--- a/include/albatross/src/core/dataset.hpp
+++ b/include/albatross/src/core/dataset.hpp
@@ -169,12 +169,10 @@ inline auto concatenate_datasets(const RegressionDataset<X> &x,
                                                                     targets);
 }
 
-} // namespace albatross
-
-template <typename X, typename std::enable_if_t<
-                          albatross::is_streamable<X>::value, int> = 0>
-inline std::ostream &
-operator<<(std::ostream &os, const albatross::RegressionDataset<X> &dataset) {
+template <typename X,
+          typename std::enable_if_t<is_streamable<X>::value, int> = 0>
+inline std::ostream &operator<<(std::ostream &os,
+                                const RegressionDataset<X> &dataset) {
   for (std::size_t i = 0; i < dataset.size(); ++i) {
     os << dataset.features[i] << "    " << dataset.targets.mean[i] << "   +/- "
        << std::sqrt(dataset.targets.get_diagonal(i)) << std::endl;
@@ -182,15 +180,16 @@ operator<<(std::ostream &os, const albatross::RegressionDataset<X> &dataset) {
   return os;
 }
 
-template <typename X, typename std::enable_if_t<
-                          !albatross::is_streamable<X>::value, int> = 0>
-inline std::ostream &
-operator<<(std::ostream &os, const albatross::RegressionDataset<X> &dataset) {
+template <typename X,
+          typename std::enable_if_t<!is_streamable<X>::value, int> = 0>
+inline std::ostream &operator<<(std::ostream &os,
+                                const RegressionDataset<X> &dataset) {
   for (std::size_t i = 0; i < dataset.size(); ++i) {
     os << i << "    " << dataset.targets.mean[i] << "   +/- "
        << std::sqrt(dataset.targets.get_diagonal(i)) << std::endl;
   }
   return os;
 }
+} // namespace albatross
 
 #endif

--- a/include/albatross/src/core/distribution.hpp
+++ b/include/albatross/src/core/distribution.hpp
@@ -252,10 +252,8 @@ concatenate_marginals(const std::vector<MarginalDistribution> &dists) {
   return MarginalDistribution(mean, variance);
 }
 
-} // namespace albatross
-
-inline std::ostream &
-operator<<(std::ostream &os, const albatross::MarginalDistribution &marginal) {
+inline std::ostream &operator<<(std::ostream &os,
+                                const MarginalDistribution &marginal) {
   for (std::size_t i = 0; i < marginal.size(); ++i) {
     os << i << "    " << marginal.mean[i] << "   +/- "
        << std::sqrt(marginal.get_diagonal(i)) << std::endl;
@@ -264,7 +262,7 @@ operator<<(std::ostream &os, const albatross::MarginalDistribution &marginal) {
 }
 
 inline std::ostream &operator<<(std::ostream &os,
-                                const albatross::JointDistribution &joint) {
+                                const JointDistribution &joint) {
   Eigen::MatrixXd combined(joint.covariance.rows(),
                            joint.covariance.cols() + 1);
   combined.rightCols(joint.covariance.cols()) = joint.covariance;
@@ -273,4 +271,5 @@ inline std::ostream &operator<<(std::ostream &os,
   return os;
 }
 
+} // namespace albatross
 #endif

--- a/include/albatross/src/graph/minimum_spanning_tree.hpp
+++ b/include/albatross/src/graph/minimum_spanning_tree.hpp
@@ -30,12 +30,6 @@ template <typename VertexType> struct Edge {
            std::tie(other.cost, other.a, other.b);
   }
 
-  friend std::ostream &operator<<(std::ostream &os,
-                                  const Edge<VertexType> &edge) {
-    os << edge.a << " <--> " << edge.b << " [" << edge.cost << "]";
-    return os;
-  }
-
   VertexType a;
   VertexType b;
   double cost;
@@ -58,14 +52,6 @@ compute_vertices(const std::vector<Edge<VertexType>> &edges) {
 template <typename VertexType> struct Graph {
   std::vector<Edge<VertexType>> edges;
   std::set<VertexType> vertices;
-
-  friend std::ostream &operator<<(std::ostream &os,
-                                  const Graph<VertexType> &graph) {
-    for (const auto &edge : graph.edges) {
-      std::cout << edge << std::endl;
-    }
-    return os;
-  }
 };
 
 template <typename VertexType>
@@ -279,6 +265,22 @@ Graph<VertexType> maximum_spanning_forest(const Graph<VertexType> &graph) {
     edge.cost *= -1;
   }
   return output;
+}
+
+template <typename VertexType>
+inline std::ostream &operator<<(std::ostream &os,
+                                const Edge<VertexType> &edge) {
+  os << edge.a << " <--> " << edge.b << " [" << edge.cost << "]";
+  return os;
+}
+
+template <typename VertexType>
+inline std::ostream &operator<<(std::ostream &os,
+                                const Graph<VertexType> &graph) {
+  for (const auto &edge : graph.edges) {
+    std::cout << edge << std::endl;
+  }
+  return os;
 }
 
 } // namespace albatross

--- a/include/albatross/src/models/ransac.hpp
+++ b/include/albatross/src/models/ransac.hpp
@@ -529,13 +529,10 @@ ModelBase<ModelType>::ransac(const StrategyType &strategy,
   return Ransac<ModelType, StrategyType>(derived(), strategy, config);
 }
 
-} // namespace albatross
-
-template <typename X, typename std::enable_if_t<
-                          albatross::is_streamable<X>::value, int> = 0>
-inline std::ostream &
-operator<<(std::ostream &os, const albatross::RansacIteration<X> &iteration) {
-
+template <typename X,
+          typename std::enable_if_t<is_streamable<X>::value, int> = 0>
+inline std::ostream &operator<<(std::ostream &os,
+                                const RansacIteration<X> &iteration) {
   os << "CANDIDATES: ";
   for (const auto &k : iteration.candidates) {
     os << k << ", ";
@@ -556,11 +553,10 @@ operator<<(std::ostream &os, const albatross::RansacIteration<X> &iteration) {
   return os;
 }
 
-template <typename X, typename std::enable_if_t<
-                          albatross::is_streamable<X>::value, int> = 0>
+template <typename X,
+          typename std::enable_if_t<is_streamable<X>::value, int> = 0>
 inline std::ostream &operator<<(std::ostream &os,
-                                const albatross::RansacOutput<X> &output) {
-
+                                const RansacOutput<X> &output) {
   for (std::size_t i = 0; i < output.iterations.size(); ++i) {
     os << "==== Iteration " << i << "====" << std::endl;
     os << output.iterations[i] << std::endl;
@@ -572,4 +568,5 @@ inline std::ostream &operator<<(std::ostream &os,
   return os;
 }
 
+} // namespace albatross
 #endif

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -424,3 +424,29 @@ TEST(test_serialize, test_gp_serialize_version) {
 }
 
 } // namespace albatross
+
+namespace other {
+
+TEST(test_serialize, test_dataset_streamable) {
+
+  albatross::MarginalDistribution targets(Eigen::VectorXd(1));
+  RegressionDataset<int> dataset({1}, targets);
+  std::ostringstream oss;
+  oss << dataset;
+}
+
+TEST(test_serialize, test_marginal_streamable) {
+
+  albatross::MarginalDistribution dist(Eigen::VectorXd(1));
+  std::ostringstream oss;
+  oss << dist;
+}
+
+TEST(test_serialize, test_joint_streamable) {
+
+  albatross::JointDistribution dist(Eigen::VectorXd(1), Eigen::MatrixXd(1, 1));
+  std::ostringstream oss;
+  oss << dist;
+}
+
+} // namespace other


### PR DESCRIPTION
This moves any of the `operator <<` overloads in albatross into the same namespace as the class it operates on.

This is done to avoid method hiding in which having any `operator <<` defined in a non-albatross namespace means any globally defined `operator <<` will get hidden.  For example:

```
#include <iostream>

namespace foo {
  struct Foo {};
}

void call(const foo::Foo &) {
  std::cout << "foo::call" << std::endl;
}

namespace bar {

struct Bar {};

//void call(const Bar &) {}

void call_foo() {
  std::cout << "bar::";
  foo::Foo x;
  call(x);
}

}

void call_foo() {
  foo::Foo x;
  call(x);
}

int main() {

  call_foo();
  bar::call_foo();
  return 0.;
}
```
will not compile if you uncomment the `void call(const Bar &) {}` line because including that line will lead to the compiler hiding any `call()` method in any parent namespaces (including the global namespace).