### PR TITLE
[SRV-225] standardize thread pool size

### DIFF
--- a/include/albatross/src/utils/async_utils.hpp
+++ b/include/albatross/src/utils/async_utils.hpp
@@ -17,6 +17,8 @@ namespace albatross {
 
 namespace detail {
 
+static constexpr std::size_t cDefaultStackSize{8 * 1024 * 1024};
+
 inline bool should_serial_apply(ThreadPool *pool) {
   return (nullptr == pool) || (pool->thread_count() <= 1);
 }
@@ -216,7 +218,7 @@ make_shared_thread_pool(std::size_t threads = 0) {
   const auto init = []() {};
 #endif // EIGEN_USE_MKL_ALL || EIGEN_USE_MKL_VML
 
-  return std::make_shared<ThreadPool>(threads, init);
+  return std::make_shared<ThreadPool>(threads, init, detail::cDefaultStackSize);
 }
 
 inline std::size_t get_thread_count(const std::shared_ptr<ThreadPool> &pool) {

--- a/include/albatross/src/utils/async_utils.hpp
+++ b/include/albatross/src/utils/async_utils.hpp
@@ -17,8 +17,6 @@ namespace albatross {
 
 namespace detail {
 
-static constexpr std::size_t cDefaultStackSize{8 * 1024 * 1024};
-
 inline bool should_serial_apply(ThreadPool *pool) {
   return (nullptr == pool) || (pool->thread_count() <= 1);
 }
@@ -203,13 +201,14 @@ static constexpr std::nullptr_t serial_thread_pool = nullptr;
 // Returns a thread pool.  By default, the thread pool has
 // `get_default_thread_count()` threads.
 inline std::shared_ptr<ThreadPool>
-make_shared_thread_pool(std::size_t threads = 0) {
-  if (threads == 1) {
+make_shared_thread_pool(std::size_t num_threads = 0,
+                        std::size_t stack_size = 0) {
+  if (num_threads == 1) {
     return serial_thread_pool;
   }
 
-  if (threads < 1) {
-    threads = get_default_thread_count();
+  if (num_threads < 1) {
+    num_threads = get_default_thread_count();
   }
 
 #if defined(EIGEN_USE_MKL_ALL) || defined(EIGEN_USE_MKL_VML)
@@ -218,7 +217,7 @@ make_shared_thread_pool(std::size_t threads = 0) {
   const auto init = []() {};
 #endif // EIGEN_USE_MKL_ALL || EIGEN_USE_MKL_VML
 
-  return std::make_shared<ThreadPool>(threads, init, detail::cDefaultStackSize);
+  return std::make_shared<ThreadPool>(num_threads, init, stack_size);
 }
 
 inline std::size_t get_thread_count(const std::shared_ptr<ThreadPool> &pool) {


### PR DESCRIPTION
# Changes

See: https://github.com/swift-nav/ThreadPool/pull/2 for background information.

The changes here make it so that the thread size is explicit and avoids stack overflow as the stack size differs between platform. This fixes issues on MacOS, among other systems.