### PR TITLE
Make sure param names aren't empty

### DIFF
--- a/include/albatross/src/core/parameter_handling_mixin.hpp
+++ b/include/albatross/src/core/parameter_handling_mixin.hpp
@@ -48,6 +48,18 @@ template <typename ParameterHandler,
 inline void unchecked_set_param(const ParameterKey &name,
                                 const Parameter &param,
                                 ParameterHandler *param_handler) {
+  // Empty parameter names have accidentally been encountered, often
+  // the root cause has to do with global definitions along the lines
+  // of:
+  //
+  //     const std::string my_param_key = "foo";
+  //
+  // which can mysteriously not get initialized. Best practice is to
+  // define such keys as:
+  //
+  //     constexpr char my_param_key[] = "foo";
+  //
+  assert(name.size() > 0 && "parameter names must be non-empty");
   param_handler->set_param(name, param);
 }
 


### PR DESCRIPTION
This assertion is meant to fail hard and fast when we encounter a (relatively) common bug pattern when defining keys for parameter names. As described in the comments,
```
  // Empty parameter names have accidentally been encountered, often
  // the root cause has to do with global definitions along the lines
  // of:
  //
  //     const std::string my_param_key = "foo";
  //
  // which can mysteriously not get initialized. Best practice is to
  // define such keys as:
  //
  //     constexpr char my_param_key[] = "foo";
```
I couldn't find a great place to check the results of `get_params`, so this is only going to fire when we attempt to set a parameter which an empty string.