### PR TITLE
Async threads should play nicely with MKL

### DIFF
--- a/include/albatross/src/utils/async_utils.hpp
+++ b/include/albatross/src/utils/async_utils.hpp
@@ -210,7 +210,21 @@ make_shared_thread_pool(std::size_t threads = 0) {
     threads = get_default_thread_count();
   }
 
-  return std::make_shared<ThreadPool>(threads);
+#if defined(EIGEN_USE_MKL_ALL) || defined(EIGEN_USE_MKL_VML)
+  const auto init = []() { mkl_set_num_threads_local(1); };
+#else  // EIGEN_USE_MKL_ALL || EIGEN_USE_MKL_VML
+  const auto init = []() {};
+#endif // EIGEN_USE_MKL_ALL || EIGEN_USE_MKL_VML
+
+  return std::make_shared<ThreadPool>(threads, init);
+}
+
+inline std::size_t get_thread_count(const std::shared_ptr<ThreadPool> &pool) {
+  if (nullptr == pool) {
+    return 1;
+  }
+
+  return pool->thread_count();
 }
 
 } // namespace albatross

--- a/include/albatross/utils/AsyncUtils
+++ b/include/albatross/utils/AsyncUtils
@@ -18,6 +18,10 @@
 
 #include <ThreadPool.h>
 
+#ifdef EIGEN_USE_MKL_ALL
+#include <mkl.h>
+#endif
+
 #include "../Common"
 #include "../src/utils/async_utils.hpp"
 


### PR DESCRIPTION
MKL uses OpenMP threads under the hood; we use our own C++11 thread pool.  When requested to set up a thread pool, the easiest approach is to set MKL to use 1 (OpenMP) thread for any operations in async worker threads.  This should avoid oversubscribing CPU resources.