### PR TITLE
Make unique_values(xs, function) work with sets

### DIFF
--- a/include/albatross/src/indexing/unique.hpp
+++ b/include/albatross/src/indexing/unique.hpp
@@ -30,9 +30,23 @@ template <typename ValueType, typename ApplyFunction,
 inline std::set<ApplyType> unique_values(const std::vector<ValueType> &xs,
                                          ApplyFunction &&f) {
   std::set<ApplyType> output;
-  for (const auto &v : xs) {
-    output.emplace(f(v));
-  }
+  std::transform(xs.begin(), xs.end(), std::inserter(output, output.begin()),
+                 std::forward<ApplyFunction>(f));
+  return output;
+}
+
+template <typename ValueType, typename ApplyFunction,
+          typename ApplyType = typename details::value_only_apply_result<
+              ApplyFunction, ValueType>::type,
+          typename std::enable_if<details::is_valid_value_only_apply_function<
+                                      ApplyFunction, ValueType>::value &&
+                                      !std::is_same<void, ApplyType>::value,
+                                  int>::type = 0>
+inline std::set<ApplyType> unique_values(const std::set<ValueType> &xs,
+                                         ApplyFunction &&f) {
+  std::set<ApplyType> output;
+  std::transform(xs.begin(), xs.end(), std::inserter(output, output.begin()),
+                 std::forward<ApplyFunction>(f));
   return output;
 }
 

--- a/tests/test_unique.cc
+++ b/tests/test_unique.cc
@@ -69,4 +69,27 @@ TEST(test_unique, unique_values_function_mixed) {
   EXPECT_EQ(unique_values(values, foo), expected);
 }
 
+// With sets
+
+TEST(test_unique, unique_values_set_function_empty) {
+  std::set<int> values = {};
+  auto foo = [](const auto &) -> double { return 4.; };
+  std::set<double> expected = {};
+  EXPECT_EQ(unique_values(values, foo), expected);
+}
+
+TEST(test_unique, unique_values_set_function) {
+  std::set<int> values = {3, 1, 5, 2};
+  auto foo = [](const auto &) -> double { return 4.; };
+  std::set<double> expected = {4.};
+  EXPECT_EQ(unique_values(values, foo), expected);
+}
+
+TEST(test_unique, unique_values_set_function_non_trival) {
+  std::set<int> values = {0, 1, 2, 3, 4, 5, 6, 7};
+  auto foo = [](const auto &x) -> double { return x % 2; };
+  std::set<double> expected = {0, 1};
+  EXPECT_EQ(unique_values(values, foo), expected);
+}
+
 } // namespace albatross


### PR DESCRIPTION
We have some utilities for `set<T> unique_values(vector<X>, func)`, but sometimes it's nice to be able to manipulate a set.
```
bool is_even(int x) {
  return x & 2 == 0;
}

std::set<int> xs = {0, 1, 2, 3, 4};
std::set<bool> even_or_odd = unique_values(xs, is_even);
```
I thought about calling this `apply` and having it operate the same way `apply` does on vectors, but I think it would be easy to assume that `apply` won't change the size of a container and I think calling it `unique_values` makes it more obvious the result will be a set.