### PR TITLE
Use PermutationMatrix instead of indices

### DIFF
--- a/include/albatross/src/cereal/eigen.hpp
+++ b/include/albatross/src/cereal/eigen.hpp
@@ -91,6 +91,29 @@ inline void load(Archive &archive,
   v.indices() = indices;
 }
 
+template <class Archive, int SizeAtCompileTime, int MaxSizeAtCompileTime,
+          typename _StorageIndex>
+inline void
+save(Archive &archive,
+     const Eigen::PermutationMatrix<SizeAtCompileTime, MaxSizeAtCompileTime,
+                                    _StorageIndex> &v,
+     const std::uint32_t) {
+  archive(cereal::make_nvp("indices", v.indices()));
+}
+
+template <class Archive, int SizeAtCompileTime, int MaxSizeAtCompileTime,
+          typename _StorageIndex>
+inline void
+load(Archive &archive,
+     Eigen::PermutationMatrix<SizeAtCompileTime, MaxSizeAtCompileTime,
+                              _StorageIndex> &v,
+     const std::uint32_t) {
+  typename Eigen::PermutationMatrix<SizeAtCompileTime, MaxSizeAtCompileTime,
+                                    _StorageIndex>::IndicesType indices;
+  archive(cereal::make_nvp("indices", indices));
+  v.indices() = indices;
+}
+
 template <typename Archive, typename _Scalar, int SizeAtCompileTime>
 inline void serialize(Archive &archive,
                       Eigen::DiagonalMatrix<_Scalar, SizeAtCompileTime> &matrix,

--- a/include/albatross/src/cereal/gp.hpp
+++ b/include/albatross/src/cereal/gp.hpp
@@ -41,8 +41,8 @@ inline void serialize(Archive &archive, Fit<SparseGPFit<FeatureType>> &fit,
   archive(cereal::make_nvp("information", fit.information));
   archive(cereal::make_nvp("train_covariance", fit.train_covariance));
   archive(cereal::make_nvp("train_features", fit.train_features));
-  archive(cereal::make_nvp("sigma_R", fit.sigma_R));
-  archive(cereal::make_nvp("permutation_indices", fit.permutation_indices));
+  archive(cereal::make_nvp("R", fit.R));
+  archive(cereal::make_nvp("P", fit.P));
   if (version > 1) {
     archive(cereal::make_nvp("numerical_rank", fit.numerical_rank));
   } else {
@@ -53,9 +53,9 @@ inline void serialize(Archive &archive, Fit<SparseGPFit<FeatureType>> &fit,
 
 template <typename Archive, typename CovFunc, typename MeanFunc,
           typename ImplType>
-void save(Archive &archive,
-          const GaussianProcessBase<CovFunc, MeanFunc, ImplType> &gp,
-          const std::uint32_t) {
+inline void save(Archive &archive,
+                 const GaussianProcessBase<CovFunc, MeanFunc, ImplType> &gp,
+                 const std::uint32_t) {
   archive(cereal::make_nvp("name", gp.get_name()));
   archive(cereal::make_nvp("params", gp.get_params()));
   archive(cereal::make_nvp("insights", gp.insights));
@@ -63,9 +63,9 @@ void save(Archive &archive,
 
 template <typename Archive, typename CovFunc, typename MeanFunc,
           typename ImplType>
-void load(Archive &archive,
-          GaussianProcessBase<CovFunc, MeanFunc, ImplType> &gp,
-          const std::uint32_t version) {
+inline void load(Archive &archive,
+                 GaussianProcessBase<CovFunc, MeanFunc, ImplType> &gp,
+                 const std::uint32_t version) {
   if (version > 0) {
     std::string model_name;
     archive(cereal::make_nvp("name", model_name));

--- a/include/albatross/src/core/declarations.hpp
+++ b/include/albatross/src/core/declarations.hpp
@@ -21,6 +21,13 @@ template <typename... Ts> class variant;
 
 using mapbox::util::variant;
 
+/*
+ * Permutations
+ */
+namespace Eigen {
+using PermutationMatrixX = PermutationMatrix<Dynamic, Dynamic, Index>;
+}
+
 namespace albatross {
 
 /*

--- a/include/albatross/src/linalg/spqr_utils.hpp
+++ b/include/albatross/src/linalg/spqr_utils.hpp
@@ -19,19 +19,20 @@ using SparseMatrix = Eigen::SparseMatrix<double>;
 
 using SPQR = Eigen::SPQR<SparseMatrix>;
 
-using SparsePermutationMatrix =
-    Eigen::PermutationMatrix<Eigen::Dynamic, Eigen::Dynamic,
-                             SPQR::StorageIndex>;
-
 inline Eigen::MatrixXd get_R(const SPQR &qr) {
   return qr.matrixR()
       .topLeftCorner(qr.cols(), qr.cols())
       .template triangularView<Eigen::Upper>();
 }
 
+inline Eigen::PermutationMatrixX get_P(const SPQR &qr) {
+  return Eigen::PermutationMatrixX(
+      qr.colsPermutation().indices().template cast<Eigen::Index>());
+}
+
 template <typename MatrixType>
 inline Eigen::MatrixXd sqrt_solve(const SPQR &qr, const MatrixType &rhs) {
-  return sqrt_solve(get_R(qr), qr.colsPermutation().indices(), rhs);
+  return sqrt_solve(get_R(qr), get_P(qr), rhs);
 }
 
 // Matrices with any dimension smaller than this will use a special

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -322,10 +322,10 @@ TYPED_TEST(SparseGaussianProcessTest, test_update) {
       (updated_in_place_pred.covariance - full_pred.covariance).norm();
 
   auto compute_sigma = [](const auto &fit_model) -> Eigen::MatrixXd {
-    const Eigen::Index n = fit_model.get_fit().sigma_R.cols();
-    Eigen::MatrixXd sigma = sqrt_solve(fit_model.get_fit().sigma_R,
-                                       fit_model.get_fit().permutation_indices,
-                                       Eigen::MatrixXd::Identity(n, n));
+    const Eigen::Index n = fit_model.get_fit().R.cols();
+    Eigen::MatrixXd sigma =
+        sqrt_solve(fit_model.get_fit().R, fit_model.get_fit().P,
+                   Eigen::MatrixXd::Identity(n, n));
     return sigma.transpose() * sigma;
   };
 


### PR DESCRIPTION
The sparse Gaussian process implementations used to store a vector of indices which represented a permutation matrix. The reason it did this was that the `PermutationMatrix` isn't directly serializable, so you end up needing to copy the indices when you deserialize one of these models. Storing the matrices this way led to a number of places with homegrown permutation matrix application, you'd see things like:
```
  for (Eigen::Index i = 0; i < permutation_indices.size(); ++i) {
    lhs.row(i) = rhs.row(permutation_indices.coeff(i));
  }
```
These loops are not easy to interpret. In this case it's computing `lhs = rhs * P.transpose()`, but the transpose is not evident from the code. It's also _really_ easy to introduce a bug in these situations (if the `rhs` isn't the same shape as how `lhs` was allocated you can encounter some really tricky memory handling errors).

This PR adds a serialization method for a raw `PermutationMatrix<>` and changes that to be the type stored in sparse GP fits. While perhaps slightly less efficient in the few situations where we now need to copy indices, that should only really matter when the size of the indices is huge, in which case these copy operations will probably be dwarfed by large linear algebra operations.