### PR TITLE
Derive Length Scales

### DIFF
--- a/include/albatross/src/covariance_functions/radial.hpp
+++ b/include/albatross/src/covariance_functions/radial.hpp
@@ -18,6 +18,9 @@ constexpr double default_radial_sigma = 10.;
 
 namespace albatross {
 
+constexpr double MAX_LENGTH_SCALE_RATIO = 1e7;
+constexpr double MIN_LENGTH_SCALE_RATIO = 1e-7;
+
 inline double squared_exponential_covariance(double distance,
                                              double length_scale,
                                              double sigma = 1.) {
@@ -26,6 +29,86 @@ inline double squared_exponential_covariance(double distance,
   }
   ALBATROSS_ASSERT(distance >= 0.);
   return sigma * sigma * exp(-pow(distance / length_scale, 2));
+}
+
+namespace detail {
+
+inline bool valid_args_for_derive_length_scale(double reference_distance,
+                                               double prior_sigma,
+                                               double std_dev_increase) {
+  assert(reference_distance > 0.);
+  return (std_dev_increase > 0. && prior_sigma > 0. &&
+          std_dev_increase < prior_sigma);
+}
+
+inline double fallback_length_scale_for_invalid_args(double reference_distance,
+                                                     double prior_sigma,
+                                                     double std_dev_increase) {
+  if (std_dev_increase <= 0.) {
+    // an increase of 0. means an extremely large length scale and would
+    // lead to a divide by zero below, so we early return.
+    return MAX_LENGTH_SCALE_RATIO * reference_distance;
+  }
+  if (prior_sigma <= 0.) {
+    // with values of zero it doesn't matter what the length scale is.
+    return MAX_LENGTH_SCALE_RATIO * reference_distance;
+  }
+  const double ratio = std_dev_increase / prior_sigma;
+  assert(ratio > 0.);
+  if (ratio >= 1.) {
+    // there's no way for the std deviation to exceed the prior std dev if
+    // this is specified just assume a tiny length scale;
+    return MIN_LENGTH_SCALE_RATIO * reference_distance;
+  }
+  if (ratio <= 0.) {
+    // in order to keep the standard deviation from increasing we need
+    // the longest length scale possible.
+    return MAX_LENGTH_SCALE_RATIO * reference_distance;
+  }
+  // all edge cases should have been handled
+  assert(false);
+  return NAN;
+}
+} // namespace detail
+
+inline double derive_squared_exponential_length_scale(double reference_distance,
+                                                      double prior_sigma,
+                                                      double std_dev_increase) {
+  if (!detail::valid_args_for_derive_length_scale(
+          reference_distance, prior_sigma, std_dev_increase)) {
+    return detail::fallback_length_scale_for_invalid_args(
+        reference_distance, prior_sigma, std_dev_increase);
+  }
+
+  // to get the increase in standard deviation over a given distance we can
+  // ask for the predictive variance for one point given another point
+  // separated by a distance `d`.
+  //
+  //   [f_0,      ~ N(|0 , |k(0), k(d)| )
+  //    f_d]          |0   |k(d), k(0)|
+  //
+  //   VAR[f_d|f_0] = k(0) - k(d) k(d) / k(0)
+  //   STD[f_d|f_0] = sqrt(k(0) - k(d)^2/ k(0))
+  //
+  // for the squared exponential funciton this means an increase in
+  // standard deviation, d_sd, can be written:
+  //
+  //   d_sd = sqrt(sigma^2 - sigma^2 exp[-(d / length_scale)^2]^2)
+  //        = sigma * sqrt(1 - exp[-(d / length_scale)^2]^2)
+  //        = sigma * sqrt(1 - exp[-2 * (d / length_scale)^2])
+  //
+  // solving for length_scale gives us
+  //
+  //   d_sd / sigma = sqrt(1 - exp[-2 * (d / length_scale)^2])
+  //   (d_sd / sigma)^2 = 1 - exp[-2 * (d / length_scale)^2]
+  //   exp[-2 * (d / length_scale)^2] = 1 - (d_sd / sigma)^2
+  //   -2 (d / length_scale)^2 = log[1 - (d_sd / sigma)^2]
+  //   (d / length_scale) = sqrt(-1/2 log[1 - (d_sd / sigma)^2])
+  //   length_scale = d / sqrt(-1/2 log[1 - (d_sd / sigma)^2])
+  const double ratio = std_dev_increase / prior_sigma;
+  assert(ratio > 0.);
+  assert(ratio < 1.);
+  return sqrt(2.0) * reference_distance / sqrt(-log(1. - ratio * ratio));
 }
 
 /*
@@ -71,6 +154,12 @@ public:
     return linspace(min, max, safe_cast_to_size_t(n));
   }
 
+  double derive_length_scale(double reference_distance, double sigma,
+                             double std_dev_increase) const {
+    return derive_squared_exponential_length_scale(reference_distance, sigma,
+                                                   std_dev_increase);
+  }
+
   // This operator is only defined when the distance metric is also defined.
   template <typename X,
             typename std::enable_if<
@@ -93,6 +182,36 @@ inline double exponential_covariance(double distance, double length_scale,
   }
   ALBATROSS_ASSERT(distance >= 0.);
   return sigma * sigma * exp(-fabs(distance / length_scale));
+}
+
+inline double derive_exponential_length_scale(double reference_distance,
+                                              double prior_sigma,
+                                              double std_dev_increase) {
+  if (!detail::valid_args_for_derive_length_scale(
+          reference_distance, prior_sigma, std_dev_increase)) {
+    return detail::fallback_length_scale_for_invalid_args(
+        reference_distance, prior_sigma, std_dev_increase);
+  }
+  // See derive_squared_exponential_length_scale for an introduction
+  // for the exponential funciton the equations vary slightly,
+  //
+  //   d_sd = sqrt(sigma^2 - sigma^2 exp[-|distance / length_scale|]^2)
+  //        = sigma * sqrt(1 - exp[-|distance / length_scale|]^2)
+  //        = sigma * sqrt(1 - exp[-2 * |distance / length_scale|])
+  //
+  // solving for length_scale gives us
+  //
+  //   d_sd / sigma = sqrt(1 - exp[-2 * |distance / length_scale|])
+  //   (d_sd / sigma)^2 = 1 - exp[-2 * |distance / length_scale|]
+  //   exp[-2 * |distance / length_scale|] = 1 - (d_sd / sigma)^2
+  //   -2 |distance / length_scale| = log[1 - (d_sd / sigma)^2]
+  //   |distance / length_scale| = -1/2 log[1 - (d_sd / sigma)^2]
+  //   length_scale = -2 * distance / log[1 - (d_sd / sigma)^2]
+  //
+  const double ratio = std_dev_increase / prior_sigma;
+  assert(ratio > 0.);
+  assert(ratio < 1.);
+  return -2.0 * reference_distance / log(1. - ratio * ratio);
 }
 
 /*
@@ -129,6 +248,12 @@ public:
     return linspace(min, max, safe_cast_to_size_t(n));
   }
 
+  double derive_length_scale(double reference_distance, double sigma,
+                             double std_dev_increase) const {
+    return derive_exponential_length_scale(reference_distance, sigma,
+                                           std_dev_increase);
+  }
+
   // This operator is only defined when the distance metric is also defined.
   template <typename X,
             typename std::enable_if<
@@ -149,8 +274,116 @@ inline double matern_32_covariance(double distance, double length_scale,
     return 0.;
   }
   assert(distance >= 0.);
-  const double sqrt_3_d = std::sqrt(3.) * distance / length_scale;
+  const double sqrt_3_d = sqrt(3.) * distance / length_scale;
   return sigma * sigma * (1 + sqrt_3_d) * exp(-sqrt_3_d);
+}
+
+template <typename Func, typename Grad>
+inline double derive_length_scale(double reference_distance, double prior_sigma,
+                                  double std_dev_increase, Func func,
+                                  Grad grad) {
+  if (!detail::valid_args_for_derive_length_scale(
+          reference_distance, prior_sigma, std_dev_increase)) {
+    return detail::fallback_length_scale_for_invalid_args(
+        reference_distance, prior_sigma, std_dev_increase);
+  }
+  // func and grad should accept a single argument "ratio" which is the
+  // length scale expressed as multiples of the reference distance.
+  //
+  //    ratio = length_scale / reference_distance
+  //
+  // The goal behind the reformulation is to be able to keep the solver
+  // stable. For example, a length scale of 1e-16 meters might
+  // be perfectly reasonable on an atomic scale, while 1e32 meters might
+  // be reasonable on an astronmical scale, so working directly with
+  // length scale could require exploring a very large range. Instead
+  // using the ratio allows a user to pick a reasonable reference
+  // distance and keep the domain searched by this back solver smaller.
+  static_assert(is_invocable_with_result<Func, double, double>::value,
+                "func sould take a single double and return the covariance");
+  static_assert(is_invocable_with_result<Grad, double, double>::value,
+                "grad sould take a single double and return the covariance");
+
+  auto log_f_eval = [&](double ratio) {
+    // with ratio = ell / reference_distance
+    // here we assume func(1, ratio) == func(reference_distance, ell)
+    const double cov = func(ratio);
+    if (cov * cov >= 1) {
+      return log(1e-16);
+    }
+    const double log_f = log(prior_sigma) + 0.5 * log(1 - cov * cov);
+    return log_f;
+  };
+
+  auto log_g_eval = [&](double ratio) {
+    const double cov = func(ratio);
+    const double denom = (1 - cov * cov);
+    assert(denom > 0);
+    return grad(ratio) * cov / denom;
+  };
+
+  const double log_target = log(std_dev_increase);
+  const double max_increase = log_f_eval(MIN_LENGTH_SCALE_RATIO);
+  if (max_increase <= log_target) {
+    return MIN_LENGTH_SCALE_RATIO * reference_distance;
+  }
+  const double min_increase = log_f_eval(MAX_LENGTH_SCALE_RATIO);
+  if (min_increase >= log_target) {
+    return MAX_LENGTH_SCALE_RATIO * reference_distance;
+  }
+
+  // linearly interpolate between log of scales as a coarse guess
+  const double alpha =
+      (max_increase - log_target) / (max_increase - min_increase);
+  double guess =
+      exp(log(MIN_LENGTH_SCALE_RATIO) +
+          alpha * (log(MAX_LENGTH_SCALE_RATIO) - log(MIN_LENGTH_SCALE_RATIO)));
+  // refine the guess
+  for (std::size_t i = 0; i < 50; ++i) {
+    const double log_f = log_f_eval(guess);
+    const double f_i = log_target - log_f;
+    if (!std::isfinite(f_i)) {
+      break;
+    }
+    double g = log_g_eval(guess);
+    if (!std::isfinite(g) || g == 0.) {
+      g = f_i > 0. ? -1e-8 : 1e-8;
+    };
+    if (g <= 0) {
+    }
+
+    const double delta = f_i / g;
+    if (fabs(f_i) < 1e-12) {
+      break;
+    }
+    if (guess - delta <= MIN_LENGTH_SCALE_RATIO) {
+      guess = 0.5 * (guess + MIN_LENGTH_SCALE_RATIO);
+    } else if (guess - delta >= MAX_LENGTH_SCALE_RATIO) {
+      guess = 0.5 * (guess + MAX_LENGTH_SCALE_RATIO);
+    } else {
+      guess -= delta;
+    }
+    guess = std::min(MAX_LENGTH_SCALE_RATIO,
+                     std::max(MIN_LENGTH_SCALE_RATIO, guess));
+  }
+
+  return guess * reference_distance;
+}
+
+inline double derive_matern_32_length_scale(double reference_distance,
+                                            double prior_sigma,
+                                            double std_dev_increase) {
+
+  auto func = [&](double ratio) { return matern_32_covariance(1., ratio, 1.); };
+
+  auto grad = [&](double ratio) {
+    return sqrt(3) * (1 + sqrt(3) / ratio) * exp(-sqrt(3) / ratio) /
+               pow(ratio, 2) -
+           sqrt(3) * exp(-sqrt(3) / ratio) / pow(ratio, 2);
+  };
+
+  return derive_length_scale(reference_distance, prior_sigma, std_dev_increase,
+                             func, grad);
 }
 
 template <class DistanceMetricType>
@@ -174,6 +407,12 @@ public:
     return "matern_32[" + this->distance_metric_.get_name() + "]";
   }
 
+  double derive_length_scale(double reference_distance, double sigma,
+                             double std_dev_increase) const {
+    return derive_matern_32_length_scale(reference_distance, sigma,
+                                         std_dev_increase);
+  }
+
   template <typename X,
             typename std::enable_if<
                 has_call_operator<DistanceMetricType, X &, X &>::value,
@@ -193,9 +432,26 @@ inline double matern_52_covariance(double distance, double length_scale,
     return 0.;
   }
   assert(distance >= 0.);
-  const double sqrt_5_d = std::sqrt(5.) * distance / length_scale;
+  const double sqrt_5_d = sqrt(5.) * distance / length_scale;
   return sigma * sigma * (1 + sqrt_5_d + sqrt_5_d * sqrt_5_d / 3.) *
          exp(-sqrt_5_d);
+}
+
+inline double derive_matern_52_length_scale(double reference_distance,
+                                            double prior_sigma,
+                                            double std_dev_increase) {
+
+  auto func = [&](double ratio) { return matern_52_covariance(1., ratio, 1.); };
+
+  auto grad = [&](double ratio) {
+    return (-sqrt(5) / pow(ratio, 2) - 10. / 3. / pow(ratio, 3)) *
+               exp(-sqrt(5) / ratio) +
+           sqrt(5) * (1 + sqrt(5) / ratio + 10. / 6. / pow(ratio, 2)) *
+               exp(-sqrt(5) / ratio) / pow(ratio, 2);
+  };
+
+  return derive_length_scale(reference_distance, prior_sigma, std_dev_increase,
+                             func, grad);
 }
 
 template <class DistanceMetricType>
@@ -217,6 +473,12 @@ public:
 
   std::string name() const {
     return "matern_52[" + this->distance_metric_.get_name() + "]";
+  }
+
+  double derive_length_scale(double reference_distance, double sigma,
+                             double std_dev_increase) const {
+    return derive_matern_52_length_scale(reference_distance, sigma,
+                                         std_dev_increase);
   }
 
   template <typename X,

--- a/tests/test_radial.cc
+++ b/tests/test_radial.cc
@@ -67,7 +67,7 @@ TYPED_TEST(RadialCovarianceTester, test_edge_cases) {
 
 TYPED_TEST(RadialCovarianceTester, test_derive_length_scale) {
 
-  auto set_sigma_length_scale = [&](double sigma, double length_scale) {
+  auto set_sigma_length_scale = [this](double sigma, double length_scale) {
     for (const auto &pair : this->test_case.get_params()) {
       if (pair.first.find("length_scale") != std::string::npos) {
         albatross::set_param_value(pair.first, length_scale, &this->test_case);
@@ -125,10 +125,10 @@ TYPED_TEST(RadialCovarianceTester, test_derive_length_scale) {
 
   // large sigmas are likely lead to numerical instabilities
   // in matrix inversions, so that seems like a reasonable limit;
-  std::vector<double> sigmas = {1e-6, 1e-4, 1e-2, 1, 1e2, 1e4, 1e6};
-  std::vector<double> distances = {1e-8, 1e-4,  1e-2, 1.,  10.,
-                                   100., 1000., 1e8,  1e12};
-  std::vector<double> proportion_increases = {
+  const std::vector<double> sigmas = {1e-6, 1e-4, 1e-2, 1, 1e2, 1e4, 1e6};
+  const std::vector<double> distances = {1e-8, 1e-4,  1e-2, 1.,  10.,
+                                         100., 1000., 1e8,  1e12};
+  const std::vector<double> proportion_increases = {
       0, 1e-8, 1e-4, 1e-2, 0.1, 0.5, 0.9, 0.99, 0.9999, 0.99999999, 1.};
   for (const auto &dist : distances) {
     for (const auto &inc : proportion_increases) {


### PR DESCRIPTION
When writing covariance functions it's best to work with parameters which can be directly used into the equations. Consider the squared exponential covariance for example,

$$
k_{se}(d) = \sigma^2 \mbox{exp}\left[-\left(\frac{d}{\ell}\right)^2\right]
$$

In our models we directly store the prior standard deviation, $\sigma$, and length scale, $\ell$. That way evaluating the covariance doesn't require unnecessary computations which could become problematic since covariance functions are often evaluated millions of times. However, the most computationally efficient choice of parameters isn't necessarily the most intuitive. One alternate representation which is often used in Kalman filtering is to define the initial standard deviation and the "process noise" or the amount the standard deviation increases between updates. If we pick a reference distance we can actually compute the equivalent process noise for any radial covariance function by asking for the predictive variance at some location given a known value some distance, $\Delta$, away. To do so we start with the prior:

$$
\begin{bmatrix}
f_0 \\
f_\Delta
\end{bmatrix}
\sim \mathcal{N}\left(0, \begin{bmatrix}k(0) & k(\Delta) \\ k(\Delta) & k(0) \end{bmatrix}\right)
$$

Then we can ask for $\sigma\left(f_\Delta | f_0\right)$,

$$
    \sigma\left(f_\Delta | f_0\right) = \sqrt{k(0) - \frac{k(\Delta)^2}{k(0)}}
$$

If we plug the squared exponential covariance function in we get,

$$
    \sigma_{se}\left(f_\Delta | f_0\right) = \sigma \sqrt{1 - \mbox{exp}\left[-2\left(\frac{\Delta}{\ell}\right)^2\right]}
$$

This offers us a way to go from the less intuitive length scale parameter to a more intuitive increase in standard deviation, $\delta=\sigma\left(f_\Delta | f_0\right)$, over some distance, $\Delta$.

This change adds methods for deriving the length scale required to achieve a given increase in standard deviation over a reference distance for all of the radial covariance functions in albatross (exponential, squared exponential, matern 3/2, matern 5/2).

Note that while the exponential and squared exponential functions had closed form solutions, the Matern covariance functions do not. As a result we use a customized newton root finding algorithm to solve for the length scales. This isn't cheap, but would only need to be used when a parameter gets set, not when the covariance function is evaluated, so should suffice.