### PR TITLE
Revert "split test headers into a seprate lib"

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_swiftnav//cc:defs.bzl", "UNIT", "swift_cc_test", "swift_cc_test_library")
+load("@rules_swiftnav//cc:defs.bzl", "UNIT", "swift_cc_test")
 load("//:copts.bzl", "COPTS")
 
 cc_library(
@@ -130,9 +130,16 @@ cc_library(
         "include/albatross/utils/MapUtils",
         "include/albatross/utils/RandomUtils",
         "include/albatross/utils/VariantUtils",
+        "tests/mock_model.h",
+        "tests/test_core_distribution.h",
+        "tests/test_covariance_utils.h",
+        "tests/test_models.h",
+        "tests/test_serialize.h",
+        "tests/test_utils.h",
     ],
     includes = [
         "include",
+        "tests",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -146,23 +153,10 @@ cc_library(
     ],
 )
 
-swift_cc_test_library(
-    name = "albatross-test-utils",
-    srcs = [
-        "tests/mock_model.h",
-        "tests/test_core_distribution.h",
-        "tests/test_covariance_utils.h",
-        "tests/test_models.h",
-        "tests/test_serialize.h",
-        "tests/test_utils.h",
-    ],
-    includes = ["tests"],
-    visibility = ["//visibility:public"],
-)
-
 swift_cc_test(
     name = "albatross-test",
     srcs = [
+        "tests/mock_model.h",
         "tests/test_apply.cc",
         "tests/test_async_utils.cc",
         "tests/test_block_utils.cc",
@@ -176,6 +170,7 @@ swift_cc_test(
         "tests/test_core_model.cc",
         "tests/test_covariance_function.cc",
         "tests/test_covariance_functions.cc",
+        "tests/test_covariance_utils.h",
         "tests/test_cross_validation.cc",
         "tests/test_csv_utils.cc",
         "tests/test_distance_metrics.cc",
@@ -201,6 +196,7 @@ swift_cc_test(
         "tests/test_scaling_function.cc",
         "tests/test_serializable_ldlt.cc",
         "tests/test_serialize.cc",
+        "tests/test_serialize.h",
         "tests/test_sparse_gp.cc",
         "tests/test_stats.cc",
         "tests/test_thread_pool.cc",
@@ -211,6 +207,7 @@ swift_cc_test(
         "tests/test_traits_evaluation.cc",
         "tests/test_traits_indexing.cc",
         "tests/test_tune.cc",
+        "tests/test_utils.h",
         "tests/test_variant_utils.cc",
     ],
     copts = COPTS,
@@ -220,7 +217,6 @@ swift_cc_test(
     type = UNIT,
     deps = [
         ":albatross",
-        ":albatross-test-utils",
         "@gtest//:gtest_main",
     ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -130,16 +130,12 @@ cc_library(
         "include/albatross/utils/MapUtils",
         "include/albatross/utils/RandomUtils",
         "include/albatross/utils/VariantUtils",
-        "tests/mock_model.h",
-        "tests/test_core_distribution.h",
         "tests/test_covariance_utils.h",
-        "tests/test_models.h",
-        "tests/test_serialize.h",
         "tests/test_utils.h",
     ],
+    copts = ["-Itests"],
     includes = [
         "include",
-        "tests",
     ],
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
This reverts commit 71dd5abff743b6686cc589c3b02594fda4d6934a.

`albatross` reexports test utilities here: `include/albatross/tests/Utills`
```
#define ALBATROSS_TESTS_UTILS_H

#include "../../../tests/test_utils.h"
#include "../../../tests/test_covariance_utils.h"

#endif
```
so I reverted `albatross-test-utils` library and I leave it as it was originally done in cmake.

I could change the `Utils` header file and `CMakeLists.txt`, but I experience a ton of friction between deps while working on `orion-engine` and I'd rather get it building ASAP. It got me thinking that perhaps we should just map bazel build files to cmake's as closely as possible and then do a clean up after removing CMake build.