### PR TITLE
bazel: Fixes for bazel build of albatross [BUILD-480]

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -75,6 +75,8 @@ cc_library(
         "include/albatross/src/details/error_handling.hpp",
         "include/albatross/src/details/method_inspection_macros.hpp",
         "include/albatross/src/details/traits.hpp",
+        "include/albatross/src/details/typecast.hpp",
+        "include/albatross/src/details/unused.hpp",
         "include/albatross/src/eigen/serializable_ldlt.hpp",
         "include/albatross/src/evaluation/cross_validation.hpp",
         "include/albatross/src/evaluation/cross_validation_utils.hpp",
@@ -209,6 +211,5 @@ swift_cc_test(
     deps = [
         ":albatross",
         "@gtest//:gtest_main",
-        "@zlib",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    strip_prefix = "rules_swiftnav-b80ca392ea24a14f8d810380b14495680255903b",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/b80ca392ea24a14f8d810380b14495680255903b.tar.gz",
+    strip_prefix = "rules_swiftnav-6f8f02805f9e15477d86628b8760780444a3f638",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/6f8f02805f9e15477d86628b8760780444a3f638.tar.gz",
 )
 
 # Rules for integrating with cmake builds


### PR DESCRIPTION
Fixes the bazel build. Requires updates in `rules_swiftnav`. See related PR for more info.

https://github.com/swift-nav/rules_swiftnav/pull/24