### PR TITLE
Added Makefile with bazel wrappers [BUILD-360]

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,7 @@
 build --repo_env=BAZEL_CXXOPTS="-std=c++14"
+
+build:clang-format-check --aspects @rules_swiftnav//clang_format:clang_format_check.bzl%clang_format_check_aspect
+build:clang-format-check --output_groups=report
+
+build:clang-tidy --aspects @rules_swiftnav//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
+build:clang-tidy --output_groups=report

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+do-all-unit-tests:
+	bazel test --test_tag_filters=unit --test_output=all //...
+
+do-all-integration-tests:
+	bazel test --test_tag_filters=integration --test_output=all //...
+
+clang-format-all-check:
+	bazel build //... --config=clang-format-check
+
+clang-format-all:
+	bazel run @rules_swiftnav//clang_format
+
+clang-tidy-all-check:
+	bazel build //... --config=clang-tidy
+
+do-code-coverage:
+	bazel coverage --test_tag_filters=unit --collect_code_coverage --combined_report=lcov //...
+
+do-generate-coverage-report: do-code-coverage
+	genhtml bazel-out/_coverage/_coverage_report.dat -o coverage

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    strip_prefix = "rules_swiftnav-6f8f02805f9e15477d86628b8760780444a3f638",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/6f8f02805f9e15477d86628b8760780444a3f638.tar.gz",
+    strip_prefix = "rules_swiftnav-e59de2d94814156ab50b467f562c8bb29beffc3c",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/e59de2d94814156ab50b467f562c8bb29beffc3c.tar.gz",
 )
 
 # Rules for integrating with cmake builds


### PR DESCRIPTION
Adding Makefile wrappers for commonly used bazel commands to make it easier for developers to start using bazel.

Added targets:
* do-all-unit-tests
* do-all-integration-tests
* clang-format-all-check
* clang-format-all
* clang-tidy-all-check
* do-code-coverage
* do-generate-coverage-report

# Design Notes
* I'm using aspects to run `clang-format` and `clang-tidy` on each file. You can see the setup in `.bazelrc`

# Jira
https://swift-nav.atlassian.net/browse/BUILD-360