### PR TITLE
Remove debug spam

### DIFF
--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -439,8 +439,6 @@ inline void load(Archive &ar, cholmod_sparse &m,
   }
   detail::suitesparse_cereal_realloc(&m.x, m.nzmax, element_size_bytes);
 
-  std::cout << "m.p size: " << p_size_bytes << " bytes" << std::endl;
-  std::cout << "m.ncol + 1: " << m.ncol + 1 << std::endl;
   detail::decode_array(ar, "m.p", m.p, (m.ncol + 1) * p_size_bytes);
   detail::decode_array(ar, "m.i", m.i, m.nzmax * integer_size_bytes);
   if (!m.packed) {

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -244,8 +244,6 @@ TEST(test_crossvalidation, test_leave_one_out_equivalences) {
   };
 
   auto joint_near = [](const auto &x, const auto &y) {
-    std::cout << x << std::endl;
-    std::cout << y << std::endl;
     EXPECT_LE((x.mean - y.mean).norm(), 1e-6);
     EXPECT_LE((x.covariance - y.covariance).norm(), 1e-6);
   };


### PR DESCRIPTION
This stuff was clearly left in by mistake and is clogging up the CI logs, not to mention logs in downstream models.