### PR TITLE
Use a thread pool instead of `std::async`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "third_party/nlopt"]
 	path = third_party/nlopt
 	url = https://github.com/swift-nav/nlopt.git
+[submodule "third_party/ThreadPool"]
+	path = third_party/ThreadPool
+	url = git@github.com:swift-nav/ThreadPool.git

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -139,11 +139,12 @@ cc_library(
         "@gzip",
         "@nlopt",
         "@variant",
+        "@ThreadPool",
     ],
 )
 
 swift_cc_test(
-    name = "albatorss-test",
+    name = "albatross-test",
     srcs = [
         "tests/mock_model.h",
         "tests/test_apply.cc",
@@ -189,6 +190,7 @@ swift_cc_test(
         "tests/test_serialize.h",
         "tests/test_sparse_gp.cc",
         "tests/test_stats.cc",
+        "tests/test_thread_pool.cc",
         "tests/test_traits_cereal.cc",
         "tests/test_traits_core.cc",
         "tests/test_traits_covariance_functions.cc",
@@ -207,5 +209,6 @@ swift_cc_test(
     deps = [
         ":albatross",
         "@gtest//:gtest_main",
+        "@zlib",
     ],
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(FastCSV REQUIRED)
 find_package(Gzip-Hpp REQUIRED)
 find_package(Variant REQUIRED)
 find_package(Nlopt REQUIRED)
+find_package(ThreadPool REQUIRED)
 
 add_library(albatross INTERFACE)
 target_include_directories(albatross INTERFACE
@@ -40,6 +41,7 @@ target_link_libraries(albatross
     fast-csv
     gzip-hpp
     variant
+    ThreadPool
     )
 
 set(albatross_COMPILE_OPTIONS

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,3 +78,8 @@ new_local_repository(
     path = "third_party/nlopt",
 )
 
+new_local_repository(
+    name = "ThreadPool",
+    build_file = "@rules_swiftnav//third_party:ThreadPool.BUILD",
+    path = "third_party/ThreadPool",
+)

--- a/cmake/FindThreadPool.cmake
+++ b/cmake/FindThreadPool.cmake
@@ -1,0 +1,9 @@
+if(TARGET ThreadPool)
+  return()
+endif()
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/ThreadPool/")
+  add_library(ThreadPool INTERFACE)
+
+  target_include_directories(ThreadPool SYSTEM INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/third_party/ThreadPool/")
+endif()

--- a/include/albatross/Core
+++ b/include/albatross/Core
@@ -16,6 +16,7 @@
 #include "Dataset"
 
 #include <type_traits>
+#include <ThreadPool.h>
 
 #include <albatross/src/core/traits.hpp>
 #include <albatross/src/core/priors.hpp>

--- a/include/albatross/src/core/model.hpp
+++ b/include/albatross/src/core/model.hpp
@@ -28,7 +28,13 @@ template <typename ModelType> class ModelBase : public ParameterHandlingMixin {
   template <typename T, typename FeatureType> friend class fit_model_type;
 
 protected:
-  ModelBase() : insights(), use_async_(DEFAULT_USE_ASYNC){};
+  ModelBase()
+      : insights(),
+        threads_(DEFAULT_USE_ASYNC
+                     ? std::make_shared<ThreadPool>(std::max(
+                           std::size_t{1},
+                           std::size_t{std::thread::hardware_concurrency()}))
+                     : nullptr){};
 
   /*
    * Fit
@@ -122,7 +128,9 @@ public:
     return derived().name();
   }
 
-  void set_async_flag(const bool use_async) { use_async_ = use_async; }
+  void set_thread_pool(std::shared_ptr<ThreadPool> new_pool) {
+    threads_ = new_pool;
+  }
 
   template <typename FeatureType>
   auto fit(const std::vector<FeatureType> &features,
@@ -154,7 +162,7 @@ public:
                                      const RansacConfig &) const;
 
   Insights insights;
-  bool use_async_;
+  std::shared_ptr<ThreadPool> threads_;
 };
 } // namespace albatross
 #endif

--- a/include/albatross/src/indexing/group_by.hpp
+++ b/include/albatross/src/indexing/group_by.hpp
@@ -154,8 +154,9 @@ public:
     return albatross::apply(map_, std::forward<ApplyFunction>(f));
   }
 
-  template <typename ApplyFunction> auto async_apply(ApplyFunction &&f) const {
-    return albatross::async_apply(map_, std::forward<ApplyFunction>(f));
+  template <typename ApplyFunction>
+  auto apply(ApplyFunction &&f, ThreadPool *pool) const {
+    return albatross::apply(map_, std::forward<ApplyFunction>(f), pool);
   }
 
 protected:
@@ -504,8 +505,8 @@ public:
   }
 
   template <typename ApplyFunction>
-  auto async_apply(const ApplyFunction &f) const {
-    return groups().async_apply(f);
+  auto apply(const ApplyFunction &f, ThreadPool *pool) const {
+    return groups().apply(f, pool);
   }
 
   ValueType get_group(const KeyType &key) const {

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -332,11 +332,7 @@ public:
         old_fit.sigma_R.template triangularView<Eigen::Upper>() *
         y_augmented.topRows(n_old);
 
-    if (Base::use_async_) {
-      y_augmented.bottomRows(n_new) = A_ldlt.async_sqrt_solve(y);
-    } else {
-      y_augmented.bottomRows(n_new) = A_ldlt.sqrt_solve(y);
-    }
+    y_augmented.bottomRows(n_new) = A_ldlt.sqrt_solve(y, Base::threads_.get());
     const Eigen::VectorXd v = B_qr.solve(y_augmented);
 
     using FitType = Fit<SparseGPFit<InducingPointFeatureType>>;
@@ -385,11 +381,7 @@ public:
     const auto B_qr = compute_sigma_qr(K_uu_ldlt, A_ldlt, K_fu);
 
     Eigen::VectorXd y_augmented = Eigen::VectorXd::Zero(B_qr.matrixR().rows());
-    if (Base::use_async_) {
-      y_augmented.topRows(y.size()) = A_ldlt.async_sqrt_solve(y);
-    } else {
-      y_augmented.topRows(y.size()) = A_ldlt.sqrt_solve(y);
-    }
+    y_augmented.topRows(y.size()) = A_ldlt.sqrt_solve(y, Base::threads_.get());
     const Eigen::VectorXd v = B_qr.solve(y_augmented);
 
     using InducingPointFeatureType = typename std::decay<decltype(u[0])>::type;

--- a/include/albatross/src/tune/finite_difference.hpp
+++ b/include/albatross/src/tune/finite_difference.hpp
@@ -17,8 +17,7 @@ namespace albatross {
 template <typename Function>
 inline std::vector<double>
 compute_gradient(Function f, const std::vector<double> &params, double f_val,
-                 bool use_async = false) {
-
+                 ThreadPool *threads = nullptr) {
   std::vector<std::size_t> inds(params.size());
   std::iota(std::begin(inds), std::end(inds), 0);
   const double epsilon = 1e-6;
@@ -29,18 +28,13 @@ compute_gradient(Function f, const std::vector<double> &params, double f_val,
     return (f(perturbed) - f_val) / epsilon;
   };
 
-  if (use_async) {
-    return albatross::async_apply(inds, compute_single_gradient);
-  } else {
-    return albatross::apply(inds, compute_single_gradient);
-  }
+  return albatross::apply(inds, compute_single_gradient, threads);
 }
 
 template <typename Function>
 inline std::vector<double>
 compute_gradient(Function f, const ParameterStore &params, double f_val,
-                 bool use_async = false) {
-
+                 ThreadPool *threads = nullptr) {
   TunableParameters tunable_params = get_tunable_parameters(params);
 
   std::vector<std::size_t> inds(tunable_params.values.size());
@@ -83,11 +77,7 @@ compute_gradient(Function f, const ParameterStore &params, double f_val,
     return grad_i;
   };
 
-  if (use_async) {
-    return albatross::async_apply(inds, compute_single_sub_gradient);
-  } else {
-    return albatross::apply(inds, compute_single_sub_gradient);
-  }
+  return albatross::apply(inds, compute_single_sub_gradient, threads);
 }
 
 } // namespace albatross

--- a/include/albatross/src/tune/greedy_tuner.hpp
+++ b/include/albatross/src/tune/greedy_tuner.hpp
@@ -103,9 +103,8 @@ template <typename Function>
 inline ParameterStore
 greedy_tune(Function evaluate_function, const ParameterStore &params,
             std::size_t n_queries_each_direction = 4,
-            std::size_t n_iterations = 10, bool use_async = true,
+            std::size_t n_iterations = 10, ThreadPool *threads = nullptr,
             std::ostream *os = &std::cout) {
-
   static_assert(
       has_call_operator<Function, ParameterStore>::value,
       "evaluate_function must have a single ParameterStore argument.");
@@ -162,15 +161,8 @@ greedy_tune(Function evaluate_function, const ParameterStore &params,
         (*os) << std::endl;
       }
 
-      auto evaluate = [&]() {
-        if (use_async) {
-          return async_apply(proposed_params, evaluate_function);
-        } else {
-          return apply(proposed_params, evaluate_function);
-        }
-      };
-
-      const auto evaluations = evaluate();
+      const auto evaluations =
+          apply(proposed_params, evaluate_function, threads);
 
       if (os) {
         (*os) << "EVALUATIONS: " << std::endl;

--- a/include/albatross/utils/AsyncUtils
+++ b/include/albatross/utils/AsyncUtils
@@ -16,6 +16,8 @@
 #include <future>
 #include <mutex>
 
+#include <ThreadPool.h>
+
 #include "../Common"
 #include "../src/utils/async_utils.hpp"
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ swift_add_tool(albatross_unit_tests
   test_serialize.cc
   test_sparse_gp.cc
   test_stats.cc
+  test_thread_pool.cc
   test_traits_cereal.cc
   test_traits_core.cc
   test_traits_details.cc

--- a/tests/test_async_utils.cc
+++ b/tests/test_async_utils.cc
@@ -24,6 +24,7 @@
 namespace albatross {
 
 TEST(test_async_utils, test_async_apply_with_capture) {
+  ThreadPool pool{get_default_thread_count()};
   std::vector<int> xs = {0, 1, 2, 3, 4, 5};
 
   std::mutex mu;
@@ -39,7 +40,7 @@ TEST(test_async_utils, test_async_apply_with_capture) {
     order_processed.push_back(x);
   };
 
-  async_apply(xs, add_to_sum);
+  apply(xs, add_to_sum, &pool);
 
   EXPECT_EQ(sum, std::accumulate(xs.begin(), xs.end(), 0));
   // Make sure the async apply was indeed processed out of order.
@@ -47,6 +48,7 @@ TEST(test_async_utils, test_async_apply_with_capture) {
 }
 
 TEST(test_async_utils, test_async_apply_map_value_only_function) {
+  ThreadPool pool{get_default_thread_count()};
   std::map<std::string, int> xs = {{"0", 0}, {"1", 1}, {"2", 2},
                                    {"3", 3}, {"4", 4}, {"5", 5}};
 
@@ -62,7 +64,7 @@ TEST(test_async_utils, test_async_apply_map_value_only_function) {
     order_processed.push_back(x);
   };
 
-  async_apply(xs, add_to_sum);
+  apply(xs, add_to_sum, &pool);
 
   EXPECT_EQ(sum, 15);
   // Make sure the async apply was indeed processed out of order.
@@ -71,6 +73,7 @@ TEST(test_async_utils, test_async_apply_map_value_only_function) {
 }
 
 TEST(test_async_utils, test_async_apply_map_key_value_function) {
+  ThreadPool pool{get_default_thread_count()};
   std::map<std::string, int> xs = {{"0", 0}, {"1", 1}, {"2", 2},
                                    {"3", 3}, {"4", 4}, {"5", 5}};
 
@@ -86,7 +89,7 @@ TEST(test_async_utils, test_async_apply_map_key_value_function) {
     order_processed.push_back(x);
   };
 
-  async_apply(xs, add_to_sum);
+  apply(xs, add_to_sum, &pool);
 
   EXPECT_EQ(sum, 15);
   // Make sure the async apply was indeed processed out of order.
@@ -95,6 +98,7 @@ TEST(test_async_utils, test_async_apply_map_key_value_function) {
 }
 
 TEST(test_async_utils, test_async_apply_speedup_vector) {
+  ThreadPool pool{get_default_thread_count()};
   auto slow_process = [&](const int i) {
     const auto start = std::chrono::system_clock::now();
     std::chrono::seconds delay(1);
@@ -109,7 +113,7 @@ TEST(test_async_utils, test_async_apply_speedup_vector) {
   }
 
   const auto start = std::chrono::system_clock::now();
-  const auto actual = async_apply(inds, slow_process);
+  const auto actual = apply(inds, slow_process, &pool);
   const auto end = std::chrono::system_clock::now();
 
   EXPECT_LT(end - start, std::chrono::seconds(inds.size() - 1));
@@ -123,6 +127,7 @@ TEST(test_async_utils, test_async_apply_speedup_vector) {
 }
 
 TEST(test_async_utils, test_async_apply_speedup_value_only_function) {
+  ThreadPool pool{get_default_thread_count()};
   auto slow_square = [&](const int i) {
     const auto start = std::chrono::system_clock::now();
     std::chrono::seconds delay(1);
@@ -134,7 +139,7 @@ TEST(test_async_utils, test_async_apply_speedup_value_only_function) {
   std::map<std::string, int> xs = {{"0", 0}, {"1", 1}, {"2", 2}, {"3", 3}};
 
   const auto start = std::chrono::system_clock::now();
-  const auto actual = async_apply(xs, slow_square);
+  const auto actual = apply(xs, slow_square, &pool);
   const auto end = std::chrono::system_clock::now();
 
   EXPECT_LT(end - start, std::chrono::seconds(xs.size() - 1));
@@ -150,6 +155,7 @@ TEST(test_async_utils, test_async_apply_speedup_value_only_function) {
 }
 
 TEST(test_async_utils, test_async_apply_speedup_key_value_function) {
+  ThreadPool pool{get_default_thread_count()};
   auto slow_square = [&](const double key, const int i) {
     const auto start = std::chrono::system_clock::now();
     std::chrono::seconds delay(1);
@@ -161,7 +167,7 @@ TEST(test_async_utils, test_async_apply_speedup_key_value_function) {
   std::map<double, int> xs = {{0., 0}, {1., 1}, {2., 2}, {3., 3}};
 
   const auto start = std::chrono::system_clock::now();
-  const auto actual = async_apply(xs, slow_square);
+  const auto actual = apply(xs, slow_square, &pool);
   const auto end = std::chrono::system_clock::now();
 
   EXPECT_LT(end - start, std::chrono::seconds(xs.size() - 1));

--- a/tests/test_thread_pool.cc
+++ b/tests/test_thread_pool.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <ThreadPool.h>
+#include <gtest/gtest.h>
+
+#include "test_utils.h"
+
+constexpr std::size_t kNumCalls = 10000;
+
+TEST(test_thread_pool, test_threaded_enqueue_dequeue) {
+  ThreadPool pool(60);
+
+  std::atomic<std::size_t> shared{0};
+
+  const auto do_it = [&shared](std::size_t value) {
+    const auto first = shared.fetch_add(value);
+    std::this_thread::sleep_for(std::chrono::nanoseconds(first));
+    shared += value;
+    return value;
+  };
+
+  std::vector<std::future<std::size_t>> results{};
+
+  for (std::size_t i = 0; i < kNumCalls; ++i) {
+    results.emplace_back(pool.enqueue(do_it, i));
+  }
+
+  const std::size_t total =
+      std::accumulate(results.begin(), results.end(), std::size_t{0},
+                      [](const auto a, auto &b) { return a + b.get(); });
+
+  // Should have had each value added to it twice.
+  EXPECT_EQ(shared.load(), (kNumCalls - 1) * kNumCalls);
+  EXPECT_EQ(total, (kNumCalls - 1) * kNumCalls / 2);
+}

--- a/tests/test_tune.cc
+++ b/tests/test_tune.cc
@@ -223,7 +223,7 @@ TEST_F(TestTuneQuadratic, test_generic) {
 
   GenericTuner async_gradient_tuner(initial_x, output_stream);
   async_gradient_tuner.optimizer = default_gradient_optimizer(params);
-  async_gradient_tuner.use_async = true;
+  async_gradient_tuner.threads = make_shared_thread_pool();
   test_tuner(async_gradient_tuner);
 }
 
@@ -241,7 +241,6 @@ TEST_F(TestTuneQuadratic, test_greedy_tune) {
 
   auto test_tuner = [&]() {
     const std::size_t n_threads = 8;
-    const bool use_async = false;
     const std::size_t n_iterations = 1000;
     ParameterStore params;
     for (std::size_t i = 0; i < initial_x.size(); ++i) {
@@ -250,7 +249,7 @@ TEST_F(TestTuneQuadratic, test_greedy_tune) {
     }
     const auto params_result =
         greedy_tune(mahalanobis_distance_params, params, n_threads,
-                    n_iterations, use_async, &output_stream);
+                    n_iterations, nullptr, &output_stream);
 
     auto to_eigen = [](const auto &p) {
       auto param_vector = get_tunable_parameters(p).values;


### PR DESCRIPTION
- Pull in a minimal third-party thread pool definition

 - Replace `apply_async()` and `solve_*async()` with overloads
   accepting a pointer to a thread pool

 - Add overloads for `compute_covariance_matrix()` to allow parallel
   threaded calculation of covariance matrices