### PR TITLE
bazel: bump rules_swiftnav [BUILD-560]

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    strip_prefix = "rules_swiftnav-e59de2d94814156ab50b467f562c8bb29beffc3c",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/e59de2d94814156ab50b467f562c8bb29beffc3c.tar.gz",
+    strip_prefix = "rules_swiftnav-26426be6b89a5b9f0489158098599b9fcd973ed4",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/26426be6b89a5b9f0489158098599b9fcd973ed4.tar.gz",
 )
 
 # Rules for integrating with cmake builds


### PR DESCRIPTION
We're adding new functions to the `rules_swiftnav` API that will be used in `gnss_converters` `libswiftnav`, and `libsbp`.

However, if we merge these, once the submodules get bumped in higher level projects, the build will break, because
bazel will still be referencing the previous API version in their own `WORKSPACE.bazel` file.

So we need to prep by first merging a PR that introduces stubs for the new functions "top down".

Then we can go back and merge the implementations in in a less strict order.

# Design Notes
- Bumps the hash for rules_swiftnav

# Testing
- Build doesn't break with these changes.

# Related PRs
- https://github.com/swift-nav/rules_swiftnav/pull/52
- https://github.com/swift-nav/rules_swiftnav/pull/51