### PR TITLE
Add wasserstein-2 metric calculation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -256,6 +256,7 @@ swift_cc_test(
     linkopts = ["-lz"],
     local_defines = ["CSV_IO_NO_THREAD"],
     type = UNIT,
+    size = "large",
     deps = [
         ":albatross",
         ":serialize-testsuite",


### PR DESCRIPTION
The Wasserstein metric measures the distance between two distributions, accounting for differences in both shape and location.  This can be used to compare two multivariate Gaussians.

This change is in support of PIC.