### PR TITLE
Remove additional semicolon

### DIFF
--- a/include/albatross/src/core/parameter_macros.hpp
+++ b/include/albatross/src/core/parameter_macros.hpp
@@ -156,8 +156,8 @@
 #define DECLARE_PARAMS(...) CALL_MACRO_X_FOR_EACH(DECLARE_PARAM, ##__VA_ARGS__)
 
 #define ALBATROSS_DECLARE_PARAMS(...)                                          \
-  DEFINE_GET_PARAMS(__VA_ARGS__);                                              \
-  DEFINE_SET_PARAM(__VA_ARGS__);                                               \
-  DECLARE_PARAMS(__VA_ARGS__);
+  DEFINE_GET_PARAMS(__VA_ARGS__)                                               \
+  DEFINE_SET_PARAM(__VA_ARGS__)                                                \
+  DECLARE_PARAMS(__VA_ARGS__)
 
 #endif


### PR DESCRIPTION
`DEFINE_GET_PARAMS`, `DEFINE_SET_PARAM` and `DECLARE_PARAMS` declare `;` by themselves, calling `ALBATROSS_DECLARE_PARAMS` leads to `;;` being declared, which is not allowed by compilers with strict warnings.

Tested in https://github.com/swift-nav/orion-engine/pull/8882