### PR TITLE
Add linear_combination::to_linear_combination()

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -218,6 +218,7 @@ swift_cc_test(
         "tests/test_group_by.cc",
         "tests/test_indexing.cc",
         "tests/test_linalg_utils.cc",
+        "tests/test_linear_combination.cc",
         "tests/test_map_utils.cc",
         "tests/test_minimum_spanning_tree.cc",
         "tests/test_model_adapter.cc",

--- a/include/albatross/src/core/linear_combination.hpp
+++ b/include/albatross/src/core/linear_combination.hpp
@@ -42,6 +42,8 @@ template <typename X> struct LinearCombination {
   Eigen::VectorXd coefficients;
 };
 
+namespace linear_combination {
+
 template <typename X> inline auto sum(const X &x, const X &y) {
   Eigen::Vector2d coefs;
   coefs << 1., 1.;
@@ -73,6 +75,16 @@ inline auto difference(const X &x, const Y &y) {
   variant<X, Y> vy = y;
   return difference(vx, vy);
 }
+
+template <typename X> inline auto to_linear_combination(const X &x) {
+  return LinearCombination<X>({x}, Eigen::VectorXd::Ones(1));
+}
+
+template <typename X>
+inline auto to_linear_combination(const LinearCombination<X> &x) {
+  return x;
+}
+} // namespace linear_combination
 
 template <typename Derived, typename X>
 inline auto operator*(const Eigen::SparseMatrixBase<Derived> &matrix,

--- a/include/albatross/src/core/linear_combination.hpp
+++ b/include/albatross/src/core/linear_combination.hpp
@@ -76,6 +76,10 @@ inline auto difference(const X &x, const Y &y) {
   return difference(vx, vy);
 }
 
+// to_linear_combination(x) lets you construct a LinearCombination
+// without explicitly knowing the type of x. If x is already a
+// LinearCombination it gets returned without modification.
+
 template <typename X> inline auto to_linear_combination(const X &x) {
   return LinearCombination<X>({x}, Eigen::VectorXd::Ones(1));
 }

--- a/tests/test_covariance_function.cc
+++ b/tests/test_covariance_function.cc
@@ -230,20 +230,20 @@ TEST(test_covariance_function, test_linear_combinations) {
   const auto one_x = cov_func(x, x);
   const auto one_xy = cov_func(y, x);
 
-  const auto sum_x = sum(x, x);
+  const auto sum_x = linear_combination::sum(x, x);
   EXPECT_EQ(cov_func(sum_x, x), 2. * one_x);
   EXPECT_EQ(cov_func(x, sum_x), 2. * one_x);
   EXPECT_EQ(cov_func(sum_x, sum_x), 4. * one_x);
-  const auto sum_xy = sum(x, y);
+  const auto sum_xy = linear_combination::sum(x, y);
   EXPECT_EQ(cov_func(x, sum_xy), one_x + one_xy);
 
-  const auto diff_y = difference(y, y);
+  const auto diff_y = linear_combination::difference(y, y);
   EXPECT_EQ(cov_func(diff_y, diff_y), 0.);
-  const auto diff_xy = difference(x, y);
+  const auto diff_xy = linear_combination::difference(x, y);
   EXPECT_EQ(cov_func(x, diff_xy), one_x - one_xy);
 
   std::vector<X> xs = {X(), X()};
-  const auto mean_x = mean(xs);
+  const auto mean_x = linear_combination::mean(xs);
   EXPECT_EQ(cov_func(mean_x, mean_x), 0.25 * cov_func(sum_x, sum_x));
 }
 

--- a/tests/test_linear_combination.cc
+++ b/tests/test_linear_combination.cc
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2023 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/Core>
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+TEST(test_linear_combination, test_sum) {
+  int x = 1;
+  int y = 2;
+  const auto combo = linear_combination::sum(x, y);
+  EXPECT_EQ(combo.values.size(), 2);
+  EXPECT_EQ(combo.values[0], x);
+  EXPECT_EQ(combo.values[1], y);
+  EXPECT_EQ(combo.coefficients.size(), 2);
+  EXPECT_EQ(combo.coefficients[0], 1);
+  EXPECT_EQ(combo.coefficients[1], 1);
+}
+
+TEST(test_linear_combination, test_sum_variant) {
+  int x = 1;
+  double y = 3.14159;
+  const auto combo = linear_combination::sum(x, y);
+  EXPECT_EQ(combo.values.size(), 2);
+  EXPECT_EQ(combo.values[0].get<int>(), x);
+  EXPECT_EQ(combo.values[1].get<double>(), y);
+  EXPECT_EQ(combo.coefficients.size(), 2);
+  EXPECT_EQ(combo.coefficients[0], 1);
+  EXPECT_EQ(combo.coefficients[1], 1);
+}
+
+TEST(test_linear_combination, test_difference) {
+  int x = 1;
+  int y = 2;
+  const auto combo = linear_combination::difference(x, y);
+  EXPECT_EQ(combo.values.size(), 2);
+  EXPECT_EQ(combo.values[0], x);
+  EXPECT_EQ(combo.values[1], y);
+  EXPECT_EQ(combo.coefficients.size(), 2);
+  EXPECT_EQ(combo.coefficients[0], 1);
+  EXPECT_EQ(combo.coefficients[1], -1);
+}
+
+TEST(test_linear_combination, test_difference_variant) {
+  int x = 1;
+  double y = 3.14159;
+  const auto combo = linear_combination::difference(x, y);
+  EXPECT_EQ(combo.values.size(), 2);
+  EXPECT_EQ(combo.values[0].get<int>(), x);
+  EXPECT_EQ(combo.values[1].get<double>(), y);
+  EXPECT_EQ(combo.coefficients.size(), 2);
+  EXPECT_EQ(combo.coefficients[0], 1);
+  EXPECT_EQ(combo.coefficients[1], -1);
+}
+
+TEST(test_linear_combination, test_mean) {
+  for (std::size_t i = 1; i < 12; ++i) {
+    std::vector<std::size_t> xs;
+    for (std::size_t j = 0; j < i; ++j) {
+      xs.emplace_back(j);
+    }
+    const auto combo = linear_combination::mean(xs);
+    EXPECT_EQ(combo.values.size(), i);
+    EXPECT_EQ(combo.values, xs);
+    EXPECT_EQ(combo.coefficients.size(), i);
+    const double expected_coef = 1.0 / static_cast<double>(i);
+    for (Eigen::Index j = 0; j < combo.coefficients.size(); ++j) {
+      EXPECT_EQ(combo.coefficients[j], expected_coef);
+    }
+  }
+}
+
+TEST(test_linear_combination, test_to_linear_combination) {
+  int x = 1;
+  const auto combo = linear_combination::to_linear_combination(x);
+  EXPECT_EQ(combo.values.size(), 1);
+  EXPECT_EQ(combo.values[0], x);
+  EXPECT_EQ(combo.coefficients.size(), 1);
+  EXPECT_EQ(combo.coefficients[0], 1);
+}
+
+TEST(test_linear_combination, test_to_combo) {
+  int x = 1;
+  int y = 2;
+  const auto diff = linear_combination::difference(x, y);
+  // diff is already a linear combination
+  const auto combo = linear_combination::to_linear_combination(diff);
+  EXPECT_EQ(combo.values.size(), 2);
+  EXPECT_EQ(combo.values[0], x);
+  EXPECT_EQ(combo.values[1], y);
+  EXPECT_EQ(combo.coefficients.size(), 2);
+  EXPECT_EQ(combo.coefficients[0], 1);
+  EXPECT_EQ(combo.coefficients[1], -1);
+}
+
+} // namespace albatross


### PR DESCRIPTION
Sometimes you have a single type which may or may not be a `LinearCombination` already and you want to either turn it into a trivial linear combination (ie, length one set of values with coefficient of 1) or just use the existing linear combo. You can now do that with:
```
int foo;
// convert to a combo
LinearCombination<int> foo_combo linear_combination::to_linear_combination(foo);
// already a combo so just return the input
LinearCombination<int> foo_combo linear_combination::to_linear_combination(foo_combo);
```

In the process I added a new namespace `linear_combination::` which contains things like `sum()` to avoid possible conflicts with other `sum` methods.