### PR TITLE
Fix new suitesparse version and Apple Clang compiling

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -80,10 +80,10 @@ http_archive(
 http_archive(
     name = "suitesparse",
     build_file = "@rules_swiftnav//third_party:suitesparse.BUILD",
-    sha256 = "f9a5cc2316a967198463198f7bf10fb8c4332de6189b0e405419a7092bc921b7",
-    strip_prefix = "SuiteSparse-7.4.0",
+    sha256 = "dccfb5f75aa83fe2edb4eb2462fc984a086c82bad8433f63c31048d84b565d74",
+    strip_prefix = "SuiteSparse-7.5.1",
     urls = [
-        "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.4.0.tar.gz",
+        "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.5.1.tar.gz",
     ],
 )
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    sha256 = "8e00b694b6dce9c91d811e2e9e13e148af5f1dd329b85b7c5d2d9d2238aa92dc",
-    strip_prefix = "rules_swiftnav-1c51c97743c9632169dd7e5a228c6ce915893236",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/1c51c97743c9632169dd7e5a228c6ce915893236.tar.gz",
+    sha256 = "807ad0cd61f8c0d7b98499a25c6bab7fee9bf17bc977e5e142cd6fccc463eb9d",
+    strip_prefix = "rules_swiftnav-rules_swiftnav-58f1d96472b43afe7995f9a17873365e15989f78",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/rules_swiftnav-58f1d96472b43afe7995f9a17873365e15989f78.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    sha256 = "cecd397562abfde8587a14336032d0223cc4ac5fe7181a305cd9010591831007",
-    strip_prefix = "rules_swiftnav-3d26f38068a0873d3eba9ede8ee7b47b3adc45f9",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/3d26f38068a0873d3eba9ede8ee7b47b3adc45f9.tar.gz",
+    sha256 = "7041ec3b0cb33293fdbbb651767932f2537cd15373526cbf7a274e1c5ee8be26",
+    strip_prefix = "rules_swiftnav-3b3d6e01e5f13f89b963454c1f184de248db861a",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/3b3d6e01e5f13f89b963454c1f184de248db861a.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_swiftnav",
     sha256 = "807ad0cd61f8c0d7b98499a25c6bab7fee9bf17bc977e5e142cd6fccc463eb9d",
-    strip_prefix = "rules_swiftnav-rules_swiftnav-58f1d96472b43afe7995f9a17873365e15989f78",
+    strip_prefix = "rules_swiftnav-58f1d96472b43afe7995f9a17873365e15989f78",
     url = "https://github.com/swift-nav/rules_swiftnav/archive/58f1d96472b43afe7995f9a17873365e15989f78.tar.gz",
 )
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    sha256 = "a1039ae27cbde2b4b8aaafe6f60d4e0611b4d06fa4293e0598fdaed94d335b02",
-    strip_prefix = "rules_swiftnav-4748176f2511dcf126cffaeedc77578032185ff5",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/4748176f2511dcf126cffaeedc77578032185ff5.tar.gz",
+    sha256 = "8e00b694b6dce9c91d811e2e9e13e148af5f1dd329b85b7c5d2d9d2238aa92dc",
+    strip_prefix = "rules_swiftnav-1c51c97743c9632169dd7e5a228c6ce915893236",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/1c51c97743c9632169dd7e5a228c6ce915893236.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")
@@ -80,10 +80,10 @@ http_archive(
 http_archive(
     name = "suitesparse",
     build_file = "@rules_swiftnav//third_party:suitesparse.BUILD",
-    sha256 = "dccfb5f75aa83fe2edb4eb2462fc984a086c82bad8433f63c31048d84b565d74",
-    strip_prefix = "SuiteSparse-7.5.1",
+    sha256 = "4cd3d161f9aa4f98ec5fa725ee5dc27bca960a3714a707a7d12b3d0abb504679",
+    strip_prefix = "SuiteSparse-7.1.0",
     urls = [
-        "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.5.1.tar.gz",
+        "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.1.0.tar.gz",
     ],
 )
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    sha256 = "7041ec3b0cb33293fdbbb651767932f2537cd15373526cbf7a274e1c5ee8be26",
-    strip_prefix = "rules_swiftnav-3b3d6e01e5f13f89b963454c1f184de248db861a",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/3b3d6e01e5f13f89b963454c1f184de248db861a.tar.gz",
+    sha256 = "752962888ca83f8eedf0e892b30810d76c5e153d3072e41c7a43db5d0dd9f6f4",
+    strip_prefix = "rules_swiftnav-366a59a69eee7fe3d8a32e05ff60974e36334649",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/366a59a69eee7fe3d8a32e05ff60974e36334649.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    sha256 = "807ad0cd61f8c0d7b98499a25c6bab7fee9bf17bc977e5e142cd6fccc463eb9d",
-    strip_prefix = "rules_swiftnav-58f1d96472b43afe7995f9a17873365e15989f78",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/58f1d96472b43afe7995f9a17873365e15989f78.tar.gz",
+    sha256 = "b55d543b80b608ca651932a749a25a1c1fda38fc23ad5d1b9b9a91cfb56b1782",
+    strip_prefix = "rules_swiftnav-85405ba2b314ac1155608ebf781c1b2ee0f3a290",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/85405ba2b314ac1155608ebf781c1b2ee0f3a290.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    sha256 = "1cc5c6e5effbac36bf812c8e69ea0fe24284a85befc0724a6a8c182f275d80cc",
-    strip_prefix = "rules_swiftnav-e6ae8980f251b9649ea69d33485ed63488931ea3",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/e6ae8980f251b9649ea69d33485ed63488931ea3.tar.gz",
+    sha256 = "943f42bf94600bf4450e1e1e9ed9df1b46df6d4fe60ccec786405eedce0dbd08",
+    strip_prefix = "rules_swiftnav-d00a00dbb0a14ff91f7fbe93d2d7a1a7cbc1cdae",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/d00a00dbb0a14ff91f7fbe93d2d7a1a7cbc1cdae.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    sha256 = "943f42bf94600bf4450e1e1e9ed9df1b46df6d4fe60ccec786405eedce0dbd08",
-    strip_prefix = "rules_swiftnav-d00a00dbb0a14ff91f7fbe93d2d7a1a7cbc1cdae",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/d00a00dbb0a14ff91f7fbe93d2d7a1a7cbc1cdae.tar.gz",
+    sha256 = "a1039ae27cbde2b4b8aaafe6f60d4e0611b4d06fa4293e0598fdaed94d335b02",
+    strip_prefix = "rules_swiftnav-4748176f2511dcf126cffaeedc77578032185ff5",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/4748176f2511dcf126cffaeedc77578032185ff5.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -80,10 +80,10 @@ http_archive(
 http_archive(
     name = "suitesparse",
     build_file = "@rules_swiftnav//third_party:suitesparse.BUILD",
-    sha256 = "4cd3d161f9aa4f98ec5fa725ee5dc27bca960a3714a707a7d12b3d0abb504679",
-    strip_prefix = "SuiteSparse-7.1.0",
+    sha256 = "f9a5cc2316a967198463198f7bf10fb8c4332de6189b0e405419a7092bc921b7",
+    strip_prefix = "SuiteSparse-7.4.0",
     urls = [
-        "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.1.0.tar.gz",
+        "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v7.4.0.tar.gz",
     ],
 )
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    sha256 = "10081febdaa01c993fd2efc194d28a32537c2c6fec09216fa45d72c7d3c99d71",
-    strip_prefix = "rules_swiftnav-162f79693aa0e9498dca4814a38ed6ca1ed7f4d6",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/162f79693aa0e9498dca4814a38ed6ca1ed7f4d6.tar.gz",
+    sha256 = "1cc5c6e5effbac36bf812c8e69ea0fe24284a85befc0724a6a8c182f275d80cc",
+    strip_prefix = "rules_swiftnav-e6ae8980f251b9649ea69d33485ed63488931ea3",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/e6ae8980f251b9649ea69d33485ed63488931ea3.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    sha256 = "b55d543b80b608ca651932a749a25a1c1fda38fc23ad5d1b9b9a91cfb56b1782",
-    strip_prefix = "rules_swiftnav-85405ba2b314ac1155608ebf781c1b2ee0f3a290",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/85405ba2b314ac1155608ebf781c1b2ee0f3a290.tar.gz",
+    sha256 = "cecd397562abfde8587a14336032d0223cc4ac5fe7181a305cd9010591831007",
+    strip_prefix = "rules_swiftnav-3d26f38068a0873d3eba9ede8ee7b47b3adc45f9",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/3d26f38068a0873d3eba9ede8ee7b47b3adc45f9.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    sha256 = "bab42848df27192cca6947528c94aa44f9934e449915be374342e67c20452ce0",
-    strip_prefix = "rules_swiftnav-faaffc764fbdb22fda4ad67ad1062394462b5339",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/faaffc764fbdb22fda4ad67ad1062394462b5339.tar.gz",
+    sha256 = "10081febdaa01c993fd2efc194d28a32537c2c6fec09216fa45d72c7d3c99d71",
+    strip_prefix = "rules_swiftnav-162f79693aa0e9498dca4814a38ed6ca1ed7f4d6",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/162f79693aa0e9498dca4814a38ed6ca1ed7f4d6.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     
 http_archive(
     name = "rules_swiftnav",
-    sha256 = "752962888ca83f8eedf0e892b30810d76c5e153d3072e41c7a43db5d0dd9f6f4",
-    strip_prefix = "rules_swiftnav-366a59a69eee7fe3d8a32e05ff60974e36334649",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/366a59a69eee7fe3d8a32e05ff60974e36334649.tar.gz",
+    sha256 = "bab42848df27192cca6947528c94aa44f9934e449915be374342e67c20452ce0",
+    strip_prefix = "rules_swiftnav-faaffc764fbdb22fda4ad67ad1062394462b5339",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/faaffc764fbdb22fda4ad67ad1062394462b5339.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -6,7 +6,7 @@ http_archive(
     name = "rules_swiftnav",
     sha256 = "807ad0cd61f8c0d7b98499a25c6bab7fee9bf17bc977e5e142cd6fccc463eb9d",
     strip_prefix = "rules_swiftnav-rules_swiftnav-58f1d96472b43afe7995f9a17873365e15989f78",
-    url = "https://github.com/swift-nav/rules_swiftnav/archive/rules_swiftnav-58f1d96472b43afe7995f9a17873365e15989f78.tar.gz",
+    url = "https://github.com/swift-nav/rules_swiftnav/archive/58f1d96472b43afe7995f9a17873365e15989f78.tar.gz",
 )
 
 load("@rules_swiftnav//cc:repositories.bzl", "register_swift_cc_toolchains", "swift_cc_toolchain")

--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -149,7 +149,6 @@ inline void save(Archive &ar, cholmod_common const &cc,
   // workspace, so we don't even do anything special when we
   // deserialize.
   ar(CEREAL_NVP(cc.itype));
-  ar(CEREAL_NVP(cc.dtype));
   ar(CEREAL_NVP(cc.no_workspace_reallocate));
   ar(CEREAL_NVP(cc.status));
   ar(CEREAL_NVP(cc.fl));
@@ -177,7 +176,7 @@ inline void save(Archive &ar, cholmod_common const &cc,
   ar(CEREAL_NVP(cc.SPQR_flopcount_bound));
   ar(CEREAL_NVP(cc.SPQR_tol_used));
   ar(CEREAL_NVP(cc.SPQR_norm_E_fro));
-  static_assert(sizeof(cc.SPQR_istat) == 10 * sizeof(SuiteSparse_long),
+  static_assert(sizeof(cc.SPQR_istat) == 8 * sizeof(SuiteSparse_long),
                 "cholmod_common.SPQR_istat expected to have 10 elements.");
   ar(::cereal::make_nvp("cc.SPQR_istat0", cc.SPQR_istat[0]));
   ar(::cereal::make_nvp("cc.SPQR_istat1", cc.SPQR_istat[1]));
@@ -261,7 +260,6 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(CEREAL_NVP(cc.mark));
   ALBATROSS_ASSERT(cholmod_l_free_work(&cc) == 1);
   ar(CEREAL_NVP(cc.itype));
-  ar(CEREAL_NVP(cc.dtype));
   ar(CEREAL_NVP(cc.no_workspace_reallocate));
   ar(CEREAL_NVP(cc.status));
   ar(CEREAL_NVP(cc.fl));
@@ -289,7 +287,7 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(CEREAL_NVP(cc.SPQR_flopcount_bound));
   ar(CEREAL_NVP(cc.SPQR_tol_used));
   ar(CEREAL_NVP(cc.SPQR_norm_E_fro));
-  static_assert(sizeof(cc.SPQR_istat) == 10 * sizeof(SuiteSparse_long),
+  static_assert(sizeof(cc.SPQR_istat) == 8 * sizeof(SuiteSparse_long),
                 "cholmod_common.SPQR_istat expected to have 10 elements.");
   ar(::cereal::make_nvp("cc.SPQR_istat0", cc.SPQR_istat[0]));
   ar(::cereal::make_nvp("cc.SPQR_istat1", cc.SPQR_istat[1]));

--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -149,6 +149,11 @@ inline void save(Archive &ar, cholmod_common const &cc,
   // workspace, so we don't even do anything special when we
   // deserialize.
   ar(CEREAL_NVP(cc.itype));
+
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
+  ar(CEREAL_NVP(cc.dtype));
+#endif
+
   ar(CEREAL_NVP(cc.no_workspace_reallocate));
   ar(CEREAL_NVP(cc.status));
   ar(CEREAL_NVP(cc.fl));
@@ -176,8 +181,18 @@ inline void save(Archive &ar, cholmod_common const &cc,
   ar(CEREAL_NVP(cc.SPQR_flopcount_bound));
   ar(CEREAL_NVP(cc.SPQR_tol_used));
   ar(CEREAL_NVP(cc.SPQR_norm_E_fro));
-  static_assert(sizeof(cc.SPQR_istat) == 8 * sizeof(SuiteSparse_long),
-                "cholmod_common.SPQR_istat expected to have 10 elements.");
+
+  // The number of elements was size 10 in CHOLMOD v4.2; reduced to 8 in CHOLMOD
+  // v5:
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
+  constexpr size_t cNumSPQRElements = 10;
+#else
+  constexpr size_t cNumSPQRElements = 8;
+#endif
+  static_assert(
+      sizeof(cc.SPQR_istat) == cNumSPQRElements * sizeof(SuiteSparse_long),
+      "cholmod_common.SPQR_istat expected to have certain number of elements.");
+
   ar(::cereal::make_nvp("cc.SPQR_istat0", cc.SPQR_istat[0]));
   ar(::cereal::make_nvp("cc.SPQR_istat1", cc.SPQR_istat[1]));
   ar(::cereal::make_nvp("cc.SPQR_istat2", cc.SPQR_istat[2]));
@@ -186,8 +201,11 @@ inline void save(Archive &ar, cholmod_common const &cc,
   ar(::cereal::make_nvp("cc.SPQR_istat5", cc.SPQR_istat[5]));
   ar(::cereal::make_nvp("cc.SPQR_istat6", cc.SPQR_istat[6]));
   ar(::cereal::make_nvp("cc.SPQR_istat7", cc.SPQR_istat[7]));
+
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
   ar(::cereal::make_nvp("cc.SPQR_istat8", cc.SPQR_istat[8]));
   ar(::cereal::make_nvp("cc.SPQR_istat9", cc.SPQR_istat[9]));
+#endif
 
   // Completely ignore all the GPU stuff.
 #ifdef GPU_BLAS
@@ -260,6 +278,11 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(CEREAL_NVP(cc.mark));
   ALBATROSS_ASSERT(cholmod_l_free_work(&cc) == 1);
   ar(CEREAL_NVP(cc.itype));
+
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
+  ar(CEREAL_NVP(cc.dtype));
+#endif
+
   ar(CEREAL_NVP(cc.no_workspace_reallocate));
   ar(CEREAL_NVP(cc.status));
   ar(CEREAL_NVP(cc.fl));
@@ -287,8 +310,18 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(CEREAL_NVP(cc.SPQR_flopcount_bound));
   ar(CEREAL_NVP(cc.SPQR_tol_used));
   ar(CEREAL_NVP(cc.SPQR_norm_E_fro));
-  static_assert(sizeof(cc.SPQR_istat) == 8 * sizeof(SuiteSparse_long),
-                "cholmod_common.SPQR_istat expected to have 10 elements.");
+
+// The number of elements was size 10 in CHOLMOD v4.2; reduced to 8 in CHOLMOD
+// v5:
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
+  constexpr size_t cNumSPQRElements = 10;
+#else
+  constexpr size_t cNumSPQRElements = 8;
+#endif
+
+  static_assert(
+      sizeof(cc.SPQR_istat) == cNumSPQRElements * sizeof(SuiteSparse_long),
+      "cholmod_common.SPQR_istat expected to have certain number of elements.");
   ar(::cereal::make_nvp("cc.SPQR_istat0", cc.SPQR_istat[0]));
   ar(::cereal::make_nvp("cc.SPQR_istat1", cc.SPQR_istat[1]));
   ar(::cereal::make_nvp("cc.SPQR_istat2", cc.SPQR_istat[2]));
@@ -297,8 +330,11 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(::cereal::make_nvp("cc.SPQR_istat5", cc.SPQR_istat[5]));
   ar(::cereal::make_nvp("cc.SPQR_istat6", cc.SPQR_istat[6]));
   ar(::cereal::make_nvp("cc.SPQR_istat7", cc.SPQR_istat[7]));
+
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
   ar(::cereal::make_nvp("cc.SPQR_istat8", cc.SPQR_istat[8]));
   ar(::cereal::make_nvp("cc.SPQR_istat9", cc.SPQR_istat[9]));
+#endif
 
   // Completely ignore all the GPU stuff.
 #ifdef GPU_BLAS

--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -15,9 +15,6 @@
 
 namespace cereal {
 
-static_assert(SUITESPARSE_VERSION >= SUITESPARSE_VER_CODE(7, 5),
-              "Suitesparse version 7.5 or greater is required.");
-
 template <class Archive>
 inline void serialize(Archive &ar, cholmod_common::cholmod_method_struct &cms,
                       std::uint32_t version ALBATROSS_UNUSED) {
@@ -152,6 +149,11 @@ inline void save(Archive &ar, cholmod_common const &cc,
   // workspace, so we don't even do anything special when we
   // deserialize.
   ar(CEREAL_NVP(cc.itype));
+
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
+  ar(CEREAL_NVP(cc.dtype));
+#endif
+
   ar(CEREAL_NVP(cc.no_workspace_reallocate));
   ar(CEREAL_NVP(cc.status));
   ar(CEREAL_NVP(cc.fl));
@@ -180,8 +182,15 @@ inline void save(Archive &ar, cholmod_common const &cc,
   ar(CEREAL_NVP(cc.SPQR_tol_used));
   ar(CEREAL_NVP(cc.SPQR_norm_E_fro));
 
+  // The number of elements was size 10 in CHOLMOD v4.2; reduced to 8 in CHOLMOD
+  // v5:
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
+  constexpr size_t cNumSPQRElements = 10;
+#else
+  constexpr size_t cNumSPQRElements = 8;
+#endif
   static_assert(
-      sizeof(cc.SPQR_istat) == 8 * sizeof(SuiteSparse_long),
+      sizeof(cc.SPQR_istat) == cNumSPQRElements * sizeof(SuiteSparse_long),
       "cholmod_common.SPQR_istat expected to have certain number of elements.");
 
   ar(::cereal::make_nvp("cc.SPQR_istat0", cc.SPQR_istat[0]));
@@ -192,6 +201,11 @@ inline void save(Archive &ar, cholmod_common const &cc,
   ar(::cereal::make_nvp("cc.SPQR_istat5", cc.SPQR_istat[5]));
   ar(::cereal::make_nvp("cc.SPQR_istat6", cc.SPQR_istat[6]));
   ar(::cereal::make_nvp("cc.SPQR_istat7", cc.SPQR_istat[7]));
+
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
+  ar(::cereal::make_nvp("cc.SPQR_istat8", cc.SPQR_istat[8]));
+  ar(::cereal::make_nvp("cc.SPQR_istat9", cc.SPQR_istat[9]));
+#endif
 
   // Completely ignore all the GPU stuff.
 #ifdef GPU_BLAS
@@ -264,6 +278,11 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(CEREAL_NVP(cc.mark));
   ALBATROSS_ASSERT(cholmod_l_free_work(&cc) == 1);
   ar(CEREAL_NVP(cc.itype));
+
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
+  ar(CEREAL_NVP(cc.dtype));
+#endif
+
   ar(CEREAL_NVP(cc.no_workspace_reallocate));
   ar(CEREAL_NVP(cc.status));
   ar(CEREAL_NVP(cc.fl));
@@ -292,10 +311,17 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(CEREAL_NVP(cc.SPQR_tol_used));
   ar(CEREAL_NVP(cc.SPQR_norm_E_fro));
 
-  static_assert(
-      sizeof(cc.SPQR_istat) == 8 * sizeof(SuiteSparse_long),
-      "cholmod_common.SPQR_istat expected to have certain number of elements.");
+// The number of elements was size 10 in CHOLMOD v4.2; reduced to 8 in CHOLMOD
+// v5:
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
+  constexpr size_t cNumSPQRElements = 10;
+#else
+  constexpr size_t cNumSPQRElements = 8;
+#endif
 
+  static_assert(
+      sizeof(cc.SPQR_istat) == cNumSPQRElements * sizeof(SuiteSparse_long),
+      "cholmod_common.SPQR_istat expected to have certain number of elements.");
   ar(::cereal::make_nvp("cc.SPQR_istat0", cc.SPQR_istat[0]));
   ar(::cereal::make_nvp("cc.SPQR_istat1", cc.SPQR_istat[1]));
   ar(::cereal::make_nvp("cc.SPQR_istat2", cc.SPQR_istat[2]));
@@ -304,6 +330,11 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(::cereal::make_nvp("cc.SPQR_istat5", cc.SPQR_istat[5]));
   ar(::cereal::make_nvp("cc.SPQR_istat6", cc.SPQR_istat[6]));
   ar(::cereal::make_nvp("cc.SPQR_istat7", cc.SPQR_istat[7]));
+
+#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
+  ar(::cereal::make_nvp("cc.SPQR_istat8", cc.SPQR_istat[8]));
+  ar(::cereal::make_nvp("cc.SPQR_istat9", cc.SPQR_istat[9]));
+#endif
 
   // Completely ignore all the GPU stuff.
 #ifdef GPU_BLAS

--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -15,9 +15,8 @@
 
 namespace cereal {
 
-static_assert(CHOLMOD_VERSION >= CHOLMOD_VER_CODE(5, 0),
-              "Suitesparse including at least version 5.0 of CHOLMOD is "
-              "required. E.g. suitesparse 7.4");
+static_assert(SUITESPARSE_VERSION >= SUITESPARSE_VER_CODE(7, 4),
+              "Suitesparse version 7.4 or greater is required.");
 
 template <class Archive>
 inline void serialize(Archive &ar, cholmod_common::cholmod_method_struct &cms,

--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -15,8 +15,8 @@
 
 namespace cereal {
 
-static_assert(SUITESPARSE_VERSION >= SUITESPARSE_VER_CODE(7, 4),
-              "Suitesparse version 7.4 or greater is required.");
+static_assert(SUITESPARSE_VERSION >= SUITESPARSE_VER_CODE(7, 5),
+              "Suitesparse version 7.5 or greater is required.");
 
 template <class Archive>
 inline void serialize(Archive &ar, cholmod_common::cholmod_method_struct &cms,

--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -15,6 +15,10 @@
 
 namespace cereal {
 
+static_assert(CHOLMOD_VERSION >= CHOLMOD_VER_CODE(5, 0),
+              "Suitesparse including at least version 5.0 of CHOLMOD is "
+              "required. E.g. suitesparse 7.4");
+
 template <class Archive>
 inline void serialize(Archive &ar, cholmod_common::cholmod_method_struct &cms,
                       std::uint32_t version ALBATROSS_UNUSED) {
@@ -149,11 +153,6 @@ inline void save(Archive &ar, cholmod_common const &cc,
   // workspace, so we don't even do anything special when we
   // deserialize.
   ar(CEREAL_NVP(cc.itype));
-
-#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
-  ar(CEREAL_NVP(cc.dtype));
-#endif
-
   ar(CEREAL_NVP(cc.no_workspace_reallocate));
   ar(CEREAL_NVP(cc.status));
   ar(CEREAL_NVP(cc.fl));
@@ -182,15 +181,8 @@ inline void save(Archive &ar, cholmod_common const &cc,
   ar(CEREAL_NVP(cc.SPQR_tol_used));
   ar(CEREAL_NVP(cc.SPQR_norm_E_fro));
 
-  // The number of elements was size 10 in CHOLMOD v4.2; reduced to 8 in CHOLMOD
-  // v5:
-#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
-  constexpr size_t cNumSPQRElements = 10;
-#else
-  constexpr size_t cNumSPQRElements = 8;
-#endif
   static_assert(
-      sizeof(cc.SPQR_istat) == cNumSPQRElements * sizeof(SuiteSparse_long),
+      sizeof(cc.SPQR_istat) == 8 * sizeof(SuiteSparse_long),
       "cholmod_common.SPQR_istat expected to have certain number of elements.");
 
   ar(::cereal::make_nvp("cc.SPQR_istat0", cc.SPQR_istat[0]));
@@ -201,11 +193,6 @@ inline void save(Archive &ar, cholmod_common const &cc,
   ar(::cereal::make_nvp("cc.SPQR_istat5", cc.SPQR_istat[5]));
   ar(::cereal::make_nvp("cc.SPQR_istat6", cc.SPQR_istat[6]));
   ar(::cereal::make_nvp("cc.SPQR_istat7", cc.SPQR_istat[7]));
-
-#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
-  ar(::cereal::make_nvp("cc.SPQR_istat8", cc.SPQR_istat[8]));
-  ar(::cereal::make_nvp("cc.SPQR_istat9", cc.SPQR_istat[9]));
-#endif
 
   // Completely ignore all the GPU stuff.
 #ifdef GPU_BLAS
@@ -278,11 +265,6 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(CEREAL_NVP(cc.mark));
   ALBATROSS_ASSERT(cholmod_l_free_work(&cc) == 1);
   ar(CEREAL_NVP(cc.itype));
-
-#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
-  ar(CEREAL_NVP(cc.dtype));
-#endif
-
   ar(CEREAL_NVP(cc.no_workspace_reallocate));
   ar(CEREAL_NVP(cc.status));
   ar(CEREAL_NVP(cc.fl));
@@ -311,17 +293,10 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(CEREAL_NVP(cc.SPQR_tol_used));
   ar(CEREAL_NVP(cc.SPQR_norm_E_fro));
 
-// The number of elements was size 10 in CHOLMOD v4.2; reduced to 8 in CHOLMOD
-// v5:
-#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
-  constexpr size_t cNumSPQRElements = 10;
-#else
-  constexpr size_t cNumSPQRElements = 8;
-#endif
-
   static_assert(
-      sizeof(cc.SPQR_istat) == cNumSPQRElements * sizeof(SuiteSparse_long),
+      sizeof(cc.SPQR_istat) == 8 * sizeof(SuiteSparse_long),
       "cholmod_common.SPQR_istat expected to have certain number of elements.");
+
   ar(::cereal::make_nvp("cc.SPQR_istat0", cc.SPQR_istat[0]));
   ar(::cereal::make_nvp("cc.SPQR_istat1", cc.SPQR_istat[1]));
   ar(::cereal::make_nvp("cc.SPQR_istat2", cc.SPQR_istat[2]));
@@ -330,11 +305,6 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(::cereal::make_nvp("cc.SPQR_istat5", cc.SPQR_istat[5]));
   ar(::cereal::make_nvp("cc.SPQR_istat6", cc.SPQR_istat[6]));
   ar(::cereal::make_nvp("cc.SPQR_istat7", cc.SPQR_istat[7]));
-
-#if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
-  ar(::cereal::make_nvp("cc.SPQR_istat8", cc.SPQR_istat[8]));
-  ar(::cereal::make_nvp("cc.SPQR_istat9", cc.SPQR_istat[9]));
-#endif
 
   // Completely ignore all the GPU stuff.
 #ifdef GPU_BLAS


### PR DESCRIPTION
https://swift-nav.atlassian.net/browse/OC-729

Handle new Suitesparse version and dix Apple Clang compiling

Submodule links need to be corrected for Cmake and eigen after these PRs are merged
https://github.com/swift-nav/cmake/pull/171
https://github.com/swift-nav/eigen/pull/4