### PR TITLE
Add Helper Functions for Leave One Group Out Cross Validation

### DIFF
--- a/doc/src/gp-details.rst
+++ b/doc/src/gp-details.rst
@@ -176,3 +176,85 @@ would:
 * Evaluate the prior covariance :math:`K_{**}`
 * Compute the posterior covariance :math:`K_{**} - Q_{f*}^T Q_{f*}`
 
+++++++++++++++++++++++++++++++++++++++++
+Cross Validation Implementation Details
+++++++++++++++++++++++++++++++++++++++++
+
+In `Gaussian Processes for Machine Learning`_ (Section 5.4.2) they describe an efficient way for making leave one out predictions, here we expand that same trick to enable making leave one group out predictions.
+
+Consider the case where we have a set of observations, :math:`y`, and we would like to make leave one group out cross validated predictions and by groups we mean independent sets of one or more variables.
+
+We start with our GP,
+
+.. math::
+
+    \mathbf{f} \sim \mathcal{N}\left(0, \Sigma \right)
+
+Which we can then break into groups,
+
+.. math::
+
+    \begin{bmatrix} \mathbf{\hat{y}} \\ \mathbf{y_i} \end{bmatrix} \sim \mathcal{N}\left(\begin{bmatrix} 0 \\ 0 \end{bmatrix}, \begin{bmatrix}\hat{\Sigma} & S \\ S^T & C \end{bmatrix}\right)
+
+Where we will be using a subset of observations, :math:`\hat{y}` to make predictions for a held out set of locations, :math:`x_i`.  We can do this directly using the Gaussian process predict formula,
+
+.. math::
+
+    [\mathbf{y_i}|\mathbf{\hat{y}}=\hat{y}] \sim \mathcal{N}\left(S^T \hat{\Sigma}^{-1} \hat{y}, C - S^T \hat{\Sigma}^{-1} S\right)
+
+But doing so would require computing :math:`\hat{\Sigma}^{-1}` for every group, :math:`i`, that we hold out.  So if we're doing leave one out with :math:`n` observations we have to do the :math:`\mathcal{O}(n^3)` inversion :math:`n` times leading to :math:`\mathcal{O}(n^4)` complexity which will quickly get infeasible.
+
+However, in the process of fitting our GP we'll need to end up computing the inverse of the full covariance, :math:`\Sigma^{-1}` as well as what we've been calling the information vector, :math:`v = \Sigma^{-1} y`.  By using block inversion we get,
+
+.. math::
+
+    \Sigma^{-1} = \begin{bmatrix}
+    \left(\hat{\Sigma} - S C^{-1} S^T\right)^{-1} & -\left(\hat{\Sigma} - S C^{-1} S^T\right)^{-1}SC^{-1} \\
+    -\left(C - S^T \hat{\Sigma}^{-1} S\right)^{-1} S^T \hat{\Sigma}^{-1} & \left(C - S^T \hat{\Sigma}^{-1} S\right)^{-1}\end{bmatrix}
+
+And if we break up :math:`v` into :math:`[\hat{v} \hspace{8pt} v_i]` using the same partitioning as :math:`y` we see,
+
+.. math::
+
+    v_i & = \left[\Sigma^{-1} y\right]_i \\
+    & = \begin{bmatrix}
+    -\left(C - S^T \hat{\Sigma}^{-1} S\right)^{-1} S^T \hat{\Sigma}^{-1} & \left(C - S^T \hat{\Sigma}^{-1} S\right)^{-1}
+    \end{bmatrix} \begin{bmatrix} \hat{y} \\ y_i \end{bmatrix} \\
+    & = -\left(C - S^T \hat{\Sigma}^{-1} S\right)^{-1} S^T \hat{\Sigma}^{-1} \hat{y} + \left(C - S^T \hat{\Sigma}^{-1} S\right)^{-1} y_i \\
+    & = -A S^T \hat{\Sigma}^{-1} \hat{y} + A y_i
+
+Where :math:`A = \left(C - S^T \hat{\Sigma}^{-1} S\right)^{-1}` is the lower right corner of :math:`\Sigma^{-1}` and :math:`A^{-1}` is the leave one out prediction covariance. Notice that if we multiply :math:`v_i` through by :math:`A^{-1}` we end up with,
+
+.. math::
+
+    A^{-1} v_i &= - S^T \hat{\Sigma}^{-1} \hat{y} + y_i \\
+    &= -\mbox{E}[\mathbf{y_i}|\hat{y}] + y_i \\
+    \mbox{E}[\mathbf{y_i}|\mathbf{\hat{y}}=\hat{y}] &= y_i - A^{-1} v_i
+
+We can then recover the leave one out predictions,
+
+.. math::
+
+    [\mathbf{y_i}|\mathbf{\hat{y}}=\hat{y}] \sim \mathcal{N}\left(y_i - A^{-1} v_i, A^{-1}\right)
+
++++++++++++++++++++++++++++++++++
+Computing :math:`A`
++++++++++++++++++++++++++++++++++
+
+Above we see that if we can compute :math:`A` then we can recover the leave one out predictions without ever directly computing :math:`\hat{\Sigma}^{-1}`.  Take the case of leave one observation out, in this case :math:`A` will be the last diagonal value of :math:`\Sigma^{-1}`.  When training a Gaussian process we'll often have a decomposition of :math:`\Sigma` laying around, typically :math:`\Sigma = LDL^T`.  To get the :math:`i^{th}` diagonal value of :math:`\Sigma^{-1}` we can first compute, :math:`q = D^{-1/2} L^{-1} e_i`, where :math:`e_i` is a vector of zeros with a one in element :math:`i`, then we find that :math:`\Sigma^{-1}_{ii} = q^T q`.  Since :math:`L` is lower triangular and :math:`D` is diagonal :math:`p` can be computed efficiently.
+
+Similarly if we're making leave one group out predictions we can build an indexing matrix :math:`E_i` which consists of columns :math:`e_j` for each :math:`j` in group :math:`i`.  Then we find that,
+
+.. math::
+
+    A = Q^T Q
+
+with
+
+.. math::
+
+    Q = D^{-1/2} L^{-1} E_i.
+
+Where :math:`L^{-1} E_i` amounts to extracting columns of :math:`L^{-1}`.
+
+.. _`Gaussian Processes for Machine Learning`: http://gaussianprocess.org/gpml/chapters/RW.pdf

--- a/include/albatross/GP
+++ b/include/albatross/GP
@@ -19,6 +19,7 @@
 #include "linalg/Block"
 
 #include <albatross/src/evaluation/likelihood.hpp>
+#include <albatross/src/evaluation/cross_validation_utils.hpp>
 #include <albatross/src/eigen/serializable_ldlt.hpp>
 #include <albatross/src/covariance_functions/representations.hpp>
 #include <albatross/src/models/gp.hpp>

--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -162,6 +162,104 @@ leave_one_out_conditional(const JointDistribution &prior,
   return MarginalDistribution(loo_mean, loo_variance);
 }
 
+namespace details {
+
+// The following methods implement leave one group out cross validation
+// for more details see:
+//
+// https://swiftnav-albatross.readthedocs.io/en/latest/gp-details.html
+
+inline Eigen::VectorXd
+held_out_prediction(const Eigen::MatrixXd &inverse_block,
+                    const Eigen::VectorXd &y, const Eigen::VectorXd &v,
+                    PredictTypeIdentity<Eigen::VectorXd>) {
+  return y - inverse_block.ldlt().solve(v);
+}
+
+inline MarginalDistribution
+held_out_prediction(const Eigen::MatrixXd &inverse_block,
+                    const Eigen::VectorXd &y, const Eigen::VectorXd &v,
+                    PredictTypeIdentity<MarginalDistribution>) {
+  const auto A_ldlt = Eigen::SerializableLDLT(inverse_block);
+  const Eigen::VectorXd mean = y - A_ldlt.solve(v);
+  return MarginalDistribution(mean, A_ldlt.inverse_diagonal());
+}
+
+inline JointDistribution
+held_out_prediction(const Eigen::MatrixXd &inverse_block,
+                    const Eigen::VectorXd &y, const Eigen::VectorXd &v,
+                    PredictTypeIdentity<JointDistribution>) {
+  const auto A_inv = inverse_block.inverse();
+  const Eigen::VectorXd mean = y - A_inv * v;
+  return JointDistribution(mean, A_inv);
+}
+
+template <typename GroupKey, typename PredictType>
+inline std::map<GroupKey, PredictType>
+held_out_predictions(const Eigen::SerializableLDLT &covariance,
+                     const Eigen::VectorXd &target_mean,
+                     const Eigen::VectorXd &information,
+                     const GroupIndexer<GroupKey> &group_indexer,
+                     PredictTypeIdentity<PredictType> predict_type) {
+
+  const std::vector<GroupIndices> indices = map_values(group_indexer);
+  const std::vector<GroupKey> group_keys = map_keys(group_indexer);
+  const auto inverse_blocks = covariance.inverse_blocks(indices);
+
+  std::map<GroupKey, PredictType> output;
+  for (std::size_t i = 0; i < inverse_blocks.size(); i++) {
+    const Eigen::VectorXd yi = subset(target_mean, indices[i]);
+    const Eigen::VectorXd vi = subset(information, indices[i]);
+    output[group_keys[i]] =
+        held_out_prediction(inverse_blocks[i], yi, vi, predict_type);
+  }
+  return output;
+}
+
+template <typename GroupKey, typename PredictType>
+inline std::map<GroupKey, PredictType>
+leave_one_group_out_conditional(const JointDistribution &prior,
+                                const MarginalDistribution &truth,
+                                const GroupIndexer<GroupKey> &group_indexer,
+                                PredictTypeIdentity<PredictType> predict_type) {
+  Eigen::MatrixXd covariance = prior.covariance;
+  covariance += truth.covariance;
+  Eigen::SerializableLDLT ldlt(covariance);
+  const Eigen::VectorXd deviation = truth.mean - prior.mean;
+  const Eigen::VectorXd information = ldlt.solve(deviation);
+  return held_out_predictions(covariance, truth.mean, information,
+                              group_indexer, predict_type);
+}
+
+} // namespace details
+
+template <typename GroupKey>
+inline std::map<GroupKey, Eigen::VectorXd>
+leave_one_group_out_conditional_means(
+    const JointDistribution &prior, const MarginalDistribution &truth,
+    const GroupIndexer<GroupKey> &group_indexer) {
+  return details::leave_one_group_out_conditional(
+      prior, truth, group_indexer, PredictTypeIdentity<Eigen::VectorXd>());
+}
+
+template <typename GroupKey>
+inline std::map<GroupKey, MarginalDistribution>
+leave_one_group_out_conditional_marginals(
+    const JointDistribution &prior, const MarginalDistribution &truth,
+    const GroupIndexer<GroupKey> &group_indexer) {
+  return details::leave_one_group_out_conditional(
+      prior, truth, group_indexer, PredictTypeIdentity<MarginalDistribution>());
+}
+
+template <typename GroupKey>
+inline std::map<GroupKey, JointDistribution>
+leave_one_group_out_conditional_joints(
+    const JointDistribution &prior, const MarginalDistribution &truth,
+    const GroupIndexer<GroupKey> &group_indexer) {
+  return details::leave_one_group_out_conditional(
+      prior, truth, group_indexer, PredictTypeIdentity<JointDistribution>());
+}
+
 } // namespace albatross
 
 #endif


### PR DESCRIPTION
I want to be able to take a prediction of some data,
```
const auto pred = model.predict(dataset.features).joint();
```
And then compute leave one group out predictions on the result,
```
const auto loo_preds = leave_one_group_out_joints(pred, dataset.targets, group_inds);
```
which is technically already possible (put `pred` in a `ConditionalGaussian` model and then cross validate), but doing so would not take advantage of the same linear algebra trick we use in the GP implementation. 

In this PR I've moved the leave one group out cross validation routines out of `gp.hpp` and into `cross_validation_utils.hpp` and added some helper functions which make it possible to efficiently compute leave one group out predictions using free functions.

In the process I realized that the cross validation trick isn't very well documented, so I added it to the readthedocs pages:

![image](https://user-images.githubusercontent.com/514053/222273299-d1ace8c1-501d-40e3-af9e-5825a2b1c7de.png)

![image](https://user-images.githubusercontent.com/514053/222273362-8e7b7460-f93d-4692-9859-b6ffa6b1229f.png)


