### PR TITLE
One Dimensional Marginal Constructor

### DIFF
--- a/include/albatross/src/core/distribution.hpp
+++ b/include/albatross/src/core/distribution.hpp
@@ -91,6 +91,10 @@ struct MarginalDistribution : public DistributionBase<MarginalDistribution> {
     assert_valid();
   };
 
+  MarginalDistribution(double mean_, double variance_)
+      : MarginalDistribution(Eigen::VectorXd::Constant(1, mean_),
+                             Eigen::VectorXd::Constant(1, variance_)) {}
+
   void assert_valid() const {
     ALBATROSS_ASSERT(mean.size() == covariance.rows());
     ALBATROSS_ASSERT(mean.size() == covariance.cols());

--- a/tests/test_core_distribution.cc
+++ b/tests/test_core_distribution.cc
@@ -18,6 +18,18 @@
 
 namespace albatross {
 
+TEST(test_core_distribution, create_one_dim) {
+
+  const double mean = M_PI;
+  const double var = std::log(2);
+  const MarginalDistribution one_dim(mean, var);
+  const Eigen::VectorXd mean_vec = Eigen::VectorXd::Constant(1, mean);
+  const Eigen::VectorXd var_vec = Eigen::VectorXd::Constant(1, var);
+
+  const MarginalDistribution from_vectors(mean_vec, var_vec);
+  EXPECT_EQ(one_dim, from_vectors);
+}
+
 TYPED_TEST_P(DistributionTest, test_subset) {
 
   TypeParam test_case;


### PR DESCRIPTION
Adds a constructor for a `MarginalDistribution` to make it easier to create one dimensional distributions.

Ie, now you can do:
```
MarginalDistribution(10.0, 0.1);
```
instead of
```
MarginalDistribution(Eigen::VectorXd::Constant(1, 10.0),
                     Eigen::VectorXd::Constant(1, 0.1));
```