### PR TITLE
ci: bazel: require bazel builds pass to merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
           bash ./ci/ensure_formated.sh
 
   bazel:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout source
@@ -132,18 +132,11 @@ jobs:
       - name: Install gcc-6
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential software-properties-common -y
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-          sudo apt-get update
-          sudo apt-get install gcc-6 g++-6 -y
+          sudo apt-get install gcc-11 g++-11 -y
           gcc -v
       - name: Run build
-        env:
-          CC: gcc-6
-          CXX: g++-6
         run: |
           bazel test //...
-        continue-on-error: true
 
   osx-clang:
     runs-on: macOS-latest


### PR DESCRIPTION
Removes the condition that passes the CI pipeline regardless of whether
the bazel build passes or not.

Also updates the bazel build to use the same ubuntu/gcc as the other stages.