### PR TITLE
Use suitesparse QR for sparse GP models [OC-310]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install gcc-11
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential software-properties-common -y
+          sudo apt-get install build-essential software-properties-common libsuitesparse-dev -y
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt-get update
           sudo apt-get install gcc-11 g++-11 -y
@@ -49,10 +49,10 @@ jobs:
       - name: Install clang-14
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential software-properties-common -y
+          sudo apt-get install build-essential software-properties-common libsuitesparse-dev -y
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt-get update
-          sudo apt-get install clang-14
+          sudo apt-get install clang-14 -y
           gcc -v
       - name: Run build
         env:
@@ -82,10 +82,10 @@ jobs:
       - name: Install clang-14
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential software-properties-common -y
+          sudo apt-get install build-essential software-properties-common libsuitesparse-dev -y
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
           sudo apt-get update
-          sudo apt-get install clang-14
+          sudo apt-get install clang-14 -y
           clang -v
       - name: Run (${{ matrix.test.name }}) sanitizer tests
         env:
@@ -153,6 +153,9 @@ jobs:
       - name: check clang
         run: |
           clang --version
+      - name: install suite-sparse
+        run: |
+          brew install suite-sparse
       - name: Run build
         env:
           CC: clang

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -61,6 +61,8 @@ cc_library(
         "include/albatross/src/cereal/ransac.hpp",
         "include/albatross/src/cereal/representations.hpp",
         "include/albatross/src/cereal/serializable_ldlt.hpp",
+        "include/albatross/src/cereal/serializable_spqr.hpp",
+        "include/albatross/src/cereal/suitesparse.hpp",
         "include/albatross/src/cereal/traits.hpp",
         "include/albatross/src/cereal/variant.hpp",
         "include/albatross/src/core/concatenate.hpp",
@@ -97,6 +99,7 @@ cc_library(
         "include/albatross/src/details/typecast.hpp",
         "include/albatross/src/details/unused.hpp",
         "include/albatross/src/eigen/serializable_ldlt.hpp",
+        "include/albatross/src/eigen/serializable_spqr.hpp",
         "include/albatross/src/evaluation/cross_validation.hpp",
         "include/albatross/src/evaluation/cross_validation_utils.hpp",
         "include/albatross/src/evaluation/differential_entropy.hpp",
@@ -118,6 +121,7 @@ cc_library(
         "include/albatross/src/linalg/block_utils.hpp",
         "include/albatross/src/linalg/print_eigen_directions.hpp",
         "include/albatross/src/linalg/qr_utils.hpp",
+        "include/albatross/src/linalg/spqr_utils.hpp",
         "include/albatross/src/models/conditional_gaussian.hpp",
         "include/albatross/src/models/gp.hpp",
         "include/albatross/src/models/least_squares.hpp",
@@ -168,8 +172,10 @@ cc_library(
         "@fast_csv",
         "@gzip",
         "@nlopt",
+        "@zlib",
         "@variant",
         "@zstd",
+        "@suitesparse//:spqr",
     ],
 )
 
@@ -249,6 +255,8 @@ swift_cc_test(
     deps = [
         ":albatross",
         ":serialize-testsuite",
+        "@zlib",
         "@gtest//:gtest_main",
+        "@suitesparse//:spqr",
     ],
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(Variant REQUIRED)
 find_package(Nlopt REQUIRED)
 find_package(ThreadPool REQUIRED)
 find_package(zstd REQUIRED)
+find_package(suitesparse REQUIRED)
 
 add_library(albatross INTERFACE)
 target_include_directories(albatross INTERFACE
@@ -51,6 +52,8 @@ target_link_libraries(albatross
     zstd::zstd
     variant
     ThreadPool
+    suitesparse::cholmod
+    suitesparse::spqr
     )
 if(ENABLE_MKL)
   find_package(MKL)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    strip_prefix = "rules_swiftnav-970f6c003a8b99d2fb6cf3487eca34425faf93d3",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/970f6c003a8b99d2fb6cf3487eca34425faf93d3.tar.gz",
+    strip_prefix = "rules_swiftnav-fcdaa64e7bb5d3b0cf7ae474c87e41db1aded764",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/fcdaa64e7bb5d3b0cf7ae474c87e41db1aded764.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")
@@ -73,7 +73,17 @@ http_archive(
     sha256 = "9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4",
     strip_prefix = "zstd-1.5.5",
     url = "https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz",
-    build_file = "@rules_swiftnav//third_party:zstd.BUILD"
+    build_file = "@rules_swiftnav//third_party:zstd.BUILD",
+)
+
+http_archive(
+    name = "suitesparse",
+    build_file = "@rules_swiftnav//third_party:suitesparse.BUILD",
+    sha256 = "4cd3d161f9aa4f98ec5fa725ee5dc27bca960a3714a707a7d12b3d0abb504679",
+    strip_prefix = "SuiteSparse-7.1.0",
+    urls = [
+        "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.1.0.tar.gz",
+    ],
 )
 
 local_repository(

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,8 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    strip_prefix = "rules_swiftnav-fcdaa64e7bb5d3b0cf7ae474c87e41db1aded764",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/fcdaa64e7bb5d3b0cf7ae474c87e41db1aded764.tar.gz",
+    sha256 = "8e00b694b6dce9c91d811e2e9e13e148af5f1dd329b85b7c5d2d9d2238aa92dc",
+    strip_prefix = "rules_swiftnav-1c51c97743c9632169dd7e5a228c6ce915893236",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/1c51c97743c9632169dd7e5a228c6ce915893236.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/include/albatross/SparseGP
+++ b/include/albatross/SparseGP
@@ -21,7 +21,7 @@
 #include "linalg/Utils"
 
 #include <albatross/src/eigen/serializable_spqr.hpp>
-#include <albatross/src/utils/block_utils.hpp>
+#include <albatross/src/linalg/block_utils.hpp>
 #include <albatross/src/utils/eigen_utils.hpp>
 #include <albatross/src/models/sparse_gp.hpp>
 

--- a/include/albatross/SparseGP
+++ b/include/albatross/SparseGP
@@ -13,9 +13,16 @@
 #ifndef ALBATROSS_SPARSE_GP_H
 #define ALBATROSS_SPARSE_GP_H
 
+#include <cholmod.h>
+#include <SuiteSparseQR.hpp>
+#include <Eigen/SPQRSupport>
+
 #include "GP"
 #include "linalg/Utils"
 
+#include <albatross/src/eigen/serializable_spqr.hpp>
+#include <albatross/src/utils/block_utils.hpp>
+#include <albatross/src/utils/eigen_utils.hpp>
 #include <albatross/src/models/sparse_gp.hpp>
 
 #endif

--- a/include/albatross/linalg/Utils
+++ b/include/albatross/linalg/Utils
@@ -13,8 +13,10 @@
 #ifndef ALBATROSS_LINALG_UTILS_H
 #define ALBATROSS_LINALG_UTILS_H
 
+#include <Eigen/SPQRSupport>
 #include "../Common"
 #include "../src/linalg/qr_utils.hpp"
+#include "../src/linalg/spqr_utils.hpp"
 #include "../src/linalg/print_eigen_directions.hpp"
 
 #endif

--- a/include/albatross/serialize/Common
+++ b/include/albatross/serialize/Common
@@ -25,9 +25,14 @@
 #include <cereal/types/map.hpp>
 #include <cereal/types/string.hpp>
 #include <cereal/types/vector.hpp>
+#include <cholmod.h>
+#include <SuiteSparseQR.hpp>
+#include <Eigen/SPQRSupport>
+#include <Eigen/SparseCore>
 
 #include "../src/cereal/traits.hpp"
 #include "../src/cereal/eigen.hpp"
 #include "../src/cereal/ThreadPool.hpp"
+#include "../src/cereal/suitesparse.hpp"
 
 #endif

--- a/include/albatross/serialize/GP
+++ b/include/albatross/serialize/GP
@@ -20,5 +20,6 @@
 #include "../src/cereal/serializable_ldlt.hpp"
 #include "../src/cereal/gp.hpp"
 #include "../src/cereal/representations.hpp"
+#include "../src/cereal/serializable_spqr.hpp"
 
 #endif

--- a/include/albatross/src/cereal/eigen.hpp
+++ b/include/albatross/src/cereal/eigen.hpp
@@ -139,6 +139,74 @@ inline void load_lower_triangle(Archive &archive,
   }
 }
 
+template <class Archive, class _Scalar, int _Options, typename _StorageIndex>
+inline void save(Archive &ar,
+                 Eigen::SparseMatrix<_Scalar, _Options, _StorageIndex> const &m,
+                 const std::uint32_t version ALBATROSS_UNUSED) {
+  const _StorageIndex rows = m.rows();
+  const _StorageIndex cols = m.cols();
+  const std::size_t nnz = albatross::cast::to_size(m.nonZeros());
+  const std::size_t size_bytes = nnz * sizeof(_Scalar);
+
+  std::vector<Eigen::Triplet<_Scalar>> elems;
+  elems.reserve(nnz);
+  for (_StorageIndex col = 0; col < m.outerSize(); ++col) {
+    for (typename Eigen::SparseMatrix<_Scalar, _Options,
+                                      _StorageIndex>::InnerIterator it(m, col);
+         it; ++it) {
+      elems.emplace_back(it.col(), it.row(), it.value());
+    }
+  }
+
+  std::string payload =
+      gzip::compress(reinterpret_cast<const char *>(elems.data()), size_bytes);
+  if (::cereal::traits::is_text_archive<Archive>::value) {
+    payload =
+        base64::encode(reinterpret_cast<const unsigned char *>(payload.data()),
+                       payload.size());
+  }
+
+  ar(CEREAL_NVP(rows));
+  ar(CEREAL_NVP(cols));
+  ar(CEREAL_NVP(nnz));
+  ar(CEREAL_NVP(payload));
+}
+
+template <class Archive, class _Scalar, int _Options, typename _StorageIndex>
+inline void load(Archive &ar,
+                 Eigen::SparseMatrix<_Scalar, _Options, _StorageIndex> &m,
+                 const std::uint32_t version ALBATROSS_UNUSED) {
+  _StorageIndex rows = 0;
+  _StorageIndex cols = 0;
+  std::size_t nnz = 0;
+  std::string payload;
+  ar(CEREAL_NVP(rows));
+  ar(CEREAL_NVP(cols));
+  ar(CEREAL_NVP(nnz));
+  ar(CEREAL_NVP(payload));
+  const std::size_t size_bytes = nnz * sizeof(_Scalar);
+
+  if (::cereal::traits::is_text_archive<Archive>::value) {
+    payload = base64::decode(payload);
+  }
+
+  const std::string decompressed =
+      gzip::decompress(payload.data(), payload.size());
+
+  ALBATROSS_ASSERT(size_bytes == decompressed.size());
+  m.resize(rows, cols);
+
+  if (size_bytes == 0) {
+    m.setZero();
+  } else {
+    std::vector<Eigen::Triplet<_Scalar>> elems(nnz);
+    std::memcpy(elems.data(), decompressed.data(), size_bytes);
+    m.setFromTriplets(elems.begin(), elems.end());
+  }
+
+  m.makeCompressed();
+}
+
 } // namespace cereal
 
 #endif

--- a/include/albatross/src/cereal/serializable_spqr.hpp
+++ b/include/albatross/src/cereal/serializable_spqr.hpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CEREAL_SERIALIZABLE_SPQR_H
+#define ALBATROSS_CEREAL_SERIALIZABLE_SPQR_H
+
+namespace Eigen {
+
+template <typename _MatrixType>
+template <class Archive>
+void SerializableSPQR<_MatrixType>::save(
+    Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) const {
+  ar(CEREAL_NVP(Base::m_isInitialized));
+  ar(CEREAL_NVP(Base::m_analysisIsOk));
+  ar(CEREAL_NVP(Base::m_factorizationIsOk));
+  ar(CEREAL_NVP(Base::m_isRUpToDate));
+  ar(CEREAL_NVP(Base::m_info));
+  ar(CEREAL_NVP(Base::m_ordering));
+  ar(CEREAL_NVP(Base::m_allow_tol));
+  ar(CEREAL_NVP(Base::m_tolerance));
+  ar(CEREAL_NVP(Base::m_R));
+  ar(CEREAL_NVP(Base::m_rank));
+  ar(CEREAL_NVP(Base::m_cc));
+  ar(CEREAL_NVP(Base::m_useDefaultThreshold));
+  ar(CEREAL_NVP(Base::m_rows));
+
+  const std::size_t integer_size_bytes = sizeof(StorageIndex);
+
+  ar(::cereal::make_nvp("m_cR", *this->m_cR));
+  ar(::cereal::make_nvp("m_H", *this->m_H));
+  ar(::cereal::make_nvp("m_HTau", *this->m_HTau));
+  encode_array(ar, "m_E", this->m_E,
+               albatross::cast::to_size(cols()) * integer_size_bytes);
+  encode_array(ar, "m_HPinv", this->m_HPinv,
+               albatross::cast::to_size(rows()) * integer_size_bytes);
+}
+
+template <typename _MatrixType>
+template <class Archive>
+void SerializableSPQR<_MatrixType>::load(
+    Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) {
+  ar(CEREAL_NVP(Base::m_isInitialized));
+  ar(CEREAL_NVP(Base::m_analysisIsOk));
+  ar(CEREAL_NVP(Base::m_factorizationIsOk));
+  ar(CEREAL_NVP(Base::m_isRUpToDate));
+  ar(CEREAL_NVP(Base::m_info));
+  ar(CEREAL_NVP(Base::m_ordering));
+  ar(CEREAL_NVP(Base::m_allow_tol));
+  ar(CEREAL_NVP(Base::m_tolerance));
+  ar(CEREAL_NVP(Base::m_R));
+  ar(CEREAL_NVP(Base::m_rank));
+  ar(CEREAL_NVP(Base::m_cc));
+  ar(CEREAL_NVP(Base::m_useDefaultThreshold));
+  ar(CEREAL_NVP(Base::m_rows));
+
+  const std::size_t integer_size_bytes = sizeof(StorageIndex);
+  this->SPQR_free();
+  this->m_cR =
+      cholmod_l_allocate_sparse(1, 1, 1, 1, 1, 0, CHOLMOD_REAL, &this->m_cc);
+  ar(::cereal::make_nvp("m_cR", *this->m_cR));
+  this->m_H =
+      cholmod_l_allocate_sparse(1, 1, 1, 1, 1, 0, CHOLMOD_REAL, &this->m_cc);
+  ar(::cereal::make_nvp("m_H", *this->m_H));
+  this->m_HTau = cholmod_l_allocate_dense(1, 1, 1, CHOLMOD_REAL, &this->m_cc);
+  ar(::cereal::make_nvp("m_HTau", *this->m_HTau));
+  this->m_E = static_cast<StorageIndex *>(cholmod_l_malloc(
+      albatross::cast::to_size(cols()), integer_size_bytes, &this->m_cc));
+  decode_array(ar, "m_E", this->m_E,
+               albatross::cast::to_size(cols()) * integer_size_bytes);
+  this->m_HPinv = static_cast<StorageIndex *>(cholmod_l_malloc(
+      albatross::cast::to_size(rows()), integer_size_bytes, &this->m_cc));
+  decode_array(ar, "m_HPinv", this->m_HPinv,
+               albatross::cast::to_size(rows()) * integer_size_bytes);
+}
+
+}  // namespace Eigen
+
+#endif  // ALBATROSS_CEREAL_SERIALIZABLE_SPQR_H

--- a/include/albatross/src/cereal/serializable_spqr.hpp
+++ b/include/albatross/src/cereal/serializable_spqr.hpp
@@ -82,6 +82,6 @@ void SerializableSPQR<_MatrixType>::load(
                albatross::cast::to_size(rows()) * integer_size_bytes);
 }
 
-}  // namespace Eigen
+} // namespace Eigen
 
-#endif  // ALBATROSS_CEREAL_SERIALIZABLE_SPQR_H
+#endif // ALBATROSS_CEREAL_SERIALIZABLE_SPQR_H

--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -288,7 +288,7 @@ inline void load(Archive &ar, cholmod_common &cc,
                        (cc.nrow + 1) * cholmod_int_size);
   detail::decode_array(ar, "cc.Xwork", cc.Xwork, cc.xworksize * sizeof(double));
 
-  cc.Iwork = cholmod_malloc(cc.iworksize, cholmod_int_size, &cc);
+  cc.Iwork = cholmod_l_malloc(cc.iworksize, cholmod_int_size, &cc);
   ar(CEREAL_NVP(cc.itype));
   ar(CEREAL_NVP(cc.dtype));
   ar(CEREAL_NVP(cc.no_workspace_reallocate));

--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -16,8 +16,7 @@
 namespace cereal {
 
 template <class Archive>
-inline void serialize(Archive &ar,
-                      cholmod_common::cholmod_method_struct &cms,
+inline void serialize(Archive &ar, cholmod_common::cholmod_method_struct &cms,
                       std::uint32_t version ALBATROSS_UNUSED) {
   ar(CEREAL_NVP(cms.lnz));
   ar(CEREAL_NVP(cms.fl));
@@ -96,7 +95,7 @@ inline void suitesparse_cereal_realloc(void **p, std::size_t count,
   ALBATROSS_ASSERT(nullptr != *p);
 }
 
-}  // namespace detail
+} // namespace detail
 
 template <class Archive>
 inline void save(Archive &ar, cholmod_common const &cc,
@@ -207,7 +206,7 @@ inline void save(Archive &ar, cholmod_common const &cc,
 #ifdef GPU_BLAS
   static_assert(false,
                 "This codec will not work for CHOLMOD / SPQR using GPU!");
-#endif  // GPU_BLAS
+#endif // GPU_BLAS
   ALBATROSS_ASSERT(cc.useGPU == 0);
   ar(CEREAL_NVP(cc.useGPU));
 
@@ -335,7 +334,7 @@ inline void load(Archive &ar, cholmod_common &cc,
 #ifdef GPU_BLAS
   static_assert(false,
                 "This codec will not work for CHOLMOD / SPQR using GPU!");
-#endif  // GPU_BLAS
+#endif // GPU_BLAS
   ar(CEREAL_NVP(cc.useGPU));
   ALBATROSS_ASSERT(cc.useGPU == 0);
 
@@ -357,8 +356,7 @@ inline std::size_t get_element_size_bytes(const Matrix &m) {
   return m.dtype == CHOLMOD_DOUBLE ? sizeof(double) : sizeof(float);
 }
 
-template <class Matrix>
-inline std::size_t get_num_x_elements(const Matrix &m) {
+template <class Matrix> inline std::size_t get_num_x_elements(const Matrix &m) {
   // Complex matrices store twice as many elements.
   // https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/dev/CHOLMOD/Core/cholmod_sparse.c#L209
   return m.nzmax * (m.xtype == CHOLMOD_COMPLEX ? 2 : 1);
@@ -481,6 +479,6 @@ inline void load(Archive &ar, cholmod_dense &m,
   ALBATROSS_ASSERT(nullptr == m.z);
 }
 
-}  // namespace cereal
+} // namespace cereal
 
-#endif  // ALBATROSS_CEREAL_SUITESPARSE_H
+#endif // ALBATROSS_CEREAL_SUITESPARSE_H

--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -371,17 +371,23 @@ template <class Matrix> inline std::size_t get_num_x_elements(const Matrix &m) {
 
 template <class Matrix>
 inline std::size_t get_p_element_size_bytes(const Matrix &m) {
+  assert((m.itype == CHOLMOD_INT || m.itype == CHOLMOD_LONG) &&
+         "we only support int and long indices");
   return m.itype == CHOLMOD_INT ? sizeof(int) : sizeof(SuiteSparse_long);
 }
 
 template <class Matrix>
 inline std::size_t get_integer_size_bytes(const Matrix &m) {
+  assert((m.itype == CHOLMOD_INT || m.itype == CHOLMOD_LONG) &&
+         "we only support int and long indices");
   return m.itype == CHOLMOD_LONG ? sizeof(SuiteSparse_long) : sizeof(int);
 }
 
 template <class Archive>
 inline void save(Archive &ar, cholmod_sparse const &m,
                  std::uint32_t version ALBATROSS_UNUSED) {
+  assert((m.itype == CHOLMOD_INT || m.itype == CHOLMOD_LONG) &&
+         "we only support int and long indices");
   ar(CEREAL_NVP(m.nrow));
   ar(CEREAL_NVP(m.ncol));
   ar(CEREAL_NVP(m.nzmax));

--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -1,0 +1,486 @@
+/*
+ * Copyright (C) 2023 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CEREAL_SUITESPARSE_H
+#define ALBATROSS_CEREAL_SUITESPARSE_H
+
+namespace cereal {
+
+template <class Archive>
+inline void serialize(Archive &ar,
+                      cholmod_common::cholmod_method_struct &cms,
+                      std::uint32_t version ALBATROSS_UNUSED) {
+  ar(CEREAL_NVP(cms.lnz));
+  ar(CEREAL_NVP(cms.fl));
+  ar(CEREAL_NVP(cms.prune_dense));
+  ar(CEREAL_NVP(cms.prune_dense2));
+  ar(CEREAL_NVP(cms.nd_oksep));
+  static_assert(sizeof(cms.other_1) == 4 * sizeof(double),
+                "cholmod_common::cholmod_method_struct::other_1 expected to "
+                "have 4 elements.");
+  ar(::cereal::make_nvp("cms.other_1_0", cms.other_1[0]));
+  ar(::cereal::make_nvp("cms.other_1_1", cms.other_1[1]));
+  ar(::cereal::make_nvp("cms.other_1_2", cms.other_1[2]));
+  ar(::cereal::make_nvp("cms.other_1_3", cms.other_1[3]));
+  ar(CEREAL_NVP(cms.nd_small));
+  static_assert(sizeof(cms.other_2) == 4 * sizeof(std::size_t),
+                "cholmod_common::cholmod_method_struct::other_2 expected to "
+                "have 4 elements.");
+  ar(::cereal::make_nvp("cms.other_2_0", cms.other_2[0]));
+  ar(::cereal::make_nvp("cms.other_2_1", cms.other_2[1]));
+  ar(::cereal::make_nvp("cms.other_2_2", cms.other_2[2]));
+  ar(::cereal::make_nvp("cms.other_2_3", cms.other_2[3]));
+  ar(CEREAL_NVP(cms.aggressive));
+  ar(CEREAL_NVP(cms.order_for_lu));
+  ar(CEREAL_NVP(cms.nd_compress));
+  ar(CEREAL_NVP(cms.nd_camd));
+  ar(CEREAL_NVP(cms.nd_components));
+  ar(CEREAL_NVP(cms.ordering));
+  static_assert(sizeof(cms.other_3) == 4 * sizeof(std::size_t),
+                "cholmod_common::cholmod_method_struct::other_3 expected to "
+                "have 4 elements.");
+  ar(::cereal::make_nvp("cms.other_3_0", cms.other_3[0]));
+  ar(::cereal::make_nvp("cms.other_3_1", cms.other_3[1]));
+  ar(::cereal::make_nvp("cms.other_3_2", cms.other_3[2]));
+  ar(::cereal::make_nvp("cms.other_3_3", cms.other_3[3]));
+}
+
+namespace detail {
+
+template <class Archive>
+inline void encode_array(Archive &ar, const char *name, void *source,
+                         std::size_t size_bytes) {
+  std::string payload =
+      gzip::compress(reinterpret_cast<const char *>(source), size_bytes);
+  if (::cereal::traits::is_text_archive<Archive>::value) {
+    payload =
+        base64::encode(reinterpret_cast<const unsigned char *>(payload.data()),
+                       payload.size());
+  }
+  ar(::cereal::make_nvp(name, payload));
+}
+
+template <class Archive>
+inline void decode_array(Archive &ar, const char *name, void *destination,
+                         std::size_t expected_bytes) {
+  ALBATROSS_ASSERT(nullptr != destination);
+  std::string payload;
+  ar(::cereal::make_nvp(name, payload));
+  if (::cereal::traits::is_text_archive<Archive>::value) {
+    payload = base64::decode(payload);
+  }
+  const std::string decompressed =
+      gzip::decompress(payload.data(), payload.size());
+  ALBATROSS_ASSERT(decompressed.size() == expected_bytes);
+  std::memcpy(destination, decompressed.data(), decompressed.size());
+}
+
+// This exists because 1) the suitesparse memory functions require a
+// cholmod_common pointer for statistics 2) the suitesparse realloc
+// helpers have difficult state properties.
+inline void suitesparse_cereal_realloc(void **p, std::size_t count,
+                                       std::size_t elem_size) {
+  if (nullptr != *p) {
+    free(*p);
+  }
+  *p = malloc(count * elem_size);
+  ALBATROSS_ASSERT(nullptr != *p);
+}
+
+}  // namespace detail
+
+template <class Archive>
+inline void save(Archive &ar, cholmod_common const &cc,
+                 std::uint32_t version ALBATROSS_UNUSED) {
+  ar(CEREAL_NVP(cc.dbound));
+  ar(CEREAL_NVP(cc.grow0));
+  ar(CEREAL_NVP(cc.grow1));
+  ar(CEREAL_NVP(cc.grow2));
+  ar(CEREAL_NVP(cc.maxrank));
+  ar(CEREAL_NVP(cc.supernodal_switch));
+  ar(CEREAL_NVP(cc.supernodal));
+  ar(CEREAL_NVP(cc.final_asis));
+  ar(CEREAL_NVP(cc.final_super));
+  ar(CEREAL_NVP(cc.final_ll));
+  ar(CEREAL_NVP(cc.final_pack));
+  ar(CEREAL_NVP(cc.final_monotonic));
+  ar(CEREAL_NVP(cc.final_resymbol));
+  static_assert(sizeof(cc.zrelax) == 3 * sizeof(double),
+                "cholmod_common::zrelax expected to have 3 elements.");
+  ar(::cereal::make_nvp("cc.zrelax0", cc.zrelax[0]));
+  ar(::cereal::make_nvp("cc.zrelax1", cc.zrelax[1]));
+  ar(::cereal::make_nvp("cc.zrelax2", cc.zrelax[2]));
+  static_assert(sizeof(cc.nrelax) == 3 * sizeof(std::size_t),
+                "cholmod_common::nrelax expected to have 3 elements.");
+  ar(::cereal::make_nvp("cc.nrelax0", cc.nrelax[0]));
+  ar(::cereal::make_nvp("cc.nrelax1", cc.nrelax[1]));
+  ar(::cereal::make_nvp("cc.nrelax2", cc.nrelax[2]));
+  ar(CEREAL_NVP(cc.prefer_zomplex));
+  ar(CEREAL_NVP(cc.prefer_upper));
+  ar(CEREAL_NVP(cc.quick_return_if_not_posdef));
+  ar(CEREAL_NVP(cc.prefer_binary));
+  ar(CEREAL_NVP(cc.print));
+  ar(CEREAL_NVP(cc.precise));
+  ar(CEREAL_NVP(cc.try_catch));
+  // Do not serialise the user error handler.
+  ar(CEREAL_NVP(cc.nmethods));
+  ar(CEREAL_NVP(cc.current));
+  ar(CEREAL_NVP(cc.selected));
+  constexpr std::size_t max_methods = sizeof(cc.method) / sizeof(cc.method[0]);
+  for (std::size_t m = 0; m < max_methods; ++m) {
+    ar(cc.method[m]);
+  }
+  // method
+  ar(CEREAL_NVP(cc.postorder));
+  ar(CEREAL_NVP(cc.default_nesdis));
+  ar(CEREAL_NVP(cc.metis_memory));
+  ar(CEREAL_NVP(cc.metis_dswitch));
+  ar(CEREAL_NVP(cc.metis_nswitch));
+  ar(::cereal::make_nvp("nrow", cc.nrow));
+  ar(CEREAL_NVP(cc.mark));
+  ar(::cereal::make_nvp("iworksize", cc.iworksize));
+  // The comments in `cholmod_core.h` define this as a size in bytes.
+  // The code, however, considers it to be a number of elements.
+  ar(::cereal::make_nvp("xworksize", cc.xworksize));
+
+  const std::size_t cholmod_int_size =
+      cc.itype == CHOLMOD_LONG ? sizeof(SuiteSparse_long) : sizeof(int);
+
+  detail::encode_array(ar, "cc.Flag", cc.Flag, cc.nrow * cholmod_int_size);
+  detail::encode_array(ar, "cc.Head", cc.Head,
+                       (cc.nrow + 1) * cholmod_int_size);
+  detail::encode_array(ar, "cc.Xwork", cc.Xwork, cc.xworksize * sizeof(double));
+
+  // Iwork omitted; must reinitialize
+  ar(CEREAL_NVP(cc.itype));
+  ar(CEREAL_NVP(cc.dtype));
+  ar(CEREAL_NVP(cc.no_workspace_reallocate));
+  ar(CEREAL_NVP(cc.status));
+  ar(CEREAL_NVP(cc.fl));
+  ar(CEREAL_NVP(cc.lnz));
+  ar(CEREAL_NVP(cc.anz));
+  ar(CEREAL_NVP(cc.modfl));
+  ar(CEREAL_NVP(cc.malloc_count));
+  ar(CEREAL_NVP(cc.memory_usage));
+  ar(CEREAL_NVP(cc.memory_inuse));
+  ar(CEREAL_NVP(cc.nrealloc_col));
+  ar(CEREAL_NVP(cc.nrealloc_factor));
+  ar(CEREAL_NVP(cc.ndbounds_hit));
+  ar(CEREAL_NVP(cc.rowfacfl));
+  ar(CEREAL_NVP(cc.aatfl));
+  ar(CEREAL_NVP(cc.called_nd));
+  ar(CEREAL_NVP(cc.blas_ok));
+  ar(CEREAL_NVP(cc.SPQR_grain));
+  ar(CEREAL_NVP(cc.SPQR_small));
+  ar(CEREAL_NVP(cc.SPQR_shrink));
+  ar(CEREAL_NVP(cc.SPQR_nthreads));
+  ar(CEREAL_NVP(cc.SPQR_flopcount));
+  ar(CEREAL_NVP(cc.SPQR_analyze_time));
+  ar(CEREAL_NVP(cc.SPQR_factorize_time));
+  ar(CEREAL_NVP(cc.SPQR_solve_time));
+  ar(CEREAL_NVP(cc.SPQR_flopcount_bound));
+  ar(CEREAL_NVP(cc.SPQR_tol_used));
+  ar(CEREAL_NVP(cc.SPQR_norm_E_fro));
+  static_assert(sizeof(cc.SPQR_istat) == 10 * sizeof(SuiteSparse_long),
+                "cholmod_common.SPQR_istat expected to have 10 elements.");
+  ar(::cereal::make_nvp("cc.SPQR_istat0", cc.SPQR_istat[0]));
+  ar(::cereal::make_nvp("cc.SPQR_istat1", cc.SPQR_istat[1]));
+  ar(::cereal::make_nvp("cc.SPQR_istat2", cc.SPQR_istat[2]));
+  ar(::cereal::make_nvp("cc.SPQR_istat3", cc.SPQR_istat[3]));
+  ar(::cereal::make_nvp("cc.SPQR_istat4", cc.SPQR_istat[4]));
+  ar(::cereal::make_nvp("cc.SPQR_istat5", cc.SPQR_istat[5]));
+  ar(::cereal::make_nvp("cc.SPQR_istat6", cc.SPQR_istat[6]));
+  ar(::cereal::make_nvp("cc.SPQR_istat7", cc.SPQR_istat[7]));
+  ar(::cereal::make_nvp("cc.SPQR_istat8", cc.SPQR_istat[8]));
+  ar(::cereal::make_nvp("cc.SPQR_istat9", cc.SPQR_istat[9]));
+
+  // Completely ignore all the GPU stuff.
+#ifdef GPU_BLAS
+  static_assert(false,
+                "This codec will not work for CHOLMOD / SPQR using GPU!");
+#endif  // GPU_BLAS
+  ALBATROSS_ASSERT(cc.useGPU == 0);
+  ar(CEREAL_NVP(cc.useGPU));
+
+  ar(CEREAL_NVP(cc.syrkStart));
+  ar(CEREAL_NVP(cc.cholmod_cpu_gemm_time));
+  ar(CEREAL_NVP(cc.cholmod_cpu_syrk_time));
+  ar(CEREAL_NVP(cc.cholmod_cpu_trsm_time));
+  ar(CEREAL_NVP(cc.cholmod_cpu_potrf_time));
+  ar(CEREAL_NVP(cc.cholmod_assemble_time));
+  ar(CEREAL_NVP(cc.cholmod_assemble_time2));
+  ar(CEREAL_NVP(cc.cholmod_cpu_gemm_calls));
+  ar(CEREAL_NVP(cc.cholmod_cpu_syrk_calls));
+  ar(CEREAL_NVP(cc.cholmod_cpu_trsm_calls));
+  ar(CEREAL_NVP(cc.cholmod_cpu_potrf_calls));
+}
+
+template <class Archive>
+inline void load(Archive &ar, cholmod_common &cc,
+                 std::uint32_t version ALBATROSS_UNUSED) {
+  ar(CEREAL_NVP(cc.dbound));
+  ar(CEREAL_NVP(cc.grow0));
+  ar(CEREAL_NVP(cc.grow1));
+  ar(CEREAL_NVP(cc.grow2));
+  ar(CEREAL_NVP(cc.maxrank));
+  ar(CEREAL_NVP(cc.supernodal_switch));
+  ar(CEREAL_NVP(cc.supernodal));
+  ar(CEREAL_NVP(cc.final_asis));
+  ar(CEREAL_NVP(cc.final_super));
+  ar(CEREAL_NVP(cc.final_ll));
+  ar(CEREAL_NVP(cc.final_pack));
+  ar(CEREAL_NVP(cc.final_monotonic));
+  ar(CEREAL_NVP(cc.final_resymbol));
+  static_assert(sizeof(cc.zrelax) == 3 * sizeof(double),
+                "cholmod_common::zrelax expected to have 3 elements.");
+  ar(::cereal::make_nvp("cc.zrelax0", cc.zrelax[0]));
+  ar(::cereal::make_nvp("cc.zrelax1", cc.zrelax[1]));
+  ar(::cereal::make_nvp("cc.zrelax2", cc.zrelax[2]));
+  static_assert(sizeof(cc.nrelax) == 3 * sizeof(std::size_t),
+                "cholmod_common::nrelax expected to have 3 elements.");
+  ar(::cereal::make_nvp("cc.nrelax0", cc.nrelax[0]));
+  ar(::cereal::make_nvp("cc.nrelax1", cc.nrelax[1]));
+  ar(::cereal::make_nvp("cc.nrelax2", cc.nrelax[2]));
+  ar(CEREAL_NVP(cc.prefer_zomplex));
+  ar(CEREAL_NVP(cc.prefer_upper));
+  ar(CEREAL_NVP(cc.quick_return_if_not_posdef));
+  ar(CEREAL_NVP(cc.prefer_binary));
+  ar(CEREAL_NVP(cc.print));
+  ar(CEREAL_NVP(cc.precise));
+  ar(CEREAL_NVP(cc.try_catch));
+  // Do not serialise the user error handler.
+  ar(CEREAL_NVP(cc.nmethods));
+  ar(CEREAL_NVP(cc.current));
+  ar(CEREAL_NVP(cc.selected));
+  constexpr std::size_t max_methods = sizeof(cc.method) / sizeof(cc.method[0]);
+  for (std::size_t m = 0; m < max_methods; ++m) {
+    ar(cc.method[m]);
+  }
+  // method
+  ar(CEREAL_NVP(cc.postorder));
+  ar(CEREAL_NVP(cc.default_nesdis));
+  ar(CEREAL_NVP(cc.metis_memory));
+  ar(CEREAL_NVP(cc.metis_dswitch));
+  ar(CEREAL_NVP(cc.metis_nswitch));
+  std::size_t nrow = 0;
+  std::size_t iworksize = 0;
+  std::size_t xworksize = 0;
+  ar(CEREAL_NVP(nrow));
+  ar(CEREAL_NVP(cc.mark));
+  ar(CEREAL_NVP(iworksize));
+  ar(CEREAL_NVP(xworksize));
+  const std::size_t cholmod_int_size =
+      cc.itype == CHOLMOD_LONG ? sizeof(SuiteSparse_long) : sizeof(int);
+  ALBATROSS_ASSERT(cholmod_l_free_work(&cc) == 1);
+  ALBATROSS_ASSERT(cholmod_l_allocate_work(nrow, iworksize, xworksize, &cc) ==
+                   1);
+  detail::decode_array(ar, "cc.Flag", cc.Flag, cc.nrow * cholmod_int_size);
+  detail::decode_array(ar, "cc.Head", cc.Head,
+                       (cc.nrow + 1) * cholmod_int_size);
+  detail::decode_array(ar, "cc.Xwork", cc.Xwork, cc.xworksize * sizeof(double));
+
+  cc.Iwork = cholmod_malloc(cc.iworksize, cholmod_int_size, &cc);
+  ar(CEREAL_NVP(cc.itype));
+  ar(CEREAL_NVP(cc.dtype));
+  ar(CEREAL_NVP(cc.no_workspace_reallocate));
+  ar(CEREAL_NVP(cc.status));
+  ar(CEREAL_NVP(cc.fl));
+  ar(CEREAL_NVP(cc.lnz));
+  ar(CEREAL_NVP(cc.anz));
+  ar(CEREAL_NVP(cc.modfl));
+  ar(CEREAL_NVP(cc.malloc_count));
+  ar(CEREAL_NVP(cc.memory_usage));
+  ar(CEREAL_NVP(cc.memory_inuse));
+  ar(CEREAL_NVP(cc.nrealloc_col));
+  ar(CEREAL_NVP(cc.nrealloc_factor));
+  ar(CEREAL_NVP(cc.ndbounds_hit));
+  ar(CEREAL_NVP(cc.rowfacfl));
+  ar(CEREAL_NVP(cc.aatfl));
+  ar(CEREAL_NVP(cc.called_nd));
+  ar(CEREAL_NVP(cc.blas_ok));
+  ar(CEREAL_NVP(cc.SPQR_grain));
+  ar(CEREAL_NVP(cc.SPQR_small));
+  ar(CEREAL_NVP(cc.SPQR_shrink));
+  ar(CEREAL_NVP(cc.SPQR_nthreads));
+  ar(CEREAL_NVP(cc.SPQR_flopcount));
+  ar(CEREAL_NVP(cc.SPQR_analyze_time));
+  ar(CEREAL_NVP(cc.SPQR_factorize_time));
+  ar(CEREAL_NVP(cc.SPQR_solve_time));
+  ar(CEREAL_NVP(cc.SPQR_flopcount_bound));
+  ar(CEREAL_NVP(cc.SPQR_tol_used));
+  ar(CEREAL_NVP(cc.SPQR_norm_E_fro));
+  static_assert(sizeof(cc.SPQR_istat) == 10 * sizeof(SuiteSparse_long),
+                "cholmod_common.SPQR_istat expected to have 10 elements.");
+  ar(::cereal::make_nvp("cc.SPQR_istat0", cc.SPQR_istat[0]));
+  ar(::cereal::make_nvp("cc.SPQR_istat1", cc.SPQR_istat[1]));
+  ar(::cereal::make_nvp("cc.SPQR_istat2", cc.SPQR_istat[2]));
+  ar(::cereal::make_nvp("cc.SPQR_istat3", cc.SPQR_istat[3]));
+  ar(::cereal::make_nvp("cc.SPQR_istat4", cc.SPQR_istat[4]));
+  ar(::cereal::make_nvp("cc.SPQR_istat5", cc.SPQR_istat[5]));
+  ar(::cereal::make_nvp("cc.SPQR_istat6", cc.SPQR_istat[6]));
+  ar(::cereal::make_nvp("cc.SPQR_istat7", cc.SPQR_istat[7]));
+  ar(::cereal::make_nvp("cc.SPQR_istat8", cc.SPQR_istat[8]));
+  ar(::cereal::make_nvp("cc.SPQR_istat9", cc.SPQR_istat[9]));
+
+  // Completely ignore all the GPU stuff.
+#ifdef GPU_BLAS
+  static_assert(false,
+                "This codec will not work for CHOLMOD / SPQR using GPU!");
+#endif  // GPU_BLAS
+  ar(CEREAL_NVP(cc.useGPU));
+  ALBATROSS_ASSERT(cc.useGPU == 0);
+
+  ar(CEREAL_NVP(cc.syrkStart));
+  ar(CEREAL_NVP(cc.cholmod_cpu_gemm_time));
+  ar(CEREAL_NVP(cc.cholmod_cpu_syrk_time));
+  ar(CEREAL_NVP(cc.cholmod_cpu_trsm_time));
+  ar(CEREAL_NVP(cc.cholmod_cpu_potrf_time));
+  ar(CEREAL_NVP(cc.cholmod_assemble_time));
+  ar(CEREAL_NVP(cc.cholmod_assemble_time2));
+  ar(CEREAL_NVP(cc.cholmod_cpu_gemm_calls));
+  ar(CEREAL_NVP(cc.cholmod_cpu_syrk_calls));
+  ar(CEREAL_NVP(cc.cholmod_cpu_trsm_calls));
+  ar(CEREAL_NVP(cc.cholmod_cpu_potrf_calls));
+}
+
+template <class Matrix>
+inline std::size_t get_element_size_bytes(const Matrix &m) {
+  return m.dtype == CHOLMOD_DOUBLE ? sizeof(double) : sizeof(float);
+}
+
+template <class Matrix>
+inline std::size_t get_num_x_elements(const Matrix &m) {
+  // Complex matrices store twice as many elements.
+  // https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/dev/CHOLMOD/Core/cholmod_sparse.c#L209
+  return m.nzmax * (m.xtype == CHOLMOD_COMPLEX ? 2 : 1);
+}
+
+template <class Matrix>
+inline std::size_t get_p_element_size_bytes(const Matrix &m) {
+  return m.itype == CHOLMOD_INT ? sizeof(int) : sizeof(SuiteSparse_long);
+}
+
+template <class Matrix>
+inline std::size_t get_integer_size_bytes(const Matrix &m) {
+  return m.itype == CHOLMOD_LONG ? sizeof(SuiteSparse_long) : sizeof(int);
+}
+
+template <class Archive>
+inline void save(Archive &ar, cholmod_sparse const &m,
+                 std::uint32_t version ALBATROSS_UNUSED) {
+  ar(CEREAL_NVP(m.nrow));
+  ar(CEREAL_NVP(m.ncol));
+  ar(CEREAL_NVP(m.nzmax));
+  ar(CEREAL_NVP(m.stype));
+  ar(CEREAL_NVP(m.itype));
+  ar(CEREAL_NVP(m.xtype));
+  ar(CEREAL_NVP(m.dtype));
+  ar(CEREAL_NVP(m.sorted));
+  ar(CEREAL_NVP(m.packed));
+
+  const std::size_t element_size_bytes = get_element_size_bytes(m);
+  const std::size_t x_elements = get_num_x_elements(m);
+  const std::size_t p_size_bytes = get_p_element_size_bytes(m);
+  const std::size_t integer_size_bytes = get_integer_size_bytes(m);
+
+  detail::encode_array(ar, "m.p", m.p, (m.ncol + 1) * p_size_bytes);
+  detail::encode_array(ar, "m.i", m.i, m.nzmax * integer_size_bytes);
+  if (nullptr != m.nz && !m.packed) {
+    detail::encode_array(ar, "m.nz", m.nz, m.ncol * integer_size_bytes);
+  }
+  if (nullptr != m.x) {
+    detail::encode_array(ar, "m.x", m.x, x_elements * element_size_bytes);
+  }
+  // This should only be non-null for "zomplex" elements
+  ALBATROSS_ASSERT(m.z == nullptr);
+}
+
+template <class Archive>
+inline void load(Archive &ar, cholmod_sparse &m,
+                 std::uint32_t version ALBATROSS_UNUSED) {
+  ar(CEREAL_NVP(m.nrow));
+  ar(CEREAL_NVP(m.ncol));
+  ar(CEREAL_NVP(m.nzmax));
+  ar(CEREAL_NVP(m.stype));
+  ar(CEREAL_NVP(m.itype));
+  ar(CEREAL_NVP(m.xtype));
+  ar(CEREAL_NVP(m.dtype));
+  ar(CEREAL_NVP(m.sorted));
+  ar(CEREAL_NVP(m.packed));
+
+  const std::size_t element_size_bytes = get_element_size_bytes(m);
+  const std::size_t x_elements = get_num_x_elements(m);
+  const std::size_t p_size_bytes = get_p_element_size_bytes(m);
+  const std::size_t integer_size_bytes = get_integer_size_bytes(m);
+
+  detail::suitesparse_cereal_realloc(&m.p, m.ncol + 1, p_size_bytes);
+  detail::suitesparse_cereal_realloc(&m.i, m.nzmax, integer_size_bytes);
+  if (!m.packed) {
+    detail::suitesparse_cereal_realloc(&m.nz, m.ncol, integer_size_bytes);
+  }
+  detail::suitesparse_cereal_realloc(&m.x, m.nzmax, element_size_bytes);
+
+  detail::decode_array(ar, "m.p", m.p, (m.ncol + 1) * p_size_bytes);
+  detail::decode_array(ar, "m.i", m.i, m.nzmax * integer_size_bytes);
+  if (!m.packed) {
+    detail::decode_array(ar, "m.nz", m.nz, m.ncol * integer_size_bytes);
+  }
+  // TODO(@peddie): in what cases may `x` be absent?
+  detail::decode_array(ar, "m.x", m.x, x_elements * element_size_bytes);
+  // This should only be non-null for "zomplex" elements
+  ALBATROSS_ASSERT(m.z == nullptr);
+}
+
+template <class Archive>
+inline void save(Archive &ar, cholmod_dense const &m,
+                 std::uint32_t version ALBATROSS_UNUSED) {
+  ar(CEREAL_NVP(m.nrow));
+  ar(CEREAL_NVP(m.ncol));
+  ar(CEREAL_NVP(m.nzmax));
+  ar(CEREAL_NVP(m.d));
+  ar(CEREAL_NVP(m.xtype));
+  ar(CEREAL_NVP(m.dtype));
+  ALBATROSS_ASSERT(m.d >= m.nrow);
+
+  const std::size_t element_size_bytes = get_element_size_bytes(m);
+  const std::size_t x_elements = get_num_x_elements(m);
+
+  if (nullptr != m.x) {
+    detail::encode_array(ar, "m.x", m.x, x_elements * element_size_bytes);
+  }
+  // "zomplex" only
+  ALBATROSS_ASSERT(nullptr == m.z);
+}
+
+template <class Archive>
+inline void load(Archive &ar, cholmod_dense &m,
+                 std::uint32_t version ALBATROSS_UNUSED) {
+  ar(CEREAL_NVP(m.nrow));
+  ar(CEREAL_NVP(m.ncol));
+  ar(CEREAL_NVP(m.nzmax));
+  ar(CEREAL_NVP(m.d));
+  ar(CEREAL_NVP(m.xtype));
+  ar(CEREAL_NVP(m.dtype));
+  ALBATROSS_ASSERT(m.d >= m.nrow);
+
+  const std::size_t element_size_bytes = get_element_size_bytes(m);
+  const std::size_t x_elements = get_num_x_elements(m);
+
+  detail::suitesparse_cereal_realloc(&m.x, x_elements, element_size_bytes);
+  detail::decode_array(ar, "m.x", m.x, x_elements * element_size_bytes);
+  // "zomplex" only
+  ALBATROSS_ASSERT(nullptr == m.z);
+}
+
+}  // namespace cereal
+
+#endif  // ALBATROSS_CEREAL_SUITESPARSE_H

--- a/include/albatross/src/eigen/serializable_spqr.hpp
+++ b/include/albatross/src/eigen/serializable_spqr.hpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_EIGEN_SERIALIZABLE_SPQR_H
+#define ALBATROSS_EIGEN_SERIALIZABLE_SPQR_H
+
+namespace Eigen {
+
+template <typename _MatrixType>
+class SerializableSPQR : public SPQR<_MatrixType> {
+  using Base = SPQR<_MatrixType>;
+public:
+  using Base::rows;
+  using Base::cols;
+  using StorageIndex = typename Base::StorageIndex;
+  enum { ColsAtCompileTime = Dynamic, MaxColsAtCompileTime = Dynamic };
+  SerializableSPQR() : Base() {
+    // Eigen does not initialise these, but it will happily call
+    // `SPQR_free()` on itself in its destructor.  Try initializing
+    // one and destructing it without passing it a matrix.
+    this->m_cR = nullptr;
+    this->m_E = nullptr;
+    this->m_H = nullptr;
+    this->m_HPinv = nullptr;
+    this->m_HTau = nullptr;
+  }
+
+  template <class Archive>
+  void save(Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) const;
+
+  template <class Archive>
+  void load(Archive &ar, const std::uint32_t version ALBATROSS_UNUSED);
+};
+
+}  // namespace Eigen
+
+#endif  // ALBATROSS_EIGEN_SERIALIZABLE_SPQR_H

--- a/include/albatross/src/eigen/serializable_spqr.hpp
+++ b/include/albatross/src/eigen/serializable_spqr.hpp
@@ -18,9 +18,10 @@ namespace Eigen {
 template <typename _MatrixType>
 class SerializableSPQR : public SPQR<_MatrixType> {
   using Base = SPQR<_MatrixType>;
+
 public:
-  using Base::rows;
   using Base::cols;
+  using Base::rows;
   using StorageIndex = typename Base::StorageIndex;
   enum { ColsAtCompileTime = Dynamic, MaxColsAtCompileTime = Dynamic };
   SerializableSPQR() : Base() {
@@ -41,6 +42,6 @@ public:
   void load(Archive &ar, const std::uint32_t version ALBATROSS_UNUSED);
 };
 
-}  // namespace Eigen
+} // namespace Eigen
 
-#endif  // ALBATROSS_EIGEN_SERIALIZABLE_SPQR_H
+#endif // ALBATROSS_EIGEN_SERIALIZABLE_SPQR_H

--- a/include/albatross/src/linalg/qr_utils.hpp
+++ b/include/albatross/src/linalg/qr_utils.hpp
@@ -26,11 +26,11 @@ get_R(const Eigen::ColPivHouseholderQR<Eigen::MatrixXd> &qr) {
 }
 
 /*
- * Computes R^-T P^T rhs given R and P from a ColPivHouseholderQR decomposition.
+ * Computes R^-T P^T rhs given R and P from a QR decomposition.
  */
-template <typename MatrixType>
+template <typename MatrixType, typename PermutationIndicesType>
 inline Eigen::MatrixXd sqrt_solve(const Eigen::MatrixXd &R,
-                                  const Eigen::VectorXi &permutation_indices,
+                                  const PermutationIndicesType &permutation_indices,
                                   const MatrixType &rhs) {
 
   Eigen::MatrixXd sqrt(rhs.rows(), rhs.cols());

--- a/include/albatross/src/linalg/qr_utils.hpp
+++ b/include/albatross/src/linalg/qr_utils.hpp
@@ -29,9 +29,10 @@ get_R(const Eigen::ColPivHouseholderQR<Eigen::MatrixXd> &qr) {
  * Computes R^-T P^T rhs given R and P from a QR decomposition.
  */
 template <typename MatrixType, typename PermutationIndicesType>
-inline Eigen::MatrixXd sqrt_solve(const Eigen::MatrixXd &R,
-                                  const PermutationIndicesType &permutation_indices,
-                                  const MatrixType &rhs) {
+inline Eigen::MatrixXd
+sqrt_solve(const Eigen::MatrixXd &R,
+           const PermutationIndicesType &permutation_indices,
+           const MatrixType &rhs) {
 
   Eigen::MatrixXd sqrt(rhs.rows(), rhs.cols());
   for (Eigen::Index i = 0; i < permutation_indices.size(); ++i) {

--- a/include/albatross/src/linalg/spqr_utils.hpp
+++ b/include/albatross/src/linalg/spqr_utils.hpp
@@ -85,7 +85,8 @@ template <typename MatrixType>
 inline void SPQR_set_pivot_threshold(
     SPQR *spqr, const MatrixType &m,
     double spqr_pivot_coefficient = kSPQRPivotCoefficient) {
-  SPQR_set_pivot_threshold(spqr, m, kMinSparsePivotSize, spqr_pivot_coefficient);
+  SPQR_set_pivot_threshold(spqr, m, kMinSparsePivotSize,
+                           spqr_pivot_coefficient);
 }
 
 inline void SPQR_set_threads(SPQR *spqr, std::size_t num_threads) {

--- a/include/albatross/src/linalg/spqr_utils.hpp
+++ b/include/albatross/src/linalg/spqr_utils.hpp
@@ -88,30 +88,30 @@ inline void SPQR_set_pivot_threshold(
   SPQR_set_pivot_threshold(spqr, m, kMinSparsePivotSize, spqr_pivot_coefficient);
 }
 
-inline std::unique_ptr<SPQR> SPQR_create() {
-  auto spqr = std::make_unique<SPQR>();
-  spqr->setSPQROrdering(SPQR_ORDERING_COLAMD);
-  return spqr;
-}
-
-inline std::unique_ptr<SPQR> SPQR_create(const SparseMatrix &A) {
-  auto spqr = SPQR_create();
-  SPQR_set_pivot_threshold(spqr.get(), A);
-  spqr->compute(A);
-  return spqr;
-}
-
 inline void SPQR_set_threads(SPQR *spqr, std::size_t num_threads) {
   spqr->cholmodCommon()->SPQR_nthreads = static_cast<int>(num_threads);
 }
 
 inline void SPQR_set_threads(SPQR *spqr, const ThreadPool *pool) {
   if (pool != nullptr) {
-    spqr->cholmodCommon()->SPQR_nthreads =
-        static_cast<int>(pool->thread_count());
+    SPQR_set_threads(spqr, pool->thread_count());
   }
 }
 
+inline std::unique_ptr<SPQR> SPQR_create(const ThreadPool *pool = nullptr) {
+  auto spqr = std::make_unique<SPQR>();
+  spqr->setSPQROrdering(SPQR_ORDERING_COLAMD);
+  SPQR_set_threads(spqr.get(), pool);
+  return spqr;
+}
+
+inline std::unique_ptr<SPQR> SPQR_create(const SparseMatrix &A,
+                                         const ThreadPool *pool = nullptr) {
+  auto spqr = SPQR_create(pool);
+  SPQR_set_pivot_threshold(spqr.get(), A);
+  spqr->compute(A);
+  return spqr;
+}
 
 } // namespace albatross
 

--- a/include/albatross/src/linalg/spqr_utils.hpp
+++ b/include/albatross/src/linalg/spqr_utils.hpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2022 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_SRC_LINALG_SPQR_UTILS_HPP
+#define ALBATROSS_SRC_LINALG_SPQR_UTILS_HPP
+
+namespace albatross {
+
+using SparseMatrix = Eigen::SparseMatrix<double>;
+
+using SPQR = Eigen::SPQR<SparseMatrix>;
+
+using SparsePermutationMatrix =
+    Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic,
+                             SPQR::StorageIndex>;
+
+inline Eigen::MatrixXd get_R(const SPQR &qr) {
+  return qr.matrixR()
+      .topLeftCorner(qr.cols(), qr.cols())
+      .template triangularView<Eigen::Upper>();
+}
+
+template <typename MatrixType>
+inline Eigen::MatrixXd sqrt_solve(const SPQR &qr, const MatrixType &rhs) {
+  return sqrt_solve(get_R(qr), qr.colsPermutation().indices(), rhs);
+}
+
+// Matrices with any dimension smaller than this will use a special
+// "small problem" pivot threshold.
+constexpr Eigen::Index kMinSparsePivotSize = 300;
+
+// This coefficient replaces the hardcoded factor of 20 in the default
+// SPQR pivot threshold policy.
+constexpr double kSPQRPivotCoefficient = 0.1;
+
+// Set the pivot threshold of the solver based on the problem to be
+// solved.
+//
+// The default SPQR pivot threshold calculation is oriented towards
+// problems considerably larger than your typical Albatross use case.
+// Depending on your problem, it may be advantageous to use this
+// function to choose a smaller threshold than the default and trade a
+// minimal speed reduction for accuracy improvements.
+template <typename MatrixType>
+inline void SPQR_set_pivot_threshold(SPQR *spqr, const MatrixType &m,
+                                     Eigen::Index min_sparse_pivot_size,
+                                     double spqr_pivot_coefficient) {
+  if (m.rows() < min_sparse_pivot_size || m.cols() < min_sparse_pivot_size) {
+    // For small matrices, just use a really tight threshold for pivot
+    // detection to reduce the inaccuracy of the sparse method.
+    spqr->setPivotThreshold(1e-15);
+  }
+  // For larger matrices, use the default SuiteSparseQR policy to
+  // choose the pivot threshold, but accept a user-controlled
+  // coefficient.
+  double max2Norm = 0.0;
+  for (Eigen::Index j = 0; j < m.cols(); j++) {
+    max2Norm = Eigen::numext::maxi(max2Norm, m.col(j).norm());
+  }
+  if (max2Norm == 0.) {
+    max2Norm = 1.;
+  }
+  spqr->setPivotThreshold(spqr_pivot_coefficient *
+                          cast::to_double(m.rows() + m.cols()) * max2Norm *
+                          Eigen::NumTraits<double>::epsilon());
+}
+
+template <typename MatrixType>
+inline void SPQR_set_pivot_threshold(SPQR *spqr, const MatrixType &m,
+                                     Eigen::Index min_sparse_pivot_size) {
+  SPQR_set_pivot_threshold(spqr, m, min_sparse_pivot_size,
+                           kSPQRPivotCoefficient);
+}
+
+template <typename MatrixType>
+inline void SPQR_set_pivot_threshold(
+    SPQR *spqr, const MatrixType &m,
+    double spqr_pivot_coefficient = kSPQRPivotCoefficient) {
+  SPQR_set_pivot_threshold(spqr, m, kMinSparsePivotSize, spqr_pivot_coefficient);
+}
+
+inline std::unique_ptr<SPQR> SPQR_create() {
+  auto spqr = std::make_unique<SPQR>();
+  spqr->setSPQROrdering(SPQR_ORDERING_COLAMD);
+  return spqr;
+}
+
+inline std::unique_ptr<SPQR> SPQR_create(const SparseMatrix &A) {
+  auto spqr = SPQR_create();
+  SPQR_set_pivot_threshold(spqr.get(), A);
+  spqr->compute(A);
+  return spqr;
+}
+
+inline void SPQR_set_threads(SPQR *spqr, std::size_t num_threads) {
+  spqr->cholmodCommon()->SPQR_nthreads = static_cast<int>(num_threads);
+}
+
+inline void SPQR_set_threads(SPQR *spqr, const ThreadPool *pool) {
+  if (pool != nullptr) {
+    spqr->cholmodCommon()->SPQR_nthreads =
+        static_cast<int>(pool->thread_count());
+  }
+}
+
+
+} // namespace albatross
+
+#endif // ALBATROSS_SRC_LINALG_SPQR_UTILS_HPP

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -321,8 +321,7 @@ public:
       B.col(pi).topRows(i + 1) = old_fit.sigma_R.col(i).topRows(i + 1);
     }
     B.bottomRows(n_new) = A_ldlt.sqrt_solve(K_fu);
-    auto B_qr = SPQR_create(B.sparseView());
-    SPQR_set_threads(B_qr.get(), Base::threads_.get());
+    auto B_qr = SPQR_create(B.sparseView(), Base::threads_.get());
 
     // Form:
     //   y_aug = |R_old P_old^T v_old|
@@ -377,7 +376,7 @@ public:
     Eigen::MatrixXd B(A_ldlt.rows() + K_uu_ldlt.rows(), K_uu_ldlt.rows());
     B.topRows(A_ldlt.rows()) = A_ldlt.sqrt_solve(K_fu);
     B.bottomRows(K_uu_ldlt.rows()) = K_uu_ldlt.sqrt_transpose();
-    return SPQR_create(B.sparseView());
+    return SPQR_create(B.sparseView(), Base::threads_.get());
   };
 
   template <
@@ -398,7 +397,6 @@ public:
     compute_internal_components(u, features, targets, &A_ldlt, &K_uu_ldlt,
                                 &K_fu, &y);
     auto B_qr = compute_sigma_qr(K_uu_ldlt, A_ldlt, K_fu);
-    SPQR_set_threads(B_qr.get(), Base::threads_.get());
 
     Eigen::VectorXd y_augmented = Eigen::VectorXd::Zero(B_qr->rows());
     y_augmented.topRows(y.size()) = A_ldlt.sqrt_solve(y, Base::threads_.get());

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -358,18 +358,6 @@ public:
   // which corresponds to the inverse square root of Sigma
   //
   //   Sigma = (B^T B)^-1
-  //
-  // Eigen::ColPivHouseholderQR<Eigen::MatrixXd>
-  // compute_sigma_qr(const Eigen::SerializableLDLT &K_uu_ldlt,
-  //                  const BlockDiagonalLDLT &A_ldlt,
-  //                  const Eigen::MatrixXd &K_fu) const {
-  //   Eigen::MatrixXd B(A_ldlt.rows() + K_uu_ldlt.rows(), K_uu_ldlt.rows());
-  //   B.topRows(A_ldlt.rows()) = A_ldlt.sqrt_solve(K_fu);
-  //   B.bottomRows(K_uu_ldlt.rows()) = K_uu_ldlt.sqrt_transpose();
-  //   return B.colPivHouseholderQr();
-  // };
-
-  // TODO(@peddie) SPQR configuration
   std::unique_ptr<Eigen::SPQR<Eigen::SparseMatrix<double>>>
   compute_sigma_qr(const Eigen::SerializableLDLT &K_uu_ldlt,
                    const BlockDiagonalLDLT &A_ldlt,

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -370,9 +370,10 @@ public:
   // };
 
   // TODO(@peddie) SPQR configuration
-  std::unique_ptr<Eigen::SPQR<Eigen::SparseMatrix<double>>> compute_sigma_qr(
-      const Eigen::SerializableLDLT &K_uu_ldlt, const BlockDiagonalLDLT &A_ldlt,
-      const Eigen::MatrixXd &K_fu) const {
+  std::unique_ptr<Eigen::SPQR<Eigen::SparseMatrix<double>>>
+  compute_sigma_qr(const Eigen::SerializableLDLT &K_uu_ldlt,
+                   const BlockDiagonalLDLT &A_ldlt,
+                   const Eigen::MatrixXd &K_fu) const {
     Eigen::MatrixXd B(A_ldlt.rows() + K_uu_ldlt.rows(), K_uu_ldlt.rows());
     B.topRows(A_ldlt.rows()) = A_ldlt.sqrt_solve(K_fu);
     B.bottomRows(K_uu_ldlt.rows()) = K_uu_ldlt.sqrt_transpose();
@@ -472,10 +473,10 @@ public:
   using Base::_predict_impl;
 
   template <typename FeatureType, typename FitFeaturetype>
-  Eigen::VectorXd _predict_impl(
-      const std::vector<FeatureType> &features,
-      const Fit<SparseGPFit<FitFeaturetype>> &sparse_gp_fit,
-      PredictTypeIdentity<Eigen::VectorXd> &&) const {
+  Eigen::VectorXd
+  _predict_impl(const std::vector<FeatureType> &features,
+                const Fit<SparseGPFit<FitFeaturetype>> &sparse_gp_fit,
+                PredictTypeIdentity<Eigen::VectorXd> &&) const {
     const auto cross_cov =
         this->covariance_function_(sparse_gp_fit.train_features, features);
     Eigen::VectorXd mean =
@@ -485,10 +486,10 @@ public:
   }
 
   template <typename FeatureType, typename FitFeaturetype>
-  MarginalDistribution _predict_impl(
-      const std::vector<FeatureType> &features,
-      const Fit<SparseGPFit<FitFeaturetype>> &sparse_gp_fit,
-      PredictTypeIdentity<MarginalDistribution> &&) const {
+  MarginalDistribution
+  _predict_impl(const std::vector<FeatureType> &features,
+                const Fit<SparseGPFit<FitFeaturetype>> &sparse_gp_fit,
+                PredictTypeIdentity<MarginalDistribution> &&) const {
     const auto cross_cov =
         this->covariance_function_(sparse_gp_fit.train_features, features);
     Eigen::VectorXd mean =
@@ -517,10 +518,10 @@ public:
   }
 
   template <typename FeatureType, typename FitFeaturetype>
-  JointDistribution _predict_impl(
-      const std::vector<FeatureType> &features,
-      const Fit<SparseGPFit<FitFeaturetype>> &sparse_gp_fit,
-      PredictTypeIdentity<JointDistribution> &&) const {
+  JointDistribution
+  _predict_impl(const std::vector<FeatureType> &features,
+                const Fit<SparseGPFit<FitFeaturetype>> &sparse_gp_fit,
+                PredictTypeIdentity<JointDistribution> &&) const {
     const auto cross_cov =
         this->covariance_function_(sparse_gp_fit.train_features, features);
     const Eigen::MatrixXd prior_cov = this->covariance_function_(features);

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -106,11 +106,11 @@ template <typename FeatureType> struct Fit<SparseGPFit<FeatureType>> {
 
   Fit(const std::vector<FeatureType> &features_,
       const Eigen::SerializableLDLT &train_covariance_,
-      Eigen::MatrixXd &&sigma_R_, PermutationIndices &&permutation_indices_,
+      const Eigen::MatrixXd &sigma_R_,
+      PermutationIndices &&permutation_indices_,
       const Eigen::VectorXd &information_, Eigen::Index numerical_rank_)
       : train_features(features_), train_covariance(train_covariance_),
-        sigma_R(std::move(sigma_R_)),
-        permutation_indices(std::move(permutation_indices_)),
+        sigma_R(sigma_R_), permutation_indices(std::move(permutation_indices_)),
         information(information_), numerical_rank(numerical_rank_) {}
 
   void shift_mean(const Eigen::VectorXd &mean_shift) {
@@ -366,7 +366,7 @@ public:
     }
     using FitType = Fit<SparseGPFit<InducingPointFeatureType>>;
     return FitType(
-        old_fit.train_features, old_fit.train_covariance, std::move(R),
+        old_fit.train_features, old_fit.train_covariance, R,
         B_qr->colsPermutation().indices().template cast<Eigen::Index>(), v,
         B_qr->rank());
   }

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -106,11 +106,11 @@ template <typename FeatureType> struct Fit<SparseGPFit<FeatureType>> {
 
   Fit(const std::vector<FeatureType> &features_,
       const Eigen::SerializableLDLT &train_covariance_,
-      const Eigen::MatrixXd sigma_R_,
-      const PermutationIndices permutation_indices_,
+      Eigen::MatrixXd &&sigma_R_, PermutationIndices &&permutation_indices_,
       const Eigen::VectorXd &information_, Eigen::Index numerical_rank_)
       : train_features(features_), train_covariance(train_covariance_),
-        sigma_R(sigma_R_), permutation_indices(permutation_indices_),
+        sigma_R(std::move(sigma_R_)),
+        permutation_indices(std::move(permutation_indices_)),
         information(information_), numerical_rank(numerical_rank_) {}
 
   void shift_mean(const Eigen::VectorXd &mean_shift) {
@@ -366,7 +366,7 @@ public:
     }
     using FitType = Fit<SparseGPFit<InducingPointFeatureType>>;
     return FitType(
-        old_fit.train_features, old_fit.train_covariance, R,
+        old_fit.train_features, old_fit.train_covariance, std::move(R),
         B_qr->colsPermutation().indices().template cast<Eigen::Index>(), v,
         B_qr->rank());
   }

--- a/include/albatross/src/utils/random_utils.hpp
+++ b/include/albatross/src/utils/random_utils.hpp
@@ -148,6 +148,40 @@ inline Eigen::VectorXd random_multivariate_normal(const Eigen::MatrixXd &cov,
                                     gen);
 }
 
+template <typename T>
+Eigen::SparseMatrix<T> random_sparse_matrix(Eigen::Index rows,
+                                            Eigen::Index cols, double fill,
+                                            std::default_random_engine &gen,
+                                            T min_element = -1e6,
+                                            T max_element = 1e6) {
+  std::uniform_real_distribution<T> valdis(min_element, max_element);
+  std::uniform_int_distribution<Eigen::Index> rowdis(0, rows - 1);
+  std::uniform_int_distribution<Eigen::Index> coldis(0, cols - 1);
+
+  std::vector<Eigen::Triplet<T>> tripletList;
+  const auto nnz = static_cast<std::size_t>(static_cast<double>(rows) *
+                                            (static_cast<double>(cols) * fill));
+  std::set<Eigen::Index> nnz_pos;
+  for (std::size_t i = 0; i < nnz; ++i) {
+    Eigen::Index r = rowdis(gen);
+    Eigen::Index c = coldis(gen);
+    Eigen::Index pos = r * cols + c;
+    while (nnz_pos.find(pos) != nnz_pos.end()) {
+      r = rowdis(gen);
+      c = coldis(gen);
+      pos = r * cols + c;
+    }
+
+    nnz_pos.insert(pos);
+    tripletList.emplace_back(r, c, valdis(gen));
+  }
+
+  Eigen::SparseMatrix<T> mat(rows, cols);
+  mat.setFromTriplets(tripletList.begin(),
+                      tripletList.end()); // create the matrix
+  return mat;
+}
+
 } // namespace albatross
 
 #endif

--- a/include/albatross/src/utils/random_utils.hpp
+++ b/include/albatross/src/utils/random_utils.hpp
@@ -149,11 +149,10 @@ inline Eigen::VectorXd random_multivariate_normal(const Eigen::MatrixXd &cov,
 }
 
 template <typename T>
-Eigen::SparseMatrix<T> random_sparse_matrix(Eigen::Index rows,
-                                            Eigen::Index cols, double fill,
-                                            std::default_random_engine &gen,
-                                            T min_element = -1e6,
-                                            T max_element = 1e6) {
+Eigen::SparseMatrix<T>
+random_sparse_matrix(Eigen::Index rows, Eigen::Index cols, double fill,
+                     std::default_random_engine &gen, T min_element = -1e6,
+                     T max_element = 1e6) {
   std::uniform_real_distribution<T> valdis(min_element, max_element);
   std::uniform_int_distribution<Eigen::Index> rowdis(0, rows - 1);
   std::uniform_int_distribution<Eigen::Index> coldis(0, cols - 1);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,8 @@ target_link_libraries(albatross_unit_tests
   nlopt
   z
   zstd::zstd
+  suitesparse::spqr
+  suitesparse::cholmod
   )
 set_target_properties(albatross_unit_tests PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF)
 

--- a/tests/test_models.h
+++ b/tests/test_models.h
@@ -53,6 +53,22 @@ public:
   auto get_dataset() const { return make_toy_linear_data(); }
 };
 
+class MakeSparseQRSparseGaussianProcess {
+public:
+  MakeSparseQRSparseGaussianProcess(){};
+
+  auto get_model() const {
+    LeaveOneOutGrouper loo;
+    UniformlySpacedInducingPoints strategy(25);
+
+    auto covariance = make_simple_covariance_function();
+    return sparse_gp_from_covariance(covariance, loo, strategy, "example",
+                                     SPQRImplementation{});
+  }
+
+  auto get_dataset() const { return make_toy_linear_data(); }
+};
+
 class MakeGaussianProcessWithMean {
   const double a = 5.;
   const double b = 1.;
@@ -287,6 +303,7 @@ public:
 
 typedef ::testing::Types<MakeLinearRegression, MakeGaussianProcess,
                          MakeGaussianProcessWithMean, MakeSparseGaussianProcess,
+                         MakeSparseQRSparseGaussianProcess,
                          MakeAdaptedGaussianProcess, MakeRansacGaussianProcess,
                          MakeRansacChiSquaredGaussianProcess,
                          MakeRansacChiSquaredGaussianProcessWithMean,

--- a/tests/test_samplers.cc
+++ b/tests/test_samplers.cc
@@ -145,7 +145,18 @@ struct LeaveOneIntervalOut {
   long int operator()(const double &f) const { return get_group(f); }
 };
 
-TEST(test_samplers, test_samplers_sparse_gp) {
+template <typename QRImplementation>
+class SparseGaussianProcessSamplerTest : public ::testing::Test {
+public:
+  QRImplementation qr;
+};
+
+typedef ::testing::Types<DenseQRImplementation, SPQRImplementation>
+    SolveStrategies;
+TYPED_TEST_SUITE(SparseGaussianProcessSamplerTest, SolveStrategies);
+
+TYPED_TEST(SparseGaussianProcessSamplerTest, test_samplers_sparse_gp) {
+  auto &qr_ = this->qr;
   const double a = 3.14;
   const double b = sqrt(2.);
   const double meas_noise_sd = 1.;
@@ -164,7 +175,7 @@ TEST(test_samplers, test_samplers_sparse_gp) {
   UniformlySpacedInducingPoints strategy(5);
 
   auto model = sparse_gp_from_covariance_and_mean(meas_noise, linear, grouper,
-                                                  strategy, "test");
+                                                  strategy, "test", qr_);
   model.set_prior("inducing_nugget", FixedPrior());
   model.set_prior("measurement_nugget", FixedPrior());
 

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -525,15 +525,19 @@ using SPQR = Eigen::SerializableSPQR<SparseMatrix>;
 
 TEST(test_serialize, serialize_spqr_simple) {
   Eigen::MatrixXd Adense(3, 3);
+  // clang-format off
   Adense <<
     1., 4, 2,
     2, 2, 9.1,
     4, 8, 111.2;
+  // clang-format on
   Eigen::VectorXd b(3);
+  // clang-format off
   b <<
     2,
     4,
     99;
+  // clang-format on
   SPQR spqr;
   spqr.setSPQROrdering(SPQR_ORDERING_COLAMD);
   spqr.compute(Adense.sparseView());

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -428,8 +428,8 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_and_update) {
   const auto iter_pred = iteratively_fit_model.predict(test_features).joint();
   const auto direct_pred = direct_fit_model.predict(test_features).joint();
 
-  EXPECT_LT((direct_pred.mean - iter_pred.mean).norm(), 2e-2);
-  EXPECT_LT((direct_pred.covariance - iter_pred.covariance).norm(), 2e-3);
+  EXPECT_LT((direct_pred.mean - iter_pred.mean).norm(), 1e-5);
+  EXPECT_LT((direct_pred.covariance - iter_pred.covariance).norm(), 2e-5);
 }
 
 TYPED_TEST(SparseGaussianProcessTest, test_shift_inducing_points) {

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -428,8 +428,8 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_and_update) {
   const auto iter_pred = iteratively_fit_model.predict(test_features).joint();
   const auto direct_pred = direct_fit_model.predict(test_features).joint();
 
-  EXPECT_LT((direct_pred.mean - iter_pred.mean).norm(), 4e-4);
-  EXPECT_LT((direct_pred.covariance - iter_pred.covariance).norm(), 8e-4);
+  EXPECT_LT((direct_pred.mean - iter_pred.mean).norm(), 4e-3);
+  EXPECT_LT((direct_pred.covariance - iter_pred.covariance).norm(), 8e-3);
 }
 
 TYPED_TEST(SparseGaussianProcessTest, test_shift_inducing_points) {

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -396,13 +396,13 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_and_update) {
   auto &grouper_ = this->grouper;
   auto &qr_ = this->qr;
   auto covariance = make_simple_covariance_function();
-  auto dataset = make_toy_linear_data(5, 1, 0.1, 100);
+  auto dataset = make_toy_linear_data();
 
-  UniformlySpacedInducingPoints strategy(100);
+  UniformlySpacedInducingPoints strategy(10);
   auto model =
       sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse", qr_);
   const auto inducing_points = strategy(covariance, dataset.features);
-  auto test_features = linspace(0.1, 9.9, 10);
+  auto test_features = linspace(0.1, 9.9, 5);
 
   const auto grouped = dataset.group_by(grouper_).groups();
   auto iteratively_fit_model = model.fit(grouped.first_value());

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -428,8 +428,8 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_and_update) {
   const auto iter_pred = iteratively_fit_model.predict(test_features).joint();
   const auto direct_pred = direct_fit_model.predict(test_features).joint();
 
-  EXPECT_LT((direct_pred.mean - iter_pred.mean).norm(), 1e-5);
-  EXPECT_LT((direct_pred.covariance - iter_pred.covariance).norm(), 2e-5);
+  EXPECT_LT((direct_pred.mean - iter_pred.mean).norm(), 4e-4);
+  EXPECT_LT((direct_pred.covariance - iter_pred.covariance).norm(), 8e-4);
 }
 
 TYPED_TEST(SparseGaussianProcessTest, test_shift_inducing_points) {

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -28,38 +28,47 @@ struct LeaveOneIntervalOut {
   long int operator()(const double &f) const { return get_group(f); }
 };
 
-template <typename GrouperFunction>
+template <typename GrouperFunctionAndQRImplementation>
 class SparseGaussianProcessTest : public ::testing::Test {
 public:
+  using GrouperFunction =
+      typename GrouperFunctionAndQRImplementation::first_type;
+  using QRImplementation =
+      typename GrouperFunctionAndQRImplementation::second_type;
   GrouperFunction grouper;
+  QRImplementation qr;
 };
 
-typedef ::testing::Types<LeaveOneIntervalOut> IndependenceAssumptions;
-TYPED_TEST_SUITE(SparseGaussianProcessTest, IndependenceAssumptions);
+typedef ::testing::Types<std::pair<LeaveOneIntervalOut, DenseQRImplementation>,
+                         std::pair<LeaveOneIntervalOut, SPQRImplementation>>
+    IndependenceAssumptionsAndSolveStrategies;
+TYPED_TEST_SUITE(SparseGaussianProcessTest,
+                 IndependenceAssumptionsAndSolveStrategies);
 
-template <typename CovFunc, typename GrouperFunction>
-void expect_sparse_gp_performance(const CovFunc &covariance,
-                                  const GrouperFunction &grouper,
-                                  double sparse_error_threshold,
-                                  double really_sparse_error_threshold) {
+template <typename CovFunc, typename GrouperFunction,
+          typename QRImplementation = DenseQRImplementation>
+void expect_sparse_gp_performance(
+    const CovFunc &covariance, const GrouperFunction &grouper,
+    double sparse_error_threshold, double really_sparse_error_threshold,
+    QRImplementation qr = DenseQRImplementation{}) {
 
   auto dataset = make_toy_linear_data();
   auto direct = gp_from_covariance(covariance, "direct");
 
   UniformlySpacedInducingPoints strategy(8);
   auto sparse =
-      sparse_gp_from_covariance(covariance, grouper, strategy, "sparse");
+      sparse_gp_from_covariance(covariance, grouper, strategy, "sparse", qr);
   sparse.set_param_value(details::inducing_nugget_name(), 1e-3);
   sparse.set_param_value(details::measurement_nugget_name(), 1e-12);
 
   UniformlySpacedInducingPoints bad_strategy(3);
-  auto really_sparse = sparse_gp_from_covariance(covariance, grouper,
-                                                 bad_strategy, "really_sparse");
+  auto really_sparse = sparse_gp_from_covariance(
+      covariance, grouper, bad_strategy, "really_sparse", qr);
   really_sparse.set_param_value(details::inducing_nugget_name(), 1e-3);
   really_sparse.set_param_value(details::measurement_nugget_name(), 1e-12);
 
   auto state_space =
-      sparse_gp_from_covariance(covariance, grouper, "state_space");
+      sparse_gp_from_covariance(covariance, grouper, "state_space", qr);
   state_space.set_param_value(details::inducing_nugget_name(), 1e-3);
   state_space.set_param_value(details::measurement_nugget_name(), 1e-12);
 
@@ -104,28 +113,28 @@ void expect_sparse_gp_performance(const CovFunc &covariance,
 }
 
 TYPED_TEST(SparseGaussianProcessTest, test_sanity) {
-
   auto &grouper_ = this->grouper;
+  auto &qr_ = this->qr;
   auto covariance = make_simple_covariance_function();
 
   // When the length scale is large the model with more inducing points
   // gets very nearly singular.  this checks to make sure that's dealt with
   // gracefully.
   covariance.set_param_value("squared_exponential_length_scale", 1000.);
-  expect_sparse_gp_performance(covariance, grouper_, 1e-2, 0.5);
+  expect_sparse_gp_performance(covariance, grouper_, 1e-2, 0.5, qr_);
 
   covariance.set_param_value("squared_exponential_length_scale", 100.);
-  expect_sparse_gp_performance(covariance, grouper_, 1e-2, 0.5);
+  expect_sparse_gp_performance(covariance, grouper_, 1e-2, 0.5, qr_);
 
   // Then when the length scale is shorter, the really sparse model
   // should become significantly worse than the sparse one.
   covariance.set_param_value("squared_exponential_length_scale", 10.);
-  expect_sparse_gp_performance(covariance, grouper_, 5e-2, 100.);
+  expect_sparse_gp_performance(covariance, grouper_, 5e-2, 100., qr_);
 }
 
 TYPED_TEST(SparseGaussianProcessTest, test_scales) {
-
   auto &grouper_ = this->grouper;
+  auto &qr_ = this->qr;
 
   auto large_dataset = make_toy_sine_data(5., 10., 0.1, 3000);
 
@@ -146,7 +155,7 @@ TYPED_TEST(SparseGaussianProcessTest, test_scales) {
 
   UniformlySpacedInducingPoints strategy(100);
   auto sparse =
-      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse");
+      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse", qr_);
 
   sparse.set_param_value("inducing_nugget", 1e-6);
 
@@ -161,14 +170,14 @@ TYPED_TEST(SparseGaussianProcessTest, test_scales) {
 }
 
 TYPED_TEST(SparseGaussianProcessTest, test_likelihood) {
-
   auto &grouper_ = this->grouper;
+  auto &qr_ = this->qr;
   auto dataset = make_toy_sine_data(5., 10., 0.1, 12);
   auto covariance = make_simple_covariance_function();
 
   UniformlySpacedInducingPoints strategy(2);
   auto sparse =
-      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse");
+      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse", qr_);
   const auto inducing_points = strategy(covariance, dataset.features);
   // We need to make sure the priors on the parameters don't enter
   // into the log_likelihood computation.
@@ -226,7 +235,6 @@ struct FixedInducingPoints {
 };
 
 TEST(test_sparse_gp, test_update_exists) {
-
   using CovFunc = SquaredExponential<EuclideanDistance>;
   using MeanFunc = ZeroMean;
   using GrouperFunction = LeaveOneIntervalOut;
@@ -242,8 +250,26 @@ TEST(test_sparse_gp, test_update_exists) {
   EXPECT_TRUE(bool(can_update_in_place<SparseGPR, FitType, double>::value));
 }
 
+TEST(test_sparse_gp_sparse_qr, test_update_exists) {
+  using CovFunc = SquaredExponential<EuclideanDistance>;
+  using MeanFunc = ZeroMean;
+  using GrouperFunction = LeaveOneIntervalOut;
+  using InducingPointStrategy = UniformlySpacedInducingPoints;
+
+  using SparseGPR =
+      SparseGaussianProcessRegression<CovFunc, MeanFunc, GrouperFunction,
+                                      InducingPointStrategy,
+                                      SPQRImplementation>;
+
+  using FitType = Fit<SparseGPFit<double>>;
+
+  EXPECT_TRUE(bool(has_valid_update<SparseGPR, FitType, double>::value));
+  EXPECT_TRUE(bool(can_update_in_place<SparseGPR, FitType, double>::value));
+}
+
 TYPED_TEST(SparseGaussianProcessTest, test_update) {
   auto &grouper_ = this->grouper;
+  auto &qr_ = this->qr;
   auto covariance = make_simple_covariance_function();
   auto dataset = make_toy_linear_data();
 
@@ -254,7 +280,7 @@ TYPED_TEST(SparseGaussianProcessTest, test_update) {
 
   FixedInducingPoints strategy(min, max, 8);
   auto sparse =
-      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse");
+      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse", qr_);
   sparse.set_param_value(details::inducing_nugget_name(), 1e-3);
   sparse.set_param_value(details::measurement_nugget_name(), 1e-12);
 
@@ -324,6 +350,7 @@ TYPED_TEST(SparseGaussianProcessTest, test_update) {
 
 TYPED_TEST(SparseGaussianProcessTest, test_rebase_inducing_points) {
   auto &grouper_ = this->grouper;
+  auto &qr_ = this->qr;
   auto covariance = make_simple_covariance_function();
   auto dataset = make_toy_linear_data();
 
@@ -334,7 +361,7 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_inducing_points) {
 
   FixedInducingPoints strategy(min, max, 8);
   auto sparse =
-      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse");
+      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse", qr_);
   sparse.set_param_value(details::inducing_nugget_name(), 1e-3);
   sparse.set_param_value(details::measurement_nugget_name(), 1e-12);
 
@@ -366,14 +393,14 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_inducing_points) {
 }
 
 TYPED_TEST(SparseGaussianProcessTest, test_rebase_and_update) {
-
   auto &grouper_ = this->grouper;
+  auto &qr_ = this->qr;
   auto covariance = make_simple_covariance_function();
   auto dataset = make_toy_linear_data(5, 1, 0.1, 100);
 
   UniformlySpacedInducingPoints strategy(100);
   auto model =
-      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse");
+      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse", qr_);
   const auto inducing_points = strategy(covariance, dataset.features);
   auto test_features = linspace(0.1, 9.9, 10);
 
@@ -407,6 +434,7 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_and_update) {
 
 TYPED_TEST(SparseGaussianProcessTest, test_shift_inducing_points) {
   auto &grouper_ = this->grouper;
+  auto &qr_ = this->qr;
   auto covariance = make_simple_covariance_function();
   auto dataset = make_toy_linear_data();
 
@@ -417,7 +445,7 @@ TYPED_TEST(SparseGaussianProcessTest, test_shift_inducing_points) {
 
   FixedInducingPoints strategy(min, max, 8);
   auto sparse =
-      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse");
+      sparse_gp_from_covariance(covariance, grouper_, strategy, "sparse", qr_);
   sparse.set_param_value(details::inducing_nugget_name(), 1e-3);
   sparse.set_param_value(details::measurement_nugget_name(), 1e-12);
 

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -127,7 +127,7 @@ TYPED_TEST(SparseGaussianProcessTest, test_scales) {
 
   auto &grouper_ = this->grouper;
 
-  auto large_dataset = make_toy_sine_data(5., 10., 0.1, 1000);
+  auto large_dataset = make_toy_sine_data(5., 10., 0.1, 3000);
 
   auto covariance = make_simple_covariance_function();
 
@@ -379,19 +379,12 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_and_update) {
 
   const auto grouped = dataset.group_by(grouper_).groups();
   auto iteratively_fit_model = model.fit(grouped.first_value());
-  std::cerr << "A:\n"
-            << iteratively_fit_model.predict(test_features).joint()
-            << std::endl;
 
   // The first fit is going to space the inducing points only over the
   // first group, here we set the inducing points to what they
   // would be if we'd fit to everything
   iteratively_fit_model =
       rebase_inducing_points(iteratively_fit_model, inducing_points);
-
-  std::cerr << "B:\n"
-            << iteratively_fit_model.predict(test_features).joint()
-            << std::endl;
 
   // Then iteratively update with the rest of the groups
   bool first = true;
@@ -408,8 +401,8 @@ TYPED_TEST(SparseGaussianProcessTest, test_rebase_and_update) {
   const auto iter_pred = iteratively_fit_model.predict(test_features).joint();
   const auto direct_pred = direct_fit_model.predict(test_features).joint();
 
-  EXPECT_LT((direct_pred.mean - iter_pred.mean).norm(), 1e-3);
-  EXPECT_LT((direct_pred.covariance - iter_pred.covariance).norm(), 2e-4);
+  EXPECT_LT((direct_pred.mean - iter_pred.mean).norm(), 2e-2);
+  EXPECT_LT((direct_pred.covariance - iter_pred.covariance).norm(), 2e-3);
 }
 
 TYPED_TEST(SparseGaussianProcessTest, test_shift_inducing_points) {


### PR DESCRIPTION
When the observation matrix (covariance between measurements to inducing points) is sufficiently sparse, a fit or update to a `SparseGP` model can be computed significantly more quickly using a sparse solver.  This patch adds support for doing this calculation with the multifrontal SPQR solver from Suitesparse rather than with Eigen's built-in Householder QR routine.

## Measurements

On a Swift model with fill ratio around 0.3, around 10k measurements and 1k inducing points, adopting SPQR alone provided over 4x speedup in the _O(N^3)_ solve step.  This increased to nearly 7x when SPQR was instructed to use 8 threads internally.  In combination with MKL, the speedup vs. the original dense QR approached 9x (again with 8 threads).

Your results may vary depending on your problem, architecture and more.