### PR TITLE
Make Wasserstein-2 distance metric robust

### DIFF
--- a/include/albatross/src/evaluation/prediction_metrics.hpp
+++ b/include/albatross/src/evaluation/prediction_metrics.hpp
@@ -153,9 +153,14 @@ inline Eigen::MatrixXd principal_sqrt(const Eigen::MatrixXd &input) {
   const Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigs(input);
   Eigen::VectorXd eigenvalues{eigs.eigenvalues()};
   if (!(eigs.eigenvalues().array() >= 0.).all()) {
-    // In the unfortunate case of ill-conditioned arguments, which can easily
-    // happen when comparing two nearby distributions, we clamp
+    // In the unfortunate case of ill-conditioned arguments, which can
+    // easily happen when comparing two nearby distributions, we clamp
     // numerically negative but morally OK eigenvalues to 0.
+    //
+    // The factor of 10 here is a heuristic to allow small negative
+    // eigenvalues (due to numerical errors) but not clamp
+    // meaningfully large ones that indicate a serious problem in
+    // calculation.
     const double min_positive =
         (eigenvalues.array() > 0)
             .select(eigenvalues.array(),

--- a/tests/test_stats.cc
+++ b/tests/test_stats.cc
@@ -184,8 +184,8 @@ template <typename RandomNumberGenerator>
 JointDistribution
 ill_conditioned_random_distribution(Eigen::Index dimension,
                                     RandomNumberGenerator &gen) {
-  bool gave_tiny = false;
-  auto dist = [gave_tiny = gave_tiny](auto &rng) mutable {
+  bool gave_tiny_eigenvalue = false;
+  auto dist = [gave_tiny = gave_tiny_eigenvalue](auto &rng) mutable {
     if (!gave_tiny) {
       gave_tiny = true;
       return cPoorConditioning;


### PR DESCRIPTION
In the case of ill-conditioned covariances or very small distances, the eigenvalues in the calculation of the principal square root have been observed to become numerically negative.  This commit modifies the routine to clamp these tiny negative eigenvalues to zero in this situation.