### PR TITLE
Clang format all fixes: format all files, use repo-local config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,10 +31,12 @@ build:system --platform_suffix=system
 build:clang-format-check --aspects @rules_swiftnav//clang_format:clang_format_check.bzl%clang_format_check_aspect
 build:clang-format-check --@rules_swiftnav//clang_format:clang_format_config=//:clang_format_config
 build:clang-format-check --output_groups=report
+build --@rules_swiftnav//clang_format:clang_format_config=//:clang_format_config
 
 # Clang tidy config
 build:clang-tidy --aspects @rules_swiftnav//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
 build:clang-tidy --output_groups=report
+
 
 # Output test errors to stderr
 test --test_output=errors

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clang-format-all-check:
 	bazel build //... --config=clang-format-check
 
 clang-format-all:
-	bazel run @rules_swiftnav//clang_format:clang_format_all --@rules_swiftnav//clang_format:clang_format_config=//:clang_format_config
+	bazel run @rules_swiftnav//clang_format:clang_format_all
 
 clang-tidy-all-check:
 	bazel build //... --config=clang-tidy


### PR DESCRIPTION
## Rationale
This PR fixes two issues:
* `make clang-format-all` is supposed to format all files. The default target that was used (`@rules_swifntav//clang_format`)  only formatted current git diff, which is empty after committing changes. Now the target always formats every single source file, which is very fast anyway.
* `rules_swiftnav` clang-format targets rely on the default [.clang-format](https://github.com/swift-nav/rules_swiftnav/blob/main/clang_format/.clang-format) configuration file when formatting. When a repository-local configuration is defined ([like albatross/.clang-format](https://github.com/swift-nav/albatross/blob/master/.clang-format)), it needs to be explicitly provided to the bazel command.