### PR TITLE
Fix macos build to 14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,7 +151,7 @@ jobs:
         run: bazel test //...
 
   osx-clang:
-    runs-on: macOS-latest
+    runs-on: macOS-14
     steps:
 
       - name: Checkout source


### PR DESCRIPTION
macos-latest had the potential to change and break master at any time.