### PR TITLE
Fork and fixup cereal library for Clang-20

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/swift-nav/fast-cpp-csv-parser.git
 [submodule "third_party/cereal"]
 	path = third_party/cereal
-	url = https://github.com/USCiLab/cereal.git
+	url = git@github.com:swift-nav/cereal.git
 [submodule "third_party/gzip-hpp"]
 	path = third_party/gzip-hpp
 	url = https://github.com/swift-nav/gzip-hpp.git


### PR DESCRIPTION
# Changes

In order to fix a build failure due to more modern Clang version, I had to fork the Cereal library and patch it up. This PR is to introduce those changes here into albatross.

See cereal changes - https://github.com/swift-nav/cereal/pull/1. 