### PR TITLE
Don't block PRs on clang-tidy any longer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -215,6 +215,7 @@ jobs:
           sudo apt-get install clang-14 clang-tools-14 clang-tidy-14 && \
           sudo ln -s /usr/bin/clang-apply-replacements-14 /usr/local/bin/clang-apply-replacements
       - name: Run build
+        continue-on-error: true
         env:
           CC: clang-14
           CXX: clang++-14


### PR DESCRIPTION
This script may have some subtle bugs and also doesn't present clear
information about what to fix; this commit makes passing `clang-tidy`
no longer required.  I'll re-enable it once the tooling is improved.