### PR TITLE
Compute covariance functions in parallel in sparse GP

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -88,6 +88,7 @@ cc_library(
         "include/albatross/src/evaluation/traits.hpp",
         "include/albatross/src/graph/minimum_spanning_tree.hpp",
         "include/albatross/src/indexing/apply.hpp",
+        "include/albatross/src/indexing/block.hpp",
         "include/albatross/src/indexing/declarations.hpp",
         "include/albatross/src/indexing/filter.hpp",
         "include/albatross/src/indexing/group_by.hpp",

--- a/include/albatross/Indexing
+++ b/include/albatross/Indexing
@@ -23,5 +23,6 @@
 #include "utils/AsyncUtils"
 
 #include <albatross/src/indexing/group_by.hpp>
+#include <albatross/src/indexing/block.hpp>
 
 #endif

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -129,11 +129,12 @@ public:
   template <typename X,
             typename std::enable_if<has_valid_caller<Derived, X, X>::value,
                                     int>::type = 0>
-  Eigen::MatrixXd operator()(const std::vector<X> &xs) const {
+  Eigen::MatrixXd operator()(const std::vector<X> &xs,
+                             ThreadPool *pool = nullptr) const {
     auto caller = [&](const auto &x, const auto &y) {
       return this->call(x, y);
     };
-    return compute_covariance_matrix(caller, xs);
+    return compute_covariance_matrix(caller, xs, pool);
   }
 
   /*
@@ -142,12 +143,12 @@ public:
   template <typename X, typename Y,
             typename std::enable_if<has_valid_caller<Derived, X, Y>::value,
                                     int>::type = 0>
-  Eigen::MatrixXd operator()(const std::vector<X> &xs,
-                             const std::vector<Y> &ys) const {
+  Eigen::MatrixXd operator()(const std::vector<X> &xs, const std::vector<Y> &ys,
+                             ThreadPool *pool = nullptr) const {
     auto caller = [&](const auto &x, const auto &y) {
       return this->call(x, y);
     };
-    return compute_covariance_matrix(caller, xs, ys);
+    return compute_covariance_matrix(caller, xs, ys, pool);
   }
 
   /*

--- a/include/albatross/src/indexing/block.hpp
+++ b/include/albatross/src/indexing/block.hpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_INDEXING_BLOCK_HPP_
+#define ALBATROSS_INDEXING_BLOCK_HPP_
+
+namespace albatross {
+
+namespace detail {
+
+// Partition a square, triangular matrix into blocks of columns
+// (upper-triangular) or rows (lower-triangular) with approximately
+// equal areas.
+//
+// Returns pairs of indices: [start, end) for each block.
+inline auto partition_triangular(Eigen::Index size,
+                                 Eigen::Index partition_count) {
+  std::vector<std::pair<Eigen::Index, Eigen::Index>> results{};
+  double area = 0;
+  Eigen::Index start_index = 0;
+  for (Eigen::Index block = 0; block < partition_count; ++block) {
+    // idx_n+1 = sqrt( 1 / k + A_n )
+    const auto end_fraction = sqrt(1 / cast::to_double(partition_count) + area);
+    area = end_fraction * end_fraction;
+    const auto end_index =
+        static_cast<Eigen::Index>(rint(cast::to_double(size) * end_fraction));
+    results.emplace_back(start_index, end_index);
+    start_index = end_index;
+  }
+
+  // Due to the ceiling, this can be one over in many cases.
+  results.back().second = std::min(results.back().second, size);
+
+  return results;
+}
+
+} // namespace detail
+
+} // namespace albatross
+
+#endif /* ALBATROSS_INDEXING_BLOCK_HPP_ */


### PR DESCRIPTION
This modifies the covariance operators to accept an optional `ThreadPool` pointer to be used for parallel calculation.  The sparse GP model now uses this facility by default in fitting (but not in prediction).
