### PR TITLE
Fix GCC 13.1.1 missing cstdlib errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/USCiLab/cereal.git
 [submodule "third_party/gzip-hpp"]
 	path = third_party/gzip-hpp
-	url = https://github.com/mapbox/gzip-hpp.git
+	url = https://github.com/swift-nav/gzip-hpp.git
 [submodule "cmake/cmake"]
 	path = cmake/common
 	url = https://github.com/swift-nav/cmake.git


### PR DESCRIPTION
# Changes

The `gzip-hpp` library had an issue that fails in GCC 13.1.1 (rightfully so). The changes made here are to now point at our own fork of the `gzip-hpp` library with the applied fix.

See https://github.com/swift-nav/gzip-hpp/pull/1 for details.