### PR TITLE
Allow external use of typecast

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -38,6 +38,7 @@ cc_library(
         "include/albatross/SparseGP",
         "include/albatross/Stats",
         "include/albatross/Tune",
+        "include/albatross/Typecast",
         "include/albatross/linalg/Block",
         "include/albatross/linalg/Utils",
         "include/albatross/serialize/Common",

--- a/include/albatross/Typecast
+++ b/include/albatross/Typecast
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_TYPECAST_INCLUDE_H
+#define ALBATROSS_TYPECAST_INCLUDE_H
+
+#include <Eigen/Core>
+
+#include <albatross/src/details/error_handling.hpp>
+#include <albatross/src/details/typecast.hpp>
+
+#endif


### PR DESCRIPTION
This enables using typecast functions without pulling `Albatross/Common`