### PR TITLE
bazel add gen_compile_commands target [BUILD-547]

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@rules_swiftnav//cc:defs.bzl", "UNIT", "swift_cc_test", "swift_cc_test_library")
 load("//:copts.bzl", "COPTS")
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+
+refresh_compile_commands(
+    name = "gen_compile_commands",
+    visibility = ["//visibility:public"],
+)
 
 cc_library(
     name = "albatross",

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,6 @@ do-code-coverage:
 
 do-generate-coverage-report: do-code-coverage
 	genhtml bazel-out/_coverage/_coverage_report.dat -o coverage
+	
+gen-compile-commands:
+	bazel run //:gen_compile_commands


### PR DESCRIPTION
# Design notes
Adds `gen_compile_commands` target that generates `compile_commands.json`. It's basically an alias for `@hedron_compile_commands//:refresh_all`. The PR also provides a corresponding `gen-compile-commands` make target.

# JIRA
* https://swift-nav.atlassian.net/browse/BUILD-547