### PR TITLE
Support defining covariance functions on batches

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -229,6 +229,7 @@ swift_cc_test(
 swift_cc_test(
     name = "albatross-test-covariance",
     srcs = [
+        "tests/test_batch_covariance.cc",
         "tests/test_covariance_function.cc",
         "tests/test_covariance_functions.cc",
         "tests/test_distance_metrics.cc",

--- a/include/albatross/src/covariance_functions/callers.hpp
+++ b/include/albatross/src/covariance_functions/callers.hpp
@@ -188,18 +188,116 @@ inline Eigen::VectorXd compute_mean_vector(MeanFuncCaller caller,
   return m;
 }
 
+/*
+ * Helper function to validate that all variants in a vector hold the same type.
+ */
+template <typename... Ts>
+inline void
+assert_homogeneous_variant_vector(const std::vector<variant<Ts...>> &variants) {
+  if (variants.empty())
+    return;
+
+  const std::size_t expected_index = variants[0].which();
+  for (std::size_t i = 1; i < variants.size(); ++i) {
+    ALBATROSS_ASSERT(
+        variants[i].which() == expected_index &&
+        "All variants in a batch operation must hold the same type");
+  }
+}
+
+/*
+ * Helper function to check if all variants in a vector hold the same type.
+ * Returns true if homogeneous (including empty), false otherwise.
+ */
+template <typename... Ts>
+inline bool
+is_homogeneous_variant_vector(const std::vector<variant<Ts...>> &variants) {
+  if (variants.empty())
+    return true;
+
+  const std::size_t expected_index = variants[0].which();
+  for (std::size_t i = 1; i < variants.size(); ++i) {
+    if (variants[i].which() != expected_index) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/*
+ * Helper function to unwrap a vector of Measurement<X> to a vector of X.
+ */
+template <typename X>
+inline std::vector<X>
+unwrap_measurements(const std::vector<Measurement<X>> &measurements) {
+  std::vector<X> values;
+  values.reserve(measurements.size());
+  for (const auto &m : measurements) {
+    values.push_back(m.value);
+  }
+  return values;
+}
+
 namespace internal {
 
 /*
  * This Caller just directly call the underlying CovFunc.
  */
 struct DirectCaller {
-  // Covariance Functions
+  // Covariance Functions - Pointwise
   template <typename CovFunc, typename X, typename Y,
             typename std::enable_if<has_valid_call_impl<CovFunc, X, Y>::value,
                                     int>::type = 0>
   static double call(const CovFunc &cov_func, const X &x, const Y &y) {
     return cov_func._call_impl(x, y);
+  }
+
+  // Covariance Functions - Batch (base case: pointwise loop)
+  // Only enabled if pointwise _call_impl exists (batch-only covariances won't
+  // reach here)
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<has_valid_call_impl<CovFunc, X, Y>::value,
+                                    int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    auto caller = [&](const auto &x, const auto &y) {
+      return cov_func._call_impl(x, y);
+    };
+    return compute_covariance_matrix(caller, xs, ys, pool);
+  }
+
+  // NOTE: If a covariance defines ONLY _call_impl_vector (no _call_impl),
+  // then BatchCaller will catch it before we reach DirectCaller, so this
+  // base case is never instantiated for batch-only covariances.
+
+  // Symmetric batch (base case: pointwise loop using symmetry)
+  template <typename CovFunc, typename X,
+            typename std::enable_if<has_valid_call_impl<CovFunc, X, X>::value,
+                                    int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    auto caller = [&](const auto &x, const auto &y) {
+      return cov_func._call_impl(x, y);
+    };
+    return compute_covariance_matrix(caller, xs, pool);
+  }
+
+  // Diagonal batch (base case: pointwise loop)
+  template <typename CovFunc, typename X,
+            typename std::enable_if<has_valid_call_impl<CovFunc, X, X>::value,
+                                    int>::type = 0>
+  static Eigen::VectorXd
+  call_vector_diagonal(const CovFunc &cov_func, const std::vector<X> &xs,
+                       [[maybe_unused]] ThreadPool *pool = nullptr) {
+    const Eigen::Index n = cast::to_index(xs.size());
+    Eigen::VectorXd diag(n);
+    for (Eigen::Index i = 0; i < n; ++i) {
+      const auto si = cast::to_size(i);
+      diag[i] = cov_func._call_impl(xs[si], xs[si]);
+    }
+    return diag;
   }
 
   // Mean Functions
@@ -235,6 +333,30 @@ template <typename SubCaller> struct SymmetricCaller {
                 int>::type = 0>
   static double call(const CovFunc &cov_func, const X &x, const Y &y) {
     return SubCaller::call(cov_func, y, x);
+  }
+
+  // Batch Covariance Functions - cross-covariance passthrough
+  template <typename CovFunc, typename X, typename Y>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, ys, pool);
+  }
+
+  // Symmetric passthrough
+  template <typename CovFunc, typename X>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, pool);
+  }
+
+  // Diagonal passthrough
+  template <typename CovFunc, typename X>
+  static Eigen::VectorXd call_vector_diagonal(const CovFunc &cov_func,
+                                              const std::vector<X> &xs,
+                                              ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector_diagonal(cov_func, xs, pool);
   }
 
   // Mean Functions
@@ -296,6 +418,268 @@ template <typename SubCaller> struct MeasurementForwarder {
   static double call(const CovFunc &cov_func, const X &x,
                      const Measurement<Y> &y) {
     return SubCaller::call(cov_func, x, y.value);
+  }
+
+  // Batch Covariance Functions
+
+  // Passthrough when no Measurement types
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<!is_measurement<X>::value &&
+                                        !is_measurement<Y>::value,
+                                    int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, ys, pool);
+  }
+
+  // Both sides Measurement: delegate to SubCaller if covariance has
+  // _call_impl_vector for Measurement types directly. This includes
+  // Sum/Product which define _call_impl_vector<Measurement<X>>.
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                is_measurement<X>::value && is_measurement<Y>::value &&
+                    has_valid_call_impl_vector<CovFunc, X, Y>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, ys, pool);
+  }
+
+  // Both sides Measurement: unwrap if no _call_impl_vector for Measurement,
+  // but the underlying type has batch support.
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                is_measurement<X>::value && is_measurement<Y>::value &&
+                    !has_valid_call_impl_vector<CovFunc, X, Y>::value &&
+                    !has_valid_call_impl<CovFunc, X, Y>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    auto unwrapped_xs = unwrap_measurements(xs);
+    auto unwrapped_ys = unwrap_measurements(ys);
+    return SubCaller::call_vector(cov_func, unwrapped_xs, unwrapped_ys, pool);
+  }
+
+  // Both sides Measurement: use pointwise if covariance function has explicit
+  // _call_impl for Measurement types (e.g. IndependentNoise which needs to
+  // distinguish Measurement self-covariance from cross-covariance) but no
+  // _call_impl_vector for Measurement types.
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                is_measurement<X>::value && is_measurement<Y>::value &&
+                    !has_valid_call_impl_vector<CovFunc, X, Y>::value &&
+                    has_valid_call_impl<CovFunc, X, Y>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    // Covariance function has special handling for Measurement types,
+    // so we must use pointwise to respect that behavior
+    auto caller = [&](const auto &x, const auto &y) {
+      return MeasurementForwarder::call(cov_func, x, y);
+    };
+    return compute_covariance_matrix(caller, xs, ys, pool);
+  }
+
+  // Left side Measurement: delegate to SubCaller if _call_impl_vector exists
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                is_measurement<X>::value && !is_measurement<Y>::value &&
+                    has_valid_call_impl_vector<CovFunc, X, Y>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, ys, pool);
+  }
+
+  // Left side Measurement: unwrap left if no _call_impl_vector, no _call_impl
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                is_measurement<X>::value && !is_measurement<Y>::value &&
+                    !has_valid_call_impl_vector<CovFunc, X, Y>::value &&
+                    !has_valid_call_impl<CovFunc, X, Y>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    auto unwrapped_xs = unwrap_measurements(xs);
+    return SubCaller::call_vector(cov_func, unwrapped_xs, ys, pool);
+  }
+
+  // Left side Measurement: pointwise if _call_impl but no _call_impl_vector
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                is_measurement<X>::value && !is_measurement<Y>::value &&
+                    !has_valid_call_impl_vector<CovFunc, X, Y>::value &&
+                    has_valid_call_impl<CovFunc, X, Y>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    auto caller = [&](const auto &x, const auto &y) {
+      return MeasurementForwarder::call(cov_func, x, y);
+    };
+    return compute_covariance_matrix(caller, xs, ys, pool);
+  }
+
+  // Right side Measurement: delegate to SubCaller if _call_impl_vector exists
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                !is_measurement<X>::value && is_measurement<Y>::value &&
+                    has_valid_call_impl_vector<CovFunc, X, Y>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, ys, pool);
+  }
+
+  // Right side Measurement: unwrap right if no _call_impl_vector, no _call_impl
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                !is_measurement<X>::value && is_measurement<Y>::value &&
+                    !has_valid_call_impl_vector<CovFunc, X, Y>::value &&
+                    !has_valid_call_impl<CovFunc, X, Y>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    auto unwrapped_ys = unwrap_measurements(ys);
+    return SubCaller::call_vector(cov_func, xs, unwrapped_ys, pool);
+  }
+
+  // Right side Measurement: pointwise if _call_impl but no _call_impl_vector
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                !is_measurement<X>::value && is_measurement<Y>::value &&
+                    !has_valid_call_impl_vector<CovFunc, X, Y>::value &&
+                    has_valid_call_impl<CovFunc, X, Y>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    auto caller = [&](const auto &x, const auto &y) {
+      return MeasurementForwarder::call(cov_func, x, y);
+    };
+    return compute_covariance_matrix(caller, xs, ys, pool);
+  }
+
+  // Symmetric: passthrough for non-Measurements
+  template <typename CovFunc, typename X,
+            typename std::enable_if<!is_measurement<X>::value, int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, pool);
+  }
+
+  // Symmetric Measurement: delegate to SubCaller if _call_impl_vector exists for Measurement directly
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                is_measurement<X>::value &&
+                    has_valid_call_impl_vector_symmetric<CovFunc, X>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, pool);
+  }
+
+  // Symmetric Measurement: unwrap and delegate if single-arg OR two-arg exists for inner type (no Measurement-specific _call_impl_vector)
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                is_measurement<X>::value &&
+                    !has_valid_call_impl_vector_symmetric<CovFunc, X>::value &&
+                    !has_valid_call_impl<CovFunc, X, X>::value &&
+                    (has_valid_call_impl_vector_single_arg<CovFunc,
+                         measurement_inner_t<X>>::value ||
+                     has_valid_call_impl_vector_symmetric<CovFunc,
+                         measurement_inner_t<X>>::value),
+                int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    auto unwrapped_xs = unwrap_measurements(xs);
+    return SubCaller::call_vector(cov_func, unwrapped_xs, pool);
+  }
+
+  // Symmetric Measurement: unwrap if no single-arg, no _call_impl_vector, no _call_impl
+  // but inner type has pointwise support
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                is_measurement<X>::value &&
+                    !has_valid_call_impl_vector_symmetric<CovFunc, X>::value &&
+                    !has_valid_call_impl<CovFunc, X, X>::value &&
+                    !has_valid_call_impl_vector_single_arg<CovFunc,
+                         measurement_inner_t<X>>::value &&
+                    !has_valid_call_impl_vector_symmetric<CovFunc,
+                         measurement_inner_t<X>>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    auto unwrapped_xs = unwrap_measurements(xs);
+    return SubCaller::call_vector(cov_func, unwrapped_xs, pool);
+  }
+
+  // Symmetric Measurement: pointwise if _call_impl exists for Measurement
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                is_measurement<X>::value &&
+                    !has_valid_call_impl_vector_symmetric<CovFunc, X>::value &&
+                    has_valid_call_impl<CovFunc, X, X>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    auto caller = [&](const auto &x, const auto &y) {
+      return MeasurementForwarder::call(cov_func, x, y);
+    };
+    return compute_covariance_matrix(caller, xs, pool);
+  }
+
+  // Diagonal: passthrough for non-Measurements
+  template <typename CovFunc, typename X,
+            typename std::enable_if<!is_measurement<X>::value, int>::type = 0>
+  static Eigen::VectorXd call_vector_diagonal(const CovFunc &cov_func,
+                                              const std::vector<X> &xs,
+                                              ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector_diagonal(cov_func, xs, pool);
+  }
+
+  // Diagonal Measurement: unwrap ONLY if no explicit _call_impl for Measurement types
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                is_measurement<X>::value &&
+                    !has_valid_call_impl<CovFunc, X, X>::value,
+                int>::type = 0>
+  static Eigen::VectorXd call_vector_diagonal(const CovFunc &cov_func,
+                                              const std::vector<X> &xs,
+                                              ThreadPool *pool = nullptr) {
+    auto unwrapped_xs = unwrap_measurements(xs);
+    return SubCaller::call_vector_diagonal(cov_func, unwrapped_xs, pool);
+  }
+
+  // Diagonal Measurement: pointwise if explicit _call_impl exists for Measurement types
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                is_measurement<X>::value &&
+                    has_valid_call_impl<CovFunc, X, X>::value,
+                int>::type = 0>
+  static Eigen::VectorXd
+  call_vector_diagonal(const CovFunc &cov_func, const std::vector<X> &xs,
+                       [[maybe_unused]] ThreadPool *pool = nullptr) {
+    const Eigen::Index n = cast::to_index(xs.size());
+    Eigen::VectorXd diag(n);
+    for (Eigen::Index i = 0; i < n; ++i) {
+      const auto si = cast::to_size(i);
+      diag[i] = MeasurementForwarder::call(cov_func, xs[si], xs[si]);
+    }
+    return diag;
   }
 
   // Mean Functions
@@ -371,6 +755,82 @@ template <typename SubCaller> struct LinearCombinationCaller {
     return sum;
   }
 
+  // Batch Covariance Functions
+
+  // Passthrough when no LinearCombination types
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<!is_linear_combination<X>::value &&
+                                        !is_linear_combination<Y>::value,
+                                    int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, ys, pool);
+  }
+
+  // Handle LinearCombination types by building matrix pointwise (like old code)
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<is_linear_combination<X>::value ||
+                                        is_linear_combination<Y>::value,
+                                    int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    auto caller = [&](const auto &x, const auto &y) {
+      return LinearCombinationCaller::call(cov_func, x, y);
+    };
+    return compute_covariance_matrix(caller, xs, ys, pool);
+  }
+
+  // Symmetric: passthrough for non-LinearCombinations
+  template <
+      typename CovFunc, typename X,
+      typename std::enable_if<!is_linear_combination<X>::value, int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, pool);
+  }
+
+  // Symmetric: pointwise for LinearCombinations
+  template <
+      typename CovFunc, typename X,
+      typename std::enable_if<is_linear_combination<X>::value, int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    auto caller = [&](const auto &x, const auto &y) {
+      return LinearCombinationCaller::call(cov_func, x, y);
+    };
+    return compute_covariance_matrix(caller, xs, pool);
+  }
+
+  // Diagonal: passthrough for non-LinearCombinations
+  template <
+      typename CovFunc, typename X,
+      typename std::enable_if<!is_linear_combination<X>::value, int>::type = 0>
+  static Eigen::VectorXd call_vector_diagonal(const CovFunc &cov_func,
+                                              const std::vector<X> &xs,
+                                              ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector_diagonal(cov_func, xs, pool);
+  }
+
+  // Diagonal: pointwise for LinearCombinations
+  template <
+      typename CovFunc, typename X,
+      typename std::enable_if<is_linear_combination<X>::value, int>::type = 0>
+  static Eigen::VectorXd
+  call_vector_diagonal(const CovFunc &cov_func, const std::vector<X> &xs,
+                       [[maybe_unused]] ThreadPool *pool = nullptr) {
+    const Eigen::Index n = cast::to_index(xs.size());
+    Eigen::VectorXd diag(n);
+    for (Eigen::Index i = 0; i < n; ++i) {
+      const auto si = cast::to_size(i);
+      diag[i] = LinearCombinationCaller::call(cov_func, xs[si], xs[si]);
+    }
+    return diag;
+  }
+
   // Mean Functions
   template <
       typename MeanFunc, typename X,
@@ -396,6 +856,768 @@ template <typename SubCaller> struct LinearCombinationCaller {
 };
 
 /*
+ * Variant batch dispatch helpers
+ *
+ * These helpers enable batch covariance dispatch for homogeneous variant
+ * vectors by:
+ * 1. Asserting all elements hold the same variant arm at runtime
+ * 2. Extracting the concrete vector using variant::get<>()
+ * 3. Dispatching to SubCaller::call_vector with the concrete types
+ */
+
+namespace variant_batch_detail {
+
+/*
+ * SortedVariantData - result of sorting a variant vector by type
+ *
+ * Contains:
+ * - sorted: The variant vector with elements grouped by type
+ * - to_sorted: Permutation matrix where sorted[i] = original[perm[i]]
+ * - block_starts: block_starts[type_idx] = first index of that type in sorted
+ *                 block_starts[sizeof...(Ts)] = total size (sentinel)
+ */
+template <typename... Ts> struct SortedVariantData {
+  std::vector<variant<Ts...>> sorted;
+  Eigen::PermutationMatrix<Eigen::Dynamic> to_sorted;
+  std::array<Eigen::Index, sizeof...(Ts) + 1> block_starts;
+};
+
+/*
+ * sort_variants_by_type - Sort a variant vector so elements are grouped by type
+ *
+ * This is a key primitive for heterogeneous variant batch dispatch.
+ * Elements are reordered so all elements of type Ts[0] come first,
+ * then all elements of type Ts[1], etc.
+ *
+ * Returns a SortedVariantData containing:
+ * - The sorted vector
+ * - A permutation matrix for recovering original order
+ * - Block boundaries for each type
+ */
+template <typename... Ts>
+SortedVariantData<Ts...>
+sort_variants_by_type(const std::vector<variant<Ts...>> &variants) {
+  SortedVariantData<Ts...> result;
+  const std::size_t n = variants.size();
+
+  // Count elements per type
+  std::array<std::size_t, sizeof...(Ts)> counts{};
+  for (const auto &v : variants) {
+    counts[v.which()]++;
+  }
+
+  // Compute block start positions (prefix sum)
+  result.block_starts[0] = 0;
+  for (std::size_t t = 0; t < sizeof...(Ts); ++t) {
+    result.block_starts[t + 1] =
+        result.block_starts[t] + cast::to_index(counts[t]);
+  }
+
+  // Build permutation and sorted vector in single pass
+  result.sorted.resize(n);
+  result.to_sorted.resize(cast::to_index(n));
+  std::array<std::size_t, sizeof...(Ts)> next_pos{};
+  for (std::size_t t = 0; t < sizeof...(Ts); ++t) {
+    next_pos[t] = cast::to_size(result.block_starts[t]);
+  }
+
+  for (std::size_t i = 0; i < n; ++i) {
+    const std::size_t type_idx = variants[i].which();
+    const std::size_t sorted_idx = next_pos[type_idx]++;
+    result.sorted[sorted_idx] = variants[i];
+    // Eigen convention: indices[orig_idx] = sorted_idx means
+    // (P * original)[sorted_idx] = original[orig_idx]
+    // So P transforms original order to sorted order.
+    result.to_sorted.indices()[cast::to_index(i)] = cast::to_index(sorted_idx);
+  }
+
+  return result;
+}
+
+/*
+ * extract_block - Extract concrete-typed block from sorted variant vector
+ *
+ * Given a SortedVariantData and a type index, extracts all elements of that
+ * type as a vector of the concrete type.
+ */
+template <typename T, typename... Ts>
+std::vector<T> extract_block(const SortedVariantData<Ts...> &sorted_data,
+                             std::size_t type_index) {
+  const Eigen::Index start = sorted_data.block_starts[type_index];
+  const Eigen::Index end = sorted_data.block_starts[type_index + 1];
+  std::vector<T> result;
+  result.reserve(cast::to_size(end - start));
+  for (Eigen::Index i = start; i < end; ++i) {
+    result.push_back(sorted_data.sorted[cast::to_size(i)].template get<T>());
+  }
+  return result;
+}
+
+// Helper to extract all values of a specific type from a homogeneous variant
+// vector. This is a simplified version of extract_from_variants that doesn't
+// depend on variant_utils.hpp's include order.
+template <typename OutputType, typename... VariantTypes>
+std::vector<OutputType>
+extract_homogeneous(const std::vector<variant<VariantTypes...>> &xs) {
+  std::vector<OutputType> output;
+  output.reserve(xs.size());
+  for (const auto &x : xs) {
+    output.push_back(x.template get<OutputType>());
+  }
+  return output;
+}
+
+// Cross-covariance: variant on left, concrete on right
+template <typename CovFunc, typename SubCaller, typename... Ts, typename Y,
+          std::size_t... Is>
+Eigen::MatrixXd dispatch_variant_batch_left_impl(
+    const CovFunc &cov_func, const std::vector<variant<Ts...>> &xs,
+    const std::vector<Y> &ys, ThreadPool *pool, std::size_t runtime_index,
+    std::index_sequence<Is...>) {
+
+  Eigen::MatrixXd result;
+  bool found = false;
+
+  // Fold expression: match runtime index to compile-time type
+  ((Is == runtime_index
+        ? (found = true,
+           result = [&]() {
+             using ConcreteType = std::tuple_element_t<Is, std::tuple<Ts...>>;
+             auto concrete_xs = extract_homogeneous<ConcreteType>(xs);
+             // Check if this type pair is supported; if not, return zeros
+             // (matches pointwise visitor behavior)
+             if constexpr (has_valid_cov_caller<CovFunc, SubCaller, ConcreteType,
+                                                Y>::value) {
+               return SubCaller::call_vector(cov_func, concrete_xs, ys, pool);
+             } else {
+               return Eigen::MatrixXd::Zero(cast::to_index(xs.size()),
+                                            cast::to_index(ys.size()));
+             }
+           }(),
+           0)
+        : 0),
+   ...);
+
+  ALBATROSS_ASSERT(found && "Invalid variant index in batch dispatch");
+  return result;
+}
+
+template <typename CovFunc, typename SubCaller, typename... Ts, typename Y>
+Eigen::MatrixXd
+dispatch_variant_batch_left(const CovFunc &cov_func,
+                            const std::vector<variant<Ts...>> &xs,
+                            const std::vector<Y> &ys, ThreadPool *pool) {
+  if (xs.empty()) {
+    return Eigen::MatrixXd(0, cast::to_index(ys.size()));
+  }
+
+  assert_homogeneous_variant_vector(xs);
+  const std::size_t runtime_index = xs[0].which();
+
+  return dispatch_variant_batch_left_impl<CovFunc, SubCaller>(
+      cov_func, xs, ys, pool, runtime_index, std::index_sequence_for<Ts...>{});
+}
+
+// Cross-covariance: concrete on left, variant on right
+template <typename CovFunc, typename SubCaller, typename X, typename... Ts,
+          std::size_t... Is>
+Eigen::MatrixXd dispatch_variant_batch_right_impl(
+    const CovFunc &cov_func, const std::vector<X> &xs,
+    const std::vector<variant<Ts...>> &ys, ThreadPool *pool,
+    std::size_t runtime_index, std::index_sequence<Is...>) {
+
+  Eigen::MatrixXd result;
+  bool found = false;
+
+  ((Is == runtime_index
+        ? (found = true,
+           result = [&]() {
+             using ConcreteType = std::tuple_element_t<Is, std::tuple<Ts...>>;
+             auto concrete_ys = extract_homogeneous<ConcreteType>(ys);
+             // Check if this type pair is supported; if not, return zeros
+             // (matches pointwise visitor behavior)
+             if constexpr (has_valid_cov_caller<CovFunc, SubCaller, X,
+                                                ConcreteType>::value) {
+               return SubCaller::call_vector(cov_func, xs, concrete_ys, pool);
+             } else {
+               return Eigen::MatrixXd::Zero(cast::to_index(xs.size()),
+                                            cast::to_index(ys.size()));
+             }
+           }(),
+           0)
+        : 0),
+   ...);
+
+  ALBATROSS_ASSERT(found && "Invalid variant index in batch dispatch");
+  return result;
+}
+
+template <typename CovFunc, typename SubCaller, typename X, typename... Ts>
+Eigen::MatrixXd
+dispatch_variant_batch_right(const CovFunc &cov_func, const std::vector<X> &xs,
+                             const std::vector<variant<Ts...>> &ys,
+                             ThreadPool *pool) {
+  if (ys.empty()) {
+    return Eigen::MatrixXd(cast::to_index(xs.size()), 0);
+  }
+
+  assert_homogeneous_variant_vector(ys);
+  const std::size_t runtime_index = ys[0].which();
+
+  return dispatch_variant_batch_right_impl<CovFunc, SubCaller>(
+      cov_func, xs, ys, pool, runtime_index, std::index_sequence_for<Ts...>{});
+}
+
+// Cross-covariance: both sides are variants
+// Inner dispatch over Y types, given a concrete X type
+template <typename CovFunc, typename SubCaller, typename XType, typename... Ys,
+          std::size_t... YIs>
+Eigen::MatrixXd dispatch_variant_batch_both_y_impl(
+    const CovFunc &cov_func, const std::vector<XType> &concrete_xs,
+    const std::vector<variant<Ys...>> &ys, ThreadPool *pool,
+    std::size_t y_index, std::index_sequence<YIs...>) {
+
+  Eigen::MatrixXd result;
+  bool found = false;
+
+  ((YIs == y_index
+        ? (found = true,
+           result = [&]() {
+             using YType = std::tuple_element_t<YIs, std::tuple<Ys...>>;
+             auto concrete_ys = extract_homogeneous<YType>(ys);
+             // Check if this type pair is supported; if not, return zeros
+             if constexpr (has_valid_cov_caller<CovFunc, SubCaller, XType,
+                                                YType>::value) {
+               return SubCaller::call_vector(cov_func, concrete_xs, concrete_ys,
+                                             pool);
+             } else {
+               return Eigen::MatrixXd::Zero(cast::to_index(concrete_xs.size()),
+                                            cast::to_index(ys.size()));
+             }
+           }(),
+           0)
+        : 0),
+   ...);
+
+  ALBATROSS_ASSERT(found && "Invalid Y variant index in batch dispatch");
+  return result;
+}
+
+// Outer dispatch over X types
+template <typename CovFunc, typename SubCaller, typename... Xs, typename... Ys,
+          std::size_t... XIs>
+Eigen::MatrixXd dispatch_variant_batch_both_x_impl(
+    const CovFunc &cov_func, const std::vector<variant<Xs...>> &xs,
+    const std::vector<variant<Ys...>> &ys, ThreadPool *pool,
+    std::size_t x_index, std::size_t y_index, std::index_sequence<XIs...>) {
+
+  Eigen::MatrixXd result;
+  bool found = false;
+
+  ((XIs == x_index
+        ? (found = true,
+           result = [&]() {
+             using XType = std::tuple_element_t<XIs, std::tuple<Xs...>>;
+             auto concrete_xs = extract_homogeneous<XType>(xs);
+             return dispatch_variant_batch_both_y_impl<CovFunc, SubCaller,
+                                                       XType>(
+                 cov_func, concrete_xs, ys, pool, y_index,
+                 std::index_sequence_for<Ys...>{});
+           }(),
+           0)
+        : 0),
+   ...);
+
+  ALBATROSS_ASSERT(found && "Invalid X variant index in batch dispatch");
+  return result;
+}
+
+template <typename CovFunc, typename SubCaller, typename... Xs, typename... Ys>
+Eigen::MatrixXd
+dispatch_variant_batch_both(const CovFunc &cov_func,
+                            const std::vector<variant<Xs...>> &xs,
+                            const std::vector<variant<Ys...>> &ys,
+                            ThreadPool *pool) {
+  if (xs.empty()) {
+    return Eigen::MatrixXd(0, cast::to_index(ys.size()));
+  }
+  if (ys.empty()) {
+    return Eigen::MatrixXd(cast::to_index(xs.size()), 0);
+  }
+
+  assert_homogeneous_variant_vector(xs);
+  assert_homogeneous_variant_vector(ys);
+  const std::size_t x_index = xs[0].which();
+  const std::size_t y_index = ys[0].which();
+
+  return dispatch_variant_batch_both_x_impl<CovFunc, SubCaller>(
+      cov_func, xs, ys, pool, x_index, y_index,
+      std::index_sequence_for<Xs...>{});
+}
+
+// Symmetric case: single variant vector
+template <typename CovFunc, typename SubCaller, typename... Ts,
+          std::size_t... Is>
+Eigen::MatrixXd dispatch_variant_batch_symmetric_impl(
+    const CovFunc &cov_func, const std::vector<variant<Ts...>> &xs,
+    ThreadPool *pool, std::size_t runtime_index, std::index_sequence<Is...>) {
+
+  Eigen::MatrixXd result;
+  bool found = false;
+
+  ((Is == runtime_index
+        ? (found = true,
+           result = [&]() {
+             using ConcreteType = std::tuple_element_t<Is, std::tuple<Ts...>>;
+             auto concrete_xs = extract_homogeneous<ConcreteType>(xs);
+             // Check if this type is supported; if not, return zeros
+             // (matches pointwise visitor behavior)
+             if constexpr (has_valid_cov_caller<CovFunc, SubCaller, ConcreteType,
+                                                ConcreteType>::value) {
+               return SubCaller::call_vector(cov_func, concrete_xs, pool);
+             } else {
+               return Eigen::MatrixXd::Zero(cast::to_index(xs.size()),
+                                            cast::to_index(xs.size()));
+             }
+           }(),
+           0)
+        : 0),
+   ...);
+
+  ALBATROSS_ASSERT(found && "Invalid variant index in batch dispatch");
+  return result;
+}
+
+template <typename CovFunc, typename SubCaller, typename... Ts>
+Eigen::MatrixXd
+dispatch_variant_batch_symmetric(const CovFunc &cov_func,
+                                 const std::vector<variant<Ts...>> &xs,
+                                 ThreadPool *pool) {
+  if (xs.empty()) {
+    return Eigen::MatrixXd(0, 0);
+  }
+
+  assert_homogeneous_variant_vector(xs);
+  const std::size_t runtime_index = xs[0].which();
+
+  return dispatch_variant_batch_symmetric_impl<CovFunc, SubCaller>(
+      cov_func, xs, pool, runtime_index, std::index_sequence_for<Ts...>{});
+}
+
+// Diagonal case: single variant vector
+template <typename CovFunc, typename SubCaller, typename... Ts,
+          std::size_t... Is>
+Eigen::VectorXd dispatch_variant_batch_diagonal_impl(
+    const CovFunc &cov_func, const std::vector<variant<Ts...>> &xs,
+    ThreadPool *pool, std::size_t runtime_index, std::index_sequence<Is...>) {
+
+  Eigen::VectorXd result;
+  bool found = false;
+
+  ((Is == runtime_index
+        ? (found = true,
+           result = [&]() {
+             using ConcreteType = std::tuple_element_t<Is, std::tuple<Ts...>>;
+             auto concrete_xs = extract_homogeneous<ConcreteType>(xs);
+             // Check if this type is supported; if not, return zeros
+             // (matches pointwise visitor behavior)
+             if constexpr (has_valid_cov_caller<CovFunc, SubCaller, ConcreteType,
+                                                ConcreteType>::value) {
+               return SubCaller::call_vector_diagonal(cov_func, concrete_xs,
+                                                      pool);
+             } else {
+               return Eigen::VectorXd::Zero(cast::to_index(xs.size()));
+             }
+           }(),
+           0)
+        : 0),
+   ...);
+
+  ALBATROSS_ASSERT(found && "Invalid variant index in batch dispatch");
+  return result;
+}
+
+template <typename CovFunc, typename SubCaller, typename... Ts>
+Eigen::VectorXd
+dispatch_variant_batch_diagonal(const CovFunc &cov_func,
+                                const std::vector<variant<Ts...>> &xs,
+                                ThreadPool *pool) {
+  if (xs.empty()) {
+    return Eigen::VectorXd(0);
+  }
+
+  assert_homogeneous_variant_vector(xs);
+  const std::size_t runtime_index = xs[0].which();
+
+  return dispatch_variant_batch_diagonal_impl<CovFunc, SubCaller>(
+      cov_func, xs, pool, runtime_index, std::index_sequence_for<Ts...>{});
+}
+
+/*
+ * ============================================================================
+ * Heterogeneous Variant Batch Dispatch
+ *
+ * These functions handle batch covariance computation for variant vectors
+ * containing a mix of different types (heterogeneous). The approach is:
+ *
+ * 1. Sort inputs by type, creating permutation vectors
+ * 2. Compute covariance blocks for each type pair
+ * 3. Unpermute the result using Eigen::PermutationMatrix
+ *
+ * This avoids O(n*m) visitor calls by computing contiguous blocks and using
+ * efficient matrix permutation operations.
+ * ============================================================================
+ */
+
+// Type wrapper to pass variant types as a single template parameter
+template <typename... Ts> struct TypeList {};
+
+/*
+ * compute_sorted_covariance_cross - Compute cross-covariance in sorted order
+ *
+ * Given sorted variant data for xs and ys, computes the covariance matrix
+ * where blocks of same-type elements are contiguous. The result matrix is
+ * in "sorted order" and needs to be unpermuted to get the original order.
+ */
+
+// Helper struct to process one row block (X type XI) against all column blocks
+template <typename CovFunc, typename SubCaller, std::size_t XI,
+          typename TypeListT, std::size_t... YIs>
+struct CrossRowBlockProcessor;
+
+template <typename CovFunc, typename SubCaller, std::size_t XI, typename... Ts,
+          std::size_t... YIs>
+struct CrossRowBlockProcessor<CovFunc, SubCaller, XI, TypeList<Ts...>, YIs...> {
+  static void process(const CovFunc &cov_func,
+                      const SortedVariantData<Ts...> &x_sorted,
+                      const SortedVariantData<Ts...> &y_sorted,
+                      Eigen::MatrixXd &result, ThreadPool *pool) {
+    using XType = std::tuple_element_t<XI, std::tuple<Ts...>>;
+    const Eigen::Index x_start = x_sorted.block_starts[XI];
+    const Eigen::Index x_end = x_sorted.block_starts[XI + 1];
+    if (x_start == x_end)
+      return; // Empty block
+
+    auto x_block = extract_block<XType>(x_sorted, XI);
+
+    // For each Y type (inner fold with fixed XI)
+    (
+        [&]() {
+          using YType = std::tuple_element_t<YIs, std::tuple<Ts...>>;
+          const Eigen::Index y_start = y_sorted.block_starts[YIs];
+          const Eigen::Index y_end = y_sorted.block_starts[YIs + 1];
+          if (y_start == y_end)
+            return; // Empty block
+
+          if constexpr (has_valid_cov_caller<CovFunc, SubCaller, XType,
+                                             YType>::value) {
+            // Use SubCaller to go through full caller chain
+            auto y_block = extract_block<YType>(y_sorted, YIs);
+            auto block_result =
+                SubCaller::call_vector(cov_func, x_block, y_block, pool);
+            // Place block into contiguous region of result
+            result.block(x_start, y_start, x_end - x_start, y_end - y_start) =
+                block_result;
+          }
+          // Unsupported pairs: leave as zero
+        }(),
+        ...);
+  }
+};
+
+// Helper to call the processor with an index sequence
+template <typename CovFunc, typename SubCaller, std::size_t XI, typename... Ts,
+          std::size_t... YIs>
+void compute_cross_row_block(const CovFunc &cov_func,
+                             const SortedVariantData<Ts...> &x_sorted,
+                             const SortedVariantData<Ts...> &y_sorted,
+                             Eigen::MatrixXd &result, ThreadPool *pool,
+                             std::index_sequence<YIs...>) {
+  CrossRowBlockProcessor<CovFunc, SubCaller, XI, TypeList<Ts...>,
+                         YIs...>::process(cov_func, x_sorted, y_sorted, result,
+                                          pool);
+}
+
+template <typename CovFunc, typename SubCaller, typename... Ts,
+          std::size_t... XIs>
+Eigen::MatrixXd compute_sorted_covariance_cross_impl(
+    const CovFunc &cov_func, const SortedVariantData<Ts...> &x_sorted,
+    const SortedVariantData<Ts...> &y_sorted, ThreadPool *pool,
+    std::index_sequence<XIs...>) {
+
+  const Eigen::Index m = cast::to_index(x_sorted.sorted.size());
+  const Eigen::Index n = cast::to_index(y_sorted.sorted.size());
+  Eigen::MatrixXd result = Eigen::MatrixXd::Zero(m, n);
+
+  // For each X type, process all Y types
+  (compute_cross_row_block<CovFunc, SubCaller, XIs>(
+       cov_func, x_sorted, y_sorted, result, pool,
+       std::index_sequence_for<Ts...>{}),
+   ...);
+
+  return result;
+}
+
+template <typename CovFunc, typename SubCaller, typename... Ts>
+Eigen::MatrixXd
+compute_sorted_covariance_cross(const CovFunc &cov_func,
+                                const SortedVariantData<Ts...> &x_sorted,
+                                const SortedVariantData<Ts...> &y_sorted,
+                                ThreadPool *pool) {
+  return compute_sorted_covariance_cross_impl<CovFunc, SubCaller>(
+      cov_func, x_sorted, y_sorted, pool, std::index_sequence_for<Ts...>{});
+}
+
+/*
+ * dispatch_heterogeneous_variant_batch_cross - Main entry point for
+ * heterogeneous cross-covariance
+ *
+ * Computes cov(xs, ys) where xs and ys are variant vectors that may contain
+ * a mix of different types.
+ */
+template <typename CovFunc, typename SubCaller, typename... Ts>
+Eigen::MatrixXd dispatch_heterogeneous_variant_batch_cross(
+    const CovFunc &cov_func, const std::vector<variant<Ts...>> &xs,
+    const std::vector<variant<Ts...>> &ys, ThreadPool *pool) {
+
+  if (xs.empty()) {
+    return Eigen::MatrixXd(0, cast::to_index(ys.size()));
+  }
+  if (ys.empty()) {
+    return Eigen::MatrixXd(cast::to_index(xs.size()), 0);
+  }
+
+  // 1. Sort both input vectors by type (single copy of each element)
+  auto x_sorted = sort_variants_by_type(xs);
+  auto y_sorted = sort_variants_by_type(ys);
+
+  // 2. Compute covariance in sorted order (contiguous block operations)
+  Eigen::MatrixXd sorted_result =
+      compute_sorted_covariance_cross<CovFunc, SubCaller>(cov_func, x_sorted,
+                                                          y_sorted, pool);
+
+  // 3. Unpermute rows and columns to original order
+  // result(i, j) = sorted_result(to_sorted[i], to_sorted[j])
+  // Equivalently: result = P_x^{-1} * sorted_result * P_y^{-T}
+  // Note: We need to evaluate the inverse before calling transpose()
+  Eigen::PermutationMatrix<Eigen::Dynamic> x_inv = x_sorted.to_sorted.inverse();
+  Eigen::PermutationMatrix<Eigen::Dynamic> y_inv = y_sorted.to_sorted.inverse();
+  return x_inv * sorted_result * y_inv.transpose();
+}
+
+/*
+ * compute_sorted_covariance_symmetric - Compute symmetric covariance in sorted
+ * order
+ *
+ * Optimized for the case where xs == ys. Computes diagonal blocks as symmetric
+ * and off-diagonal blocks once.
+ */
+
+// Helper: process one row block (X type XI) against column blocks (Y types >= XI)
+template <typename CovFunc, typename SubCaller, std::size_t XI,
+          typename TypeListT, std::size_t... YIs>
+struct SymmetricRowBlockProcessor;
+
+template <typename CovFunc, typename SubCaller, std::size_t XI, typename... Ts,
+          std::size_t... YIs>
+struct SymmetricRowBlockProcessor<CovFunc, SubCaller, XI, TypeList<Ts...>,
+                                  YIs...> {
+  static void process(const CovFunc &cov_func,
+                      const SortedVariantData<Ts...> &sorted,
+                      Eigen::MatrixXd &result, ThreadPool *pool) {
+    using XType = std::tuple_element_t<XI, std::tuple<Ts...>>;
+    const Eigen::Index x_start = sorted.block_starts[XI];
+    const Eigen::Index x_end = sorted.block_starts[XI + 1];
+    if (x_start == x_end)
+      return; // Empty block
+
+    auto x_block = extract_block<XType>(sorted, XI);
+
+    // For each Y type (inner fold with fixed XI)
+    (
+        [&]() {
+          using YType = std::tuple_element_t<YIs, std::tuple<Ts...>>;
+          const Eigen::Index y_start = sorted.block_starts[YIs];
+          const Eigen::Index y_end = sorted.block_starts[YIs + 1];
+          if (y_start == y_end)
+            return; // Empty block
+
+          // Only compute upper triangle (including diagonal blocks)
+          if constexpr (YIs < XI)
+            return;
+
+          if constexpr (has_valid_cov_caller<CovFunc, SubCaller, XType,
+                                             YType>::value) {
+            // Use SubCaller to go through full caller chain
+            auto y_block = extract_block<YType>(sorted, YIs);
+            Eigen::MatrixXd block_result;
+
+            if constexpr (XI == YIs) {
+              // Diagonal block: compute symmetric
+              block_result = SubCaller::call_vector(cov_func, x_block, pool);
+            } else {
+              // Off-diagonal block
+              block_result =
+                  SubCaller::call_vector(cov_func, x_block, y_block, pool);
+            }
+
+            // Place in upper triangle
+            result.block(x_start, y_start, x_end - x_start, y_end - y_start) =
+                block_result;
+
+            // Mirror to lower triangle for off-diagonal blocks
+            if constexpr (XI != YIs) {
+              result.block(y_start, x_start, y_end - y_start, x_end - x_start) =
+                  block_result.transpose();
+            }
+          }
+          // Unsupported pairs: leave as zero
+        }(),
+        ...);
+  }
+};
+
+// Helper to call the processor with an index sequence
+template <typename CovFunc, typename SubCaller, std::size_t XI, typename... Ts,
+          std::size_t... YIs>
+void compute_symmetric_row_block(const CovFunc &cov_func,
+                                 const SortedVariantData<Ts...> &sorted,
+                                 Eigen::MatrixXd &result, ThreadPool *pool,
+                                 std::index_sequence<YIs...>) {
+  SymmetricRowBlockProcessor<CovFunc, SubCaller, XI, TypeList<Ts...>,
+                             YIs...>::process(cov_func, sorted, result, pool);
+}
+
+template <typename CovFunc, typename SubCaller, typename... Ts,
+          std::size_t... XIs>
+Eigen::MatrixXd compute_sorted_covariance_symmetric_impl(
+    const CovFunc &cov_func, const SortedVariantData<Ts...> &sorted,
+    ThreadPool *pool, std::index_sequence<XIs...>) {
+
+  const Eigen::Index n = cast::to_index(sorted.sorted.size());
+  Eigen::MatrixXd result = Eigen::MatrixXd::Zero(n, n);
+
+  // For each X type, process Y types >= X
+  (compute_symmetric_row_block<CovFunc, SubCaller, XIs>(
+       cov_func, sorted, result, pool, std::index_sequence_for<Ts...>{}),
+   ...);
+
+  return result;
+}
+
+template <typename CovFunc, typename SubCaller, typename... Ts>
+Eigen::MatrixXd
+compute_sorted_covariance_symmetric(const CovFunc &cov_func,
+                                    const SortedVariantData<Ts...> &sorted,
+                                    ThreadPool *pool) {
+  return compute_sorted_covariance_symmetric_impl<CovFunc, SubCaller>(
+      cov_func, sorted, pool, std::index_sequence_for<Ts...>{});
+}
+
+/*
+ * dispatch_heterogeneous_variant_batch_symmetric - Main entry point for
+ * heterogeneous symmetric covariance
+ *
+ * Computes cov(xs, xs) where xs is a variant vector that may contain
+ * a mix of different types.
+ */
+template <typename CovFunc, typename SubCaller, typename... Ts>
+Eigen::MatrixXd dispatch_heterogeneous_variant_batch_symmetric(
+    const CovFunc &cov_func, const std::vector<variant<Ts...>> &xs,
+    ThreadPool *pool) {
+
+  if (xs.empty()) {
+    return Eigen::MatrixXd(0, 0);
+  }
+
+  // 1. Sort input by type (single copy of each element)
+  auto sorted = sort_variants_by_type(xs);
+
+  // 2. Compute symmetric covariance in sorted order
+  Eigen::MatrixXd sorted_result =
+      compute_sorted_covariance_symmetric<CovFunc, SubCaller>(cov_func, sorted,
+                                                              pool);
+
+  // 3. Unpermute: single permutation matrix since xs == ys
+  // result = P^{-1} * sorted_result * P^{-T}
+  // Note: We need to evaluate the inverse before calling transpose()
+  Eigen::PermutationMatrix<Eigen::Dynamic> P_inv = sorted.to_sorted.inverse();
+  return P_inv * sorted_result * P_inv.transpose();
+}
+
+/*
+ * dispatch_heterogeneous_variant_batch_diagonal - Main entry point for
+ * heterogeneous diagonal extraction
+ *
+ * Computes diag(cov(xs, xs)) where xs is a variant vector that may contain
+ * a mix of different types.
+ */
+template <typename CovFunc, typename SubCaller, typename... Ts,
+          std::size_t... Is>
+Eigen::VectorXd dispatch_heterogeneous_variant_batch_diagonal_impl(
+    const CovFunc &cov_func, const SortedVariantData<Ts...> &sorted,
+    ThreadPool *pool, std::index_sequence<Is...>) {
+
+  const Eigen::Index n = cast::to_index(sorted.sorted.size());
+  Eigen::VectorXd sorted_diag = Eigen::VectorXd::Zero(n);
+
+  // For each type
+  (
+      [&]() {
+        using XType = std::tuple_element_t<Is, std::tuple<Ts...>>;
+        const Eigen::Index start = sorted.block_starts[Is];
+        const Eigen::Index end = sorted.block_starts[Is + 1];
+        if (start == end)
+          return; // Empty block
+
+        auto block = extract_block<XType>(sorted, Is);
+
+        // Use SubCaller to go through full caller chain for diagonal
+        if constexpr (has_valid_cov_caller<CovFunc, SubCaller, XType,
+                                           XType>::value) {
+          auto block_diag = SubCaller::call_vector_diagonal(cov_func, block, pool);
+          sorted_diag.segment(start, end - start) = block_diag;
+        }
+        // Unsupported types: leave as zero
+      }(),
+      ...);
+
+  return sorted_diag;
+}
+
+template <typename CovFunc, typename SubCaller, typename... Ts>
+Eigen::VectorXd dispatch_heterogeneous_variant_batch_diagonal(
+    const CovFunc &cov_func, const std::vector<variant<Ts...>> &xs,
+    ThreadPool *pool) {
+
+  if (xs.empty()) {
+    return Eigen::VectorXd(0);
+  }
+
+  // 1. Sort input by type
+  auto sorted = sort_variants_by_type(xs);
+
+  // 2. Compute diagonal in sorted order
+  Eigen::VectorXd sorted_diag =
+      dispatch_heterogeneous_variant_batch_diagonal_impl<CovFunc, SubCaller>(
+          cov_func, sorted, pool, std::index_sequence_for<Ts...>{});
+
+  // 3. Unpermute: apply inverse permutation to get original order
+  // With Eigen convention: indices[orig_idx] = sorted_idx
+  // We want: result[orig_idx] = sorted_diag[sorted_idx]
+  const Eigen::Index n = cast::to_index(xs.size());
+  Eigen::VectorXd result(n);
+  for (Eigen::Index orig_idx = 0; orig_idx < n; ++orig_idx) {
+    const Eigen::Index sorted_idx = sorted.to_sorted.indices()[orig_idx];
+    result[orig_idx] = sorted_diag[sorted_idx];
+  }
+
+  return result;
+}
+
+} // namespace variant_batch_detail
+
+/*
  * VariantForwarder
  *
  * The variant forwarder allows covariance functions to be called with
@@ -417,7 +1639,7 @@ template <typename SubCaller> struct LinearCombinationCaller {
  *
  */
 template <typename SubCaller> struct VariantForwarder {
-  // Covariance Functions
+  // Covariance Functions - Pointwise
 
   // directly forward on the case where both types aren't variants
   template <typename CovFunc, typename X, typename Y,
@@ -427,6 +1649,126 @@ template <typename SubCaller> struct VariantForwarder {
                 int>::type = 0>
   static double call(const CovFunc &cov_func, const X &x, const Y &y) {
     return SubCaller::call(cov_func, x, y);
+  }
+
+  // Covariance Functions - Batch
+
+  // Passthrough when no variants
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                !is_variant<X>::value && !is_variant<Y>::value, int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, ys, pool);
+  }
+
+  // Variant on left, concrete on right: extract and dispatch if homogeneous,
+  // otherwise fall back to pointwise
+  template <typename CovFunc, typename... Ts, typename Y,
+            typename std::enable_if<!is_variant<Y>::value, int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<variant<Ts...>> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    if (is_homogeneous_variant_vector(xs)) {
+      return variant_batch_detail::dispatch_variant_batch_left<CovFunc,
+                                                               SubCaller>(
+          cov_func, xs, ys, pool);
+    }
+    // Heterogeneous: fall back to pointwise
+    auto caller = [&](const auto &x, const auto &y) {
+      return VariantForwarder::call(cov_func, x, y);
+    };
+    return compute_covariance_matrix(caller, xs, ys, pool);
+  }
+
+  // Concrete on left, variant on right: extract and dispatch if homogeneous,
+  // otherwise fall back to pointwise
+  template <typename CovFunc, typename X, typename... Ts,
+            typename std::enable_if<!is_variant<X>::value, int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<variant<Ts...>> &ys, ThreadPool *pool = nullptr) {
+    if (is_homogeneous_variant_vector(ys)) {
+      return variant_batch_detail::dispatch_variant_batch_right<CovFunc,
+                                                                SubCaller>(
+          cov_func, xs, ys, pool);
+    }
+    // Heterogeneous: fall back to pointwise
+    auto caller = [&](const auto &x, const auto &y) {
+      return VariantForwarder::call(cov_func, x, y);
+    };
+    return compute_covariance_matrix(caller, xs, ys, pool);
+  }
+
+  // Both sides variant (same variant type): use heterogeneous batch dispatch
+  // This handles both homogeneous (single type) and heterogeneous (mixed types)
+  // cases efficiently using sort-compute-unpermute.
+  template <typename CovFunc, typename... Ts>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<variant<Ts...>> &xs,
+              const std::vector<variant<Ts...>> &ys, ThreadPool *pool = nullptr) {
+    // Use heterogeneous dispatch for all cases - it handles homogeneous
+    // efficiently (single non-empty block) and heterogeneous correctly
+    return variant_batch_detail::dispatch_heterogeneous_variant_batch_cross<
+        CovFunc, SubCaller>(cov_func, xs, ys, pool);
+  }
+
+  // Both sides variant but DIFFERENT variant types: fall back to pointwise
+  // This handles cases like variant<A,B,C> vs variant<B,C> which can happen
+  // in cross-covariance scenarios.
+  template <typename CovFunc, typename... XTs, typename... YTs,
+            typename std::enable_if<
+                !std::is_same<variant<XTs...>, variant<YTs...>>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<variant<XTs...>> &xs,
+              const std::vector<variant<YTs...>> &ys, ThreadPool *pool = nullptr) {
+    // Fall back to pointwise computation for mismatched variant types
+    auto caller = [&](const auto &x, const auto &y) {
+      return VariantForwarder::call(cov_func, x, y);
+    };
+    return compute_covariance_matrix(caller, xs, ys, pool);
+  }
+
+  // Symmetric: passthrough for non-variants
+  template <typename CovFunc, typename X,
+            typename std::enable_if<!is_variant<X>::value, int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector(cov_func, xs, pool);
+  }
+
+  // Symmetric: use heterogeneous batch dispatch for all variant cases
+  // This handles both homogeneous and heterogeneous efficiently
+  template <typename CovFunc, typename... Ts>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<variant<Ts...>> &xs,
+                                     ThreadPool *pool = nullptr) {
+    // Use heterogeneous dispatch for all cases
+    return variant_batch_detail::dispatch_heterogeneous_variant_batch_symmetric<
+        CovFunc, SubCaller>(cov_func, xs, pool);
+  }
+
+  // Diagonal: passthrough for non-variants
+  template <typename CovFunc, typename X,
+            typename std::enable_if<!is_variant<X>::value, int>::type = 0>
+  static Eigen::VectorXd call_vector_diagonal(const CovFunc &cov_func,
+                                              const std::vector<X> &xs,
+                                              ThreadPool *pool = nullptr) {
+    return SubCaller::call_vector_diagonal(cov_func, xs, pool);
+  }
+
+  // Diagonal: use heterogeneous batch dispatch for all variant cases
+  template <typename CovFunc, typename... Ts>
+  static Eigen::VectorXd
+  call_vector_diagonal(const CovFunc &cov_func,
+                       const std::vector<variant<Ts...>> &xs,
+                       ThreadPool *pool = nullptr) {
+    // Use heterogeneous dispatch for all cases
+    return variant_batch_detail::dispatch_heterogeneous_variant_batch_diagonal<
+        CovFunc, SubCaller>(cov_func, xs, pool);
   }
 
   /*
@@ -543,14 +1885,193 @@ template <typename SubCaller> struct VariantForwarder {
   }
 };
 
+/*
+ * BatchCaller - attempts batch covariance via _call_impl_vector
+ */
+template <typename SubCaller> struct BatchCaller {
+  // Batch method exists - use it directly
+  template <
+      typename CovFunc, typename X, typename Y,
+      typename std::enable_if<has_valid_call_impl_vector<CovFunc, X, Y>::value,
+                              int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    return cov_func._call_impl_vector(xs, ys, pool);
+  }
+
+  // No batch - build matrix pointwise using SubCaller
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                !has_valid_call_impl_vector<CovFunc, X, Y>::value &&
+                    has_valid_cov_caller<CovFunc, SubCaller, X, Y>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              const std::vector<Y> &ys, ThreadPool *pool = nullptr) {
+    auto caller = [&](const auto &x, const auto &y) {
+      return SubCaller::call(cov_func, x, y);
+    };
+    return compute_covariance_matrix(caller, xs, ys, pool);
+  }
+
+  // Symmetric batch Priority 1: single-vector method exists - use it
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                has_valid_call_impl_vector_single_arg<CovFunc, X>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    return cov_func._call_impl_vector(xs, pool);  // Single-vector call
+  }
+
+  // Symmetric batch Priority 2: two-vector symmetric method exists (no single-vector)
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                !has_valid_call_impl_vector_single_arg<CovFunc, X>::value &&
+                    has_valid_call_impl_vector_symmetric<CovFunc, X>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    return cov_func._call_impl_vector(xs, xs, pool);  // Two-vector call
+  }
+
+  // Symmetric batch Priority 3: pointwise fallback (no batch methods)
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                !has_valid_call_impl_vector_single_arg<CovFunc, X>::value &&
+                    !has_valid_call_impl_vector_symmetric<CovFunc, X>::value &&
+                    has_valid_cov_caller<CovFunc, SubCaller, X, X>::value,
+                int>::type = 0>
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     ThreadPool *pool = nullptr) {
+    auto caller = [&](const auto &x, const auto &y) {
+      return SubCaller::call(cov_func, x, y);
+    };
+    return compute_covariance_matrix(caller, xs, pool);
+  }
+
+  // Primary: use batch when available (synthesize scalar from batch)
+  // This ensures consistency between scalar and matrix calls.
+  template <
+      typename CovFunc, typename X, typename Y,
+      typename std::enable_if<has_valid_call_impl_vector<CovFunc, X, Y>::value,
+                              int>::type = 0>
+  static double call(const CovFunc &cov_func, const X &x, const Y &y) {
+    const std::vector<X> xs{x};
+    const std::vector<Y> ys{y};
+    return cov_func._call_impl_vector(xs, ys, nullptr)(0, 0);
+  }
+
+  // Fallback: use pointwise when batch is not available
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                (!has_valid_call_impl_vector<CovFunc, X, Y>::value &&
+                 has_valid_cov_caller<CovFunc, SubCaller, X, Y>::value),
+                int>::type = 0>
+  static double call(const CovFunc &cov_func, const X &x, const Y &y) {
+    return SubCaller::call(cov_func, x, y);
+  }
+
+  // Synthesize scalar from single-arg batch (for single-arg-only covariances)
+  // This handles covariances that define _call_impl_vector(xs, pool) but NOT
+  // _call_impl_vector(xs, ys, pool) or _call_impl.
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                std::is_same<X, Y>::value &&
+                    has_valid_call_impl_vector_single_arg<CovFunc, X>::value &&
+                    !has_valid_call_impl_vector<CovFunc, X, X>::value &&
+                    !has_valid_cov_caller<CovFunc, SubCaller, X, X>::value,
+                int>::type = 0>
+  static double call(const CovFunc &cov_func, const X &x, const Y &y) {
+    // For single-arg-only covariances, create a 2-element vector and extract
+    // the cross element (0,1) for the scalar result
+    const std::vector<X> both{x, y};
+    return cov_func._call_impl_vector(both, nullptr)(0, 1);
+  }
+
+  // Mean function pass-through
+  template <
+      typename MeanFunc, typename X,
+      typename std::enable_if<
+          has_valid_mean_caller<MeanFunc, SubCaller, X>::value, int>::type = 0>
+  static double call(const MeanFunc &mean_func, const X &x) {
+    return SubCaller::call(mean_func, x);
+  }
+
+  // Diagonal batch: use _call_impl_vector_diagonal when available
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                has_valid_call_impl_vector_diagonal<CovFunc, X>::value,
+                int>::type = 0>
+  static Eigen::VectorXd call_vector_diagonal(const CovFunc &cov_func,
+                                              const std::vector<X> &xs,
+                                              ThreadPool *pool = nullptr) {
+    return cov_func._call_impl_vector_diagonal(xs, pool);
+  }
+
+  // Diagonal no batch - extract diagonal pointwise (when SubCaller supports it)
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                !has_valid_call_impl_vector_diagonal<CovFunc, X>::value &&
+                    has_valid_cov_caller<CovFunc, SubCaller, X, X>::value,
+                int>::type = 0>
+  static Eigen::VectorXd
+  call_vector_diagonal(const CovFunc &cov_func, const std::vector<X> &xs,
+                       [[maybe_unused]] ThreadPool *pool = nullptr) {
+    const Eigen::Index n = cast::to_index(xs.size());
+    Eigen::VectorXd diag(n);
+    for (Eigen::Index i = 0; i < n; ++i) {
+      const auto si = cast::to_size(i);
+      diag[i] = SubCaller::call(cov_func, xs[si], xs[si]);
+    }
+    return diag;
+  }
+
+  // Diagonal for two-arg batch-only covariances - synthesize from _call_impl_vector(xs, ys, pool)
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                !has_valid_call_impl_vector_diagonal<CovFunc, X>::value &&
+                    !has_valid_cov_caller<CovFunc, SubCaller, X, X>::value &&
+                    !has_valid_call_impl_vector_single_arg<CovFunc, X>::value &&
+                    has_valid_call_impl_vector<CovFunc, X, X>::value,
+                int>::type = 0>
+  static Eigen::VectorXd call_vector_diagonal(const CovFunc &cov_func,
+                                              const std::vector<X> &xs,
+                                              ThreadPool *pool = nullptr) {
+    // Extract diagonal from full matrix
+    // This is less efficient but correct for batch-only covariances
+    return cov_func._call_impl_vector(xs, xs, pool).diagonal();
+  }
+
+  // Diagonal for single-arg-only covariances - synthesize from _call_impl_vector(xs, pool)
+  template <typename CovFunc, typename X,
+            typename std::enable_if<
+                !has_valid_call_impl_vector_diagonal<CovFunc, X>::value &&
+                    !has_valid_cov_caller<CovFunc, SubCaller, X, X>::value &&
+                    has_valid_call_impl_vector_single_arg<CovFunc, X>::value &&
+                    !has_valid_call_impl_vector<CovFunc, X, X>::value,
+                int>::type = 0>
+  static Eigen::VectorXd call_vector_diagonal(const CovFunc &cov_func,
+                                              const std::vector<X> &xs,
+                                              ThreadPool *pool = nullptr) {
+    // Extract diagonal from single-arg batch result
+    return cov_func._call_impl_vector(xs, pool).diagonal();
+  }
+};
+
 } // namespace internal
 
 /*
  * This defines the order of operations of the covariance function Callers.
  */
-using DefaultCaller = internal::VariantForwarder<internal::MeasurementForwarder<
-    internal::LinearCombinationCaller<internal::VariantForwarder<
-        internal::SymmetricCaller<internal::DirectCaller>>>>>;
+using DefaultCaller = internal::VariantForwarder<
+    internal::MeasurementForwarder<internal::LinearCombinationCaller<
+        internal::BatchCaller<internal::VariantForwarder<
+            internal::SymmetricCaller<internal::DirectCaller>>>>>>;
 
 template <typename Caller, typename CovFunc, typename... Args>
 class caller_has_valid_call
@@ -561,6 +2082,37 @@ class caller_has_valid_call
 template <typename CovFunc, typename... Args>
 class has_valid_caller
     : public caller_has_valid_call<DefaultCaller, CovFunc, Args...> {};
+
+/*
+ * Check if EITHER pointwise OR batch is available for a type pair.
+ * This allows operator() to be enabled for batch-only covariances.
+ */
+template <typename CovFunc, typename X, typename Y>
+class has_valid_caller_or_batch {
+public:
+  static constexpr bool value =
+      has_valid_caller<CovFunc, X, Y>::value ||
+      has_valid_call_impl_vector<CovFunc, X, Y>::value;
+};
+
+// Symmetric version: check if pointwise OR symmetric batch (single-arg or two-arg) is available
+template <typename CovFunc, typename X>
+class has_valid_caller_or_batch_symmetric {
+public:
+  static constexpr bool value =
+      has_valid_caller<CovFunc, X, X>::value ||
+      has_valid_call_impl_vector_single_arg<CovFunc, X>::value ||
+      has_valid_call_impl_vector_symmetric<CovFunc, X>::value;
+};
+
+// Diagonal version: check if pointwise OR diagonal batch is available
+template <typename CovFunc, typename X>
+class has_valid_caller_or_batch_diagonal {
+public:
+  static constexpr bool value =
+      has_valid_caller<CovFunc, X, X>::value ||
+      has_valid_call_impl_vector_diagonal<CovFunc, X>::value;
+};
 
 /*
  * This defines a helper trait which indicates whether a call to a
@@ -583,9 +2135,13 @@ class has_valid_caller
  * while has_valid_caller should evaluate true in both cases, but only the
  * first is equivalent, the others _could_ be equivalent but aren't
  * neccesarily.
+ *
+ * Note: BatchCaller is included to support batch-only covariances that
+ * define _call_impl_vector but not _call_impl. BatchCaller can synthesize
+ * pointwise results from the batch method.
  */
 using EquivalentCaller = internal::MeasurementForwarder<
-    internal::SymmetricCaller<internal::DirectCaller>>;
+    internal::BatchCaller<internal::SymmetricCaller<internal::DirectCaller>>>;
 
 template <typename CovFunc, typename... Args>
 class has_equivalent_caller

--- a/include/albatross/src/covariance_functions/callers.hpp
+++ b/include/albatross/src/covariance_functions/callers.hpp
@@ -158,7 +158,8 @@ inline Eigen::MatrixXd compute_covariance_matrix_lower_triangle(
 
   const auto block_count = cast::to_index(pool->thread_count());
   const auto blocks = detail::partition_triangular(size, block_count);
-  // Reflect: convert upper-triangle-growing partitions to lower-triangle-shrinking
+  // Reflect: convert upper-triangle-growing partitions to
+  // lower-triangle-shrinking
   std::vector<std::pair<Eigen::Index, Eigen::Index>> lower_blocks;
   lower_blocks.reserve(blocks.size());
   for (auto it = blocks.rbegin(); it != blocks.rend(); ++it) {
@@ -596,61 +597,63 @@ template <typename SubCaller> struct MeasurementForwarder {
   // Symmetric: passthrough for non-Measurements
   template <typename CovFunc, typename X,
             typename std::enable_if<!is_measurement<X>::value, int>::type = 0>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              ThreadPool *pool = nullptr,
+              MirrorPolicy mirror = MirrorPolicy::Mirror) {
     return SubCaller::call_vector(cov_func, xs, pool, mirror);
   }
 
-  // Symmetric Measurement: delegate to SubCaller if _call_impl_vector exists for Measurement directly
+  // Symmetric Measurement: delegate to SubCaller if _call_impl_vector exists
+  // for Measurement directly
   template <typename CovFunc, typename X,
             typename std::enable_if<
                 is_measurement<X>::value &&
                     has_valid_call_impl_vector_symmetric<CovFunc, X>::value,
                 int>::type = 0>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              ThreadPool *pool = nullptr,
+              MirrorPolicy mirror = MirrorPolicy::Mirror) {
     return SubCaller::call_vector(cov_func, xs, pool, mirror);
   }
 
-  // Symmetric Measurement: unwrap and delegate if single-arg OR two-arg exists for inner type (no Measurement-specific _call_impl_vector)
+  // Symmetric Measurement: unwrap and delegate if single-arg OR two-arg exists
+  // for inner type (no Measurement-specific _call_impl_vector)
   template <typename CovFunc, typename X,
             typename std::enable_if<
                 is_measurement<X>::value &&
                     !has_valid_call_impl_vector_symmetric<CovFunc, X>::value &&
                     !has_valid_call_impl<CovFunc, X, X>::value &&
-                    (has_valid_call_impl_vector_single_arg<CovFunc,
-                         measurement_inner_t<X>>::value ||
-                     has_valid_call_impl_vector_symmetric<CovFunc,
-                         measurement_inner_t<X>>::value),
+                    (has_valid_call_impl_vector_single_arg<
+                         CovFunc, measurement_inner_t<X>>::value ||
+                     has_valid_call_impl_vector_symmetric<
+                         CovFunc, measurement_inner_t<X>>::value),
                 int>::type = 0>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              ThreadPool *pool = nullptr,
+              MirrorPolicy mirror = MirrorPolicy::Mirror) {
     auto unwrapped_xs = unwrap_measurements(xs);
     return SubCaller::call_vector(cov_func, unwrapped_xs, pool, mirror);
   }
 
-  // Symmetric Measurement: unwrap if no single-arg, no _call_impl_vector, no _call_impl
-  // but inner type has pointwise support
+  // Symmetric Measurement: unwrap if no single-arg, no _call_impl_vector, no
+  // _call_impl but inner type has pointwise support
   template <typename CovFunc, typename X,
             typename std::enable_if<
                 is_measurement<X>::value &&
                     !has_valid_call_impl_vector_symmetric<CovFunc, X>::value &&
                     !has_valid_call_impl<CovFunc, X, X>::value &&
-                    !has_valid_call_impl_vector_single_arg<CovFunc,
-                         measurement_inner_t<X>>::value &&
-                    !has_valid_call_impl_vector_symmetric<CovFunc,
-                         measurement_inner_t<X>>::value,
+                    !has_valid_call_impl_vector_single_arg<
+                        CovFunc, measurement_inner_t<X>>::value &&
+                    !has_valid_call_impl_vector_symmetric<
+                        CovFunc, measurement_inner_t<X>>::value,
                 int>::type = 0>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              ThreadPool *pool = nullptr,
+              MirrorPolicy mirror = MirrorPolicy::Mirror) {
     auto unwrapped_xs = unwrap_measurements(xs);
     return SubCaller::call_vector(cov_func, unwrapped_xs, pool, mirror);
   }
@@ -662,10 +665,9 @@ template <typename SubCaller> struct MeasurementForwarder {
                     !has_valid_call_impl_vector_symmetric<CovFunc, X>::value &&
                     has_valid_call_impl<CovFunc, X, X>::value,
                 int>::type = 0>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy = MirrorPolicy::Mirror) {
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              ThreadPool *pool = nullptr, MirrorPolicy = MirrorPolicy::Mirror) {
     auto caller = [&](const auto &x, const auto &y) {
       return MeasurementForwarder::call(cov_func, x, y);
     };
@@ -681,12 +683,13 @@ template <typename SubCaller> struct MeasurementForwarder {
     return SubCaller::call_vector_diagonal(cov_func, xs, pool);
   }
 
-  // Diagonal Measurement: unwrap ONLY if no explicit _call_impl for Measurement types
-  template <typename CovFunc, typename X,
-            typename std::enable_if<
-                is_measurement<X>::value &&
-                    !has_valid_call_impl<CovFunc, X, X>::value,
-                int>::type = 0>
+  // Diagonal Measurement: unwrap ONLY if no explicit _call_impl for Measurement
+  // types
+  template <
+      typename CovFunc, typename X,
+      typename std::enable_if<is_measurement<X>::value &&
+                                  !has_valid_call_impl<CovFunc, X, X>::value,
+                              int>::type = 0>
   static Eigen::VectorXd call_vector_diagonal(const CovFunc &cov_func,
                                               const std::vector<X> &xs,
                                               ThreadPool *pool = nullptr) {
@@ -694,12 +697,13 @@ template <typename SubCaller> struct MeasurementForwarder {
     return SubCaller::call_vector_diagonal(cov_func, unwrapped_xs, pool);
   }
 
-  // Diagonal Measurement: pointwise if explicit _call_impl exists for Measurement types
-  template <typename CovFunc, typename X,
-            typename std::enable_if<
-                is_measurement<X>::value &&
-                    has_valid_call_impl<CovFunc, X, X>::value,
-                int>::type = 0>
+  // Diagonal Measurement: pointwise if explicit _call_impl exists for
+  // Measurement types
+  template <
+      typename CovFunc, typename X,
+      typename std::enable_if<is_measurement<X>::value &&
+                                  has_valid_call_impl<CovFunc, X, X>::value,
+                              int>::type = 0>
   static Eigen::VectorXd
   call_vector_diagonal(const CovFunc &cov_func, const std::vector<X> &xs,
                        [[maybe_unused]] ThreadPool *pool = nullptr) {
@@ -816,10 +820,10 @@ template <typename SubCaller> struct LinearCombinationCaller {
   template <
       typename CovFunc, typename X,
       typename std::enable_if<!is_linear_combination<X>::value, int>::type = 0>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              ThreadPool *pool = nullptr,
+              MirrorPolicy mirror = MirrorPolicy::Mirror) {
     return SubCaller::call_vector(cov_func, xs, pool, mirror);
   }
 
@@ -827,10 +831,9 @@ template <typename SubCaller> struct LinearCombinationCaller {
   template <
       typename CovFunc, typename X,
       typename std::enable_if<is_linear_combination<X>::value, int>::type = 0>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy = MirrorPolicy::Mirror) {
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              ThreadPool *pool = nullptr, MirrorPolicy = MirrorPolicy::Mirror) {
     auto caller = [&](const auto &x, const auto &y) {
       return LinearCombinationCaller::call(cov_func, x, y);
     };
@@ -1012,21 +1015,26 @@ Eigen::MatrixXd dispatch_variant_batch_left_impl(
 
   // Fold expression: match runtime index to compile-time type
   ((Is == runtime_index
-        ? (found = true,
-           result = [&]() {
-             using ConcreteType = std::tuple_element_t<Is, std::tuple<Ts...>>;
-             auto concrete_xs = extract_homogeneous<ConcreteType>(xs);
-             // Check if this type pair is supported; if not, return zeros
-             // (matches pointwise visitor behavior)
-             if constexpr (has_valid_cov_caller<CovFunc, SubCaller, ConcreteType,
-                                                Y>::value) {
-               return SubCaller::call_vector(cov_func, concrete_xs, ys, pool);
-             } else {
-               return Eigen::MatrixXd::Zero(cast::to_index(xs.size()),
-                                            cast::to_index(ys.size()));
-             }
-           }(),
-           0)
+        ? (
+              found = true,
+              result =
+                  [&]() {
+                    using ConcreteType =
+                        std::tuple_element_t<Is, std::tuple<Ts...>>;
+                    auto concrete_xs = extract_homogeneous<ConcreteType>(xs);
+                    // Check if this type pair is supported; if not, return
+                    // zeros (matches pointwise visitor behavior)
+                    if constexpr (has_valid_cov_caller<CovFunc, SubCaller,
+                                                       ConcreteType,
+                                                       Y>::value) {
+                      return SubCaller::call_vector(cov_func, concrete_xs, ys,
+                                                    pool);
+                    } else {
+                      return Eigen::MatrixXd::Zero(cast::to_index(xs.size()),
+                                                   cast::to_index(ys.size()));
+                    }
+                  }(),
+              0)
         : 0),
    ...);
 
@@ -1062,21 +1070,25 @@ Eigen::MatrixXd dispatch_variant_batch_right_impl(
   bool found = false;
 
   ((Is == runtime_index
-        ? (found = true,
-           result = [&]() {
-             using ConcreteType = std::tuple_element_t<Is, std::tuple<Ts...>>;
-             auto concrete_ys = extract_homogeneous<ConcreteType>(ys);
-             // Check if this type pair is supported; if not, return zeros
-             // (matches pointwise visitor behavior)
-             if constexpr (has_valid_cov_caller<CovFunc, SubCaller, X,
-                                                ConcreteType>::value) {
-               return SubCaller::call_vector(cov_func, xs, concrete_ys, pool);
-             } else {
-               return Eigen::MatrixXd::Zero(cast::to_index(xs.size()),
-                                            cast::to_index(ys.size()));
-             }
-           }(),
-           0)
+        ? (
+              found = true,
+              result =
+                  [&]() {
+                    using ConcreteType =
+                        std::tuple_element_t<Is, std::tuple<Ts...>>;
+                    auto concrete_ys = extract_homogeneous<ConcreteType>(ys);
+                    // Check if this type pair is supported; if not, return
+                    // zeros (matches pointwise visitor behavior)
+                    if constexpr (has_valid_cov_caller<CovFunc, SubCaller, X,
+                                                       ConcreteType>::value) {
+                      return SubCaller::call_vector(cov_func, xs, concrete_ys,
+                                                    pool);
+                    } else {
+                      return Eigen::MatrixXd::Zero(cast::to_index(xs.size()),
+                                                   cast::to_index(ys.size()));
+                    }
+                  }(),
+              0)
         : 0),
    ...);
 
@@ -1113,21 +1125,25 @@ Eigen::MatrixXd dispatch_variant_batch_both_y_impl(
   bool found = false;
 
   ((YIs == y_index
-        ? (found = true,
-           result = [&]() {
-             using YType = std::tuple_element_t<YIs, std::tuple<Ys...>>;
-             auto concrete_ys = extract_homogeneous<YType>(ys);
-             // Check if this type pair is supported; if not, return zeros
-             if constexpr (has_valid_cov_caller<CovFunc, SubCaller, XType,
-                                                YType>::value) {
-               return SubCaller::call_vector(cov_func, concrete_xs, concrete_ys,
-                                             pool);
-             } else {
-               return Eigen::MatrixXd::Zero(cast::to_index(concrete_xs.size()),
-                                            cast::to_index(ys.size()));
-             }
-           }(),
-           0)
+        ? (
+              found = true,
+              result =
+                  [&]() {
+                    using YType = std::tuple_element_t<YIs, std::tuple<Ys...>>;
+                    auto concrete_ys = extract_homogeneous<YType>(ys);
+                    // Check if this type pair is supported; if not, return
+                    // zeros
+                    if constexpr (has_valid_cov_caller<CovFunc, SubCaller,
+                                                       XType, YType>::value) {
+                      return SubCaller::call_vector(cov_func, concrete_xs,
+                                                    concrete_ys, pool);
+                    } else {
+                      return Eigen::MatrixXd::Zero(
+                          cast::to_index(concrete_xs.size()),
+                          cast::to_index(ys.size()));
+                    }
+                  }(),
+              0)
         : 0),
    ...);
 
@@ -1147,16 +1163,18 @@ Eigen::MatrixXd dispatch_variant_batch_both_x_impl(
   bool found = false;
 
   ((XIs == x_index
-        ? (found = true,
-           result = [&]() {
-             using XType = std::tuple_element_t<XIs, std::tuple<Xs...>>;
-             auto concrete_xs = extract_homogeneous<XType>(xs);
-             return dispatch_variant_batch_both_y_impl<CovFunc, SubCaller,
-                                                       XType>(
-                 cov_func, concrete_xs, ys, pool, y_index,
-                 std::index_sequence_for<Ys...>{});
-           }(),
-           0)
+        ? (
+              found = true,
+              result =
+                  [&]() {
+                    using XType = std::tuple_element_t<XIs, std::tuple<Xs...>>;
+                    auto concrete_xs = extract_homogeneous<XType>(xs);
+                    return dispatch_variant_batch_both_y_impl<CovFunc,
+                                                              SubCaller, XType>(
+                        cov_func, concrete_xs, ys, pool, y_index,
+                        std::index_sequence_for<Ys...>{});
+                  }(),
+              0)
         : 0),
    ...);
 
@@ -1165,11 +1183,9 @@ Eigen::MatrixXd dispatch_variant_batch_both_x_impl(
 }
 
 template <typename CovFunc, typename SubCaller, typename... Xs, typename... Ys>
-Eigen::MatrixXd
-dispatch_variant_batch_both(const CovFunc &cov_func,
-                            const std::vector<variant<Xs...>> &xs,
-                            const std::vector<variant<Ys...>> &ys,
-                            ThreadPool *pool) {
+Eigen::MatrixXd dispatch_variant_batch_both(
+    const CovFunc &cov_func, const std::vector<variant<Xs...>> &xs,
+    const std::vector<variant<Ys...>> &ys, ThreadPool *pool) {
   if (xs.empty()) {
     return Eigen::MatrixXd(0, cast::to_index(ys.size()));
   }
@@ -1198,21 +1214,26 @@ Eigen::MatrixXd dispatch_variant_batch_symmetric_impl(
   bool found = false;
 
   ((Is == runtime_index
-        ? (found = true,
-           result = [&]() {
-             using ConcreteType = std::tuple_element_t<Is, std::tuple<Ts...>>;
-             auto concrete_xs = extract_homogeneous<ConcreteType>(xs);
-             // Check if this type is supported; if not, return zeros
-             // (matches pointwise visitor behavior)
-             if constexpr (has_valid_cov_caller<CovFunc, SubCaller, ConcreteType,
-                                                ConcreteType>::value) {
-               return SubCaller::call_vector(cov_func, concrete_xs, pool);
-             } else {
-               return Eigen::MatrixXd::Zero(cast::to_index(xs.size()),
-                                            cast::to_index(xs.size()));
-             }
-           }(),
-           0)
+        ? (
+              found = true,
+              result =
+                  [&]() {
+                    using ConcreteType =
+                        std::tuple_element_t<Is, std::tuple<Ts...>>;
+                    auto concrete_xs = extract_homogeneous<ConcreteType>(xs);
+                    // Check if this type is supported; if not, return zeros
+                    // (matches pointwise visitor behavior)
+                    if constexpr (has_valid_cov_caller<CovFunc, SubCaller,
+                                                       ConcreteType,
+                                                       ConcreteType>::value) {
+                      return SubCaller::call_vector(cov_func, concrete_xs,
+                                                    pool);
+                    } else {
+                      return Eigen::MatrixXd::Zero(cast::to_index(xs.size()),
+                                                   cast::to_index(xs.size()));
+                    }
+                  }(),
+              0)
         : 0),
    ...);
 
@@ -1247,21 +1268,25 @@ Eigen::VectorXd dispatch_variant_batch_diagonal_impl(
   bool found = false;
 
   ((Is == runtime_index
-        ? (found = true,
-           result = [&]() {
-             using ConcreteType = std::tuple_element_t<Is, std::tuple<Ts...>>;
-             auto concrete_xs = extract_homogeneous<ConcreteType>(xs);
-             // Check if this type is supported; if not, return zeros
-             // (matches pointwise visitor behavior)
-             if constexpr (has_valid_cov_caller<CovFunc, SubCaller, ConcreteType,
-                                                ConcreteType>::value) {
-               return SubCaller::call_vector_diagonal(cov_func, concrete_xs,
-                                                      pool);
-             } else {
-               return Eigen::VectorXd::Zero(cast::to_index(xs.size()));
-             }
-           }(),
-           0)
+        ? (
+              found = true,
+              result =
+                  [&]() {
+                    using ConcreteType =
+                        std::tuple_element_t<Is, std::tuple<Ts...>>;
+                    auto concrete_xs = extract_homogeneous<ConcreteType>(xs);
+                    // Check if this type is supported; if not, return zeros
+                    // (matches pointwise visitor behavior)
+                    if constexpr (has_valid_cov_caller<CovFunc, SubCaller,
+                                                       ConcreteType,
+                                                       ConcreteType>::value) {
+                      return SubCaller::call_vector_diagonal(cov_func,
+                                                             concrete_xs, pool);
+                    } else {
+                      return Eigen::VectorXd::Zero(cast::to_index(xs.size()));
+                    }
+                  }(),
+              0)
         : 0),
    ...);
 
@@ -1391,11 +1416,9 @@ Eigen::MatrixXd compute_sorted_covariance_cross_impl(
 }
 
 template <typename CovFunc, typename SubCaller, typename... Ts>
-Eigen::MatrixXd
-compute_sorted_covariance_cross(const CovFunc &cov_func,
-                                const SortedVariantData<Ts...> &x_sorted,
-                                const SortedVariantData<Ts...> &y_sorted,
-                                ThreadPool *pool) {
+Eigen::MatrixXd compute_sorted_covariance_cross(
+    const CovFunc &cov_func, const SortedVariantData<Ts...> &x_sorted,
+    const SortedVariantData<Ts...> &y_sorted, ThreadPool *pool) {
   return compute_sorted_covariance_cross_impl<CovFunc, SubCaller>(
       cov_func, x_sorted, y_sorted, pool, std::index_sequence_for<Ts...>{});
 }
@@ -1445,7 +1468,8 @@ Eigen::MatrixXd dispatch_heterogeneous_variant_batch_cross(
  * and off-diagonal blocks once.
  */
 
-// Helper: process one row block (X type XI) against column blocks (Y types >= XI)
+// Helper: process one row block (X type XI) against column blocks (Y types >=
+// XI)
 template <typename CovFunc, typename SubCaller, std::size_t XI,
           typename TypeListT, std::size_t... YIs>
 struct SymmetricRowBlockProcessor;
@@ -1607,7 +1631,8 @@ Eigen::VectorXd dispatch_heterogeneous_variant_batch_diagonal_impl(
         // Use SubCaller to go through full caller chain for diagonal
         if constexpr (has_valid_cov_caller<CovFunc, SubCaller, XType,
                                            XType>::value) {
-          auto block_diag = SubCaller::call_vector_diagonal(cov_func, block, pool);
+          auto block_diag =
+              SubCaller::call_vector_diagonal(cov_func, block, pool);
           sorted_diag.segment(start, end - start) = block_diag;
         }
         // Unsupported types: leave as zero
@@ -1718,9 +1743,10 @@ template <typename SubCaller> struct VariantForwarder {
   // otherwise fall back to pointwise
   template <typename CovFunc, typename X, typename... Ts,
             typename std::enable_if<!is_variant<X>::value, int>::type = 0>
-  static Eigen::MatrixXd
-  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
-              const std::vector<variant<Ts...>> &ys, ThreadPool *pool = nullptr) {
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<X> &xs,
+                                     const std::vector<variant<Ts...>> &ys,
+                                     ThreadPool *pool = nullptr) {
     if (is_homogeneous_variant_vector(ys)) {
       return variant_batch_detail::dispatch_variant_batch_right<CovFunc,
                                                                 SubCaller>(
@@ -1737,9 +1763,10 @@ template <typename SubCaller> struct VariantForwarder {
   // This handles both homogeneous (single type) and heterogeneous (mixed types)
   // cases efficiently using sort-compute-unpermute.
   template <typename CovFunc, typename... Ts>
-  static Eigen::MatrixXd
-  call_vector(const CovFunc &cov_func, const std::vector<variant<Ts...>> &xs,
-              const std::vector<variant<Ts...>> &ys, ThreadPool *pool = nullptr) {
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<variant<Ts...>> &xs,
+                                     const std::vector<variant<Ts...>> &ys,
+                                     ThreadPool *pool = nullptr) {
     // Use heterogeneous dispatch for all cases - it handles homogeneous
     // efficiently (single non-empty block) and heterogeneous correctly
     return variant_batch_detail::dispatch_heterogeneous_variant_batch_cross<
@@ -1753,9 +1780,10 @@ template <typename SubCaller> struct VariantForwarder {
             typename std::enable_if<
                 !std::is_same<variant<XTs...>, variant<YTs...>>::value,
                 int>::type = 0>
-  static Eigen::MatrixXd
-  call_vector(const CovFunc &cov_func, const std::vector<variant<XTs...>> &xs,
-              const std::vector<variant<YTs...>> &ys, ThreadPool *pool = nullptr) {
+  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
+                                     const std::vector<variant<XTs...>> &xs,
+                                     const std::vector<variant<YTs...>> &ys,
+                                     ThreadPool *pool = nullptr) {
     // Fall back to pointwise computation for mismatched variant types
     auto caller = [&](const auto &x, const auto &y) {
       return VariantForwarder::call(cov_func, x, y);
@@ -1766,20 +1794,19 @@ template <typename SubCaller> struct VariantForwarder {
   // Symmetric: passthrough for non-variants
   template <typename CovFunc, typename X,
             typename std::enable_if<!is_variant<X>::value, int>::type = 0>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              ThreadPool *pool = nullptr,
+              MirrorPolicy mirror = MirrorPolicy::Mirror) {
     return SubCaller::call_vector(cov_func, xs, pool, mirror);
   }
 
   // Symmetric: use heterogeneous batch dispatch for all variant cases
   // This handles both homogeneous and heterogeneous efficiently
   template <typename CovFunc, typename... Ts>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<variant<Ts...>> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy = MirrorPolicy::Mirror) {
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<variant<Ts...>> &xs,
+              ThreadPool *pool = nullptr, MirrorPolicy = MirrorPolicy::Mirror) {
     // Use heterogeneous dispatch for all cases
     return variant_batch_detail::dispatch_heterogeneous_variant_batch_symmetric<
         CovFunc, SubCaller>(cov_func, xs, pool);
@@ -1959,10 +1986,10 @@ template <typename SubCaller> struct BatchCaller {
             typename std::enable_if<
                 has_valid_call_impl_vector_single_arg<CovFunc, X>::value,
                 int>::type = 0>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              ThreadPool *pool = nullptr,
+              MirrorPolicy mirror = MirrorPolicy::Mirror) {
     Eigen::MatrixXd result = cov_func._call_impl_vector(xs, pool);
     if (mirror == MirrorPolicy::Mirror) {
       result.triangularView<Eigen::StrictlyUpper>() =
@@ -1971,17 +1998,17 @@ template <typename SubCaller> struct BatchCaller {
     return result;
   }
 
-  // Symmetric batch Priority 2: two-vector symmetric method exists (no single-vector)
+  // Symmetric batch Priority 2: two-vector symmetric method exists (no
+  // single-vector)
   template <typename CovFunc, typename X,
             typename std::enable_if<
                 !has_valid_call_impl_vector_single_arg<CovFunc, X>::value &&
                     has_valid_call_impl_vector_symmetric<CovFunc, X>::value,
                 int>::type = 0>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy = MirrorPolicy::Mirror) {
-    return cov_func._call_impl_vector(xs, xs, pool);  // Two-vector call
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              ThreadPool *pool = nullptr, MirrorPolicy = MirrorPolicy::Mirror) {
+    return cov_func._call_impl_vector(xs, xs, pool); // Two-vector call
   }
 
   // Symmetric batch Priority 3: pointwise fallback (no batch methods)
@@ -1991,10 +2018,9 @@ template <typename SubCaller> struct BatchCaller {
                     !has_valid_call_impl_vector_symmetric<CovFunc, X>::value &&
                     has_valid_cov_caller<CovFunc, SubCaller, X, X>::value,
                 int>::type = 0>
-  static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
-                                     const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr,
-                                     MirrorPolicy = MirrorPolicy::Mirror) {
+  static Eigen::MatrixXd
+  call_vector(const CovFunc &cov_func, const std::vector<X> &xs,
+              ThreadPool *pool = nullptr, MirrorPolicy = MirrorPolicy::Mirror) {
     auto caller = [&](const auto &x, const auto &y) {
       return SubCaller::call(cov_func, x, y);
     };
@@ -2002,10 +2028,10 @@ template <typename SubCaller> struct BatchCaller {
   }
 
   // Primary: use pointwise when available
-  template <typename CovFunc, typename X, typename Y,
-            typename std::enable_if<
-                has_valid_cov_caller<CovFunc, SubCaller, X, Y>::value,
-                int>::type = 0>
+  template <
+      typename CovFunc, typename X, typename Y,
+      typename std::enable_if<
+          has_valid_cov_caller<CovFunc, SubCaller, X, Y>::value, int>::type = 0>
   static double call(const CovFunc &cov_func, const X &x, const Y &y) {
     return SubCaller::call(cov_func, x, y);
   }
@@ -2080,7 +2106,8 @@ template <typename SubCaller> struct BatchCaller {
     return diag;
   }
 
-  // Diagonal for two-arg batch-only covariances - synthesize from _call_impl_vector(xs, ys, pool)
+  // Diagonal for two-arg batch-only covariances - synthesize from
+  // _call_impl_vector(xs, ys, pool)
   template <typename CovFunc, typename X,
             typename std::enable_if<
                 !has_valid_call_impl_vector_diagonal<CovFunc, X>::value &&
@@ -2096,7 +2123,8 @@ template <typename SubCaller> struct BatchCaller {
     return cov_func._call_impl_vector(xs, xs, pool).diagonal();
   }
 
-  // Diagonal for single-arg-only covariances - synthesize from _call_impl_vector(xs, pool)
+  // Diagonal for single-arg-only covariances - synthesize from
+  // _call_impl_vector(xs, pool)
   template <typename CovFunc, typename X,
             typename std::enable_if<
                 !has_valid_call_impl_vector_diagonal<CovFunc, X>::value &&
@@ -2144,7 +2172,8 @@ public:
       has_valid_call_impl_vector<CovFunc, X, Y>::value;
 };
 
-// Symmetric version: check if pointwise OR symmetric batch (single-arg or two-arg) is available
+// Symmetric version: check if pointwise OR symmetric batch (single-arg or
+// two-arg) is available
 template <typename CovFunc, typename X>
 class has_valid_caller_or_batch_symmetric {
 public:

--- a/include/albatross/src/covariance_functions/callers.hpp
+++ b/include/albatross/src/covariance_functions/callers.hpp
@@ -251,6 +251,14 @@ unwrap_measurements(const std::vector<Measurement<X>> &measurements) {
 
 namespace internal {
 
+// Controls whether BatchCaller mirrors the lower triangle into the
+// strictly-upper triangle after a symmetric single-arg call_vector.
+// Composites (Sum, Product) that only read the lower triangle of child
+// results pass SkipMirror to avoid redundant O(n²/2) copies at each
+// nesting level.  The default (Mirror) preserves the current
+// always-correct behavior for any caller that forgets to forward it.
+enum class MirrorPolicy { Mirror, SkipMirror };
+
 /*
  * This Caller just directly call the underlying CovFunc.
  */
@@ -584,8 +592,9 @@ template <typename SubCaller> struct MeasurementForwarder {
             typename std::enable_if<!is_measurement<X>::value, int>::type = 0>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr) {
-    return SubCaller::call_vector(cov_func, xs, pool);
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
+    return SubCaller::call_vector(cov_func, xs, pool, mirror);
   }
 
   // Symmetric Measurement: delegate to SubCaller if _call_impl_vector exists for Measurement directly
@@ -596,8 +605,9 @@ template <typename SubCaller> struct MeasurementForwarder {
                 int>::type = 0>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr) {
-    return SubCaller::call_vector(cov_func, xs, pool);
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
+    return SubCaller::call_vector(cov_func, xs, pool, mirror);
   }
 
   // Symmetric Measurement: unwrap and delegate if single-arg OR two-arg exists for inner type (no Measurement-specific _call_impl_vector)
@@ -613,9 +623,10 @@ template <typename SubCaller> struct MeasurementForwarder {
                 int>::type = 0>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr) {
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
     auto unwrapped_xs = unwrap_measurements(xs);
-    return SubCaller::call_vector(cov_func, unwrapped_xs, pool);
+    return SubCaller::call_vector(cov_func, unwrapped_xs, pool, mirror);
   }
 
   // Symmetric Measurement: unwrap if no single-arg, no _call_impl_vector, no _call_impl
@@ -632,9 +643,10 @@ template <typename SubCaller> struct MeasurementForwarder {
                 int>::type = 0>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr) {
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
     auto unwrapped_xs = unwrap_measurements(xs);
-    return SubCaller::call_vector(cov_func, unwrapped_xs, pool);
+    return SubCaller::call_vector(cov_func, unwrapped_xs, pool, mirror);
   }
 
   // Symmetric Measurement: pointwise if _call_impl exists for Measurement
@@ -646,7 +658,8 @@ template <typename SubCaller> struct MeasurementForwarder {
                 int>::type = 0>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr) {
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy = MirrorPolicy::Mirror) {
     auto caller = [&](const auto &x, const auto &y) {
       return MeasurementForwarder::call(cov_func, x, y);
     };
@@ -799,8 +812,9 @@ template <typename SubCaller> struct LinearCombinationCaller {
       typename std::enable_if<!is_linear_combination<X>::value, int>::type = 0>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr) {
-    return SubCaller::call_vector(cov_func, xs, pool);
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
+    return SubCaller::call_vector(cov_func, xs, pool, mirror);
   }
 
   // Symmetric: pointwise for LinearCombinations
@@ -809,7 +823,8 @@ template <typename SubCaller> struct LinearCombinationCaller {
       typename std::enable_if<is_linear_combination<X>::value, int>::type = 0>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr) {
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy = MirrorPolicy::Mirror) {
     auto caller = [&](const auto &x, const auto &y) {
       return LinearCombinationCaller::call(cov_func, x, y);
     };
@@ -1747,8 +1762,9 @@ template <typename SubCaller> struct VariantForwarder {
             typename std::enable_if<!is_variant<X>::value, int>::type = 0>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr) {
-    return SubCaller::call_vector(cov_func, xs, pool);
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
+    return SubCaller::call_vector(cov_func, xs, pool, mirror);
   }
 
   // Symmetric: use heterogeneous batch dispatch for all variant cases
@@ -1756,7 +1772,8 @@ template <typename SubCaller> struct VariantForwarder {
   template <typename CovFunc, typename... Ts>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<variant<Ts...>> &xs,
-                                     ThreadPool *pool = nullptr) {
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy = MirrorPolicy::Mirror) {
     // Use heterogeneous dispatch for all cases
     return variant_batch_detail::dispatch_heterogeneous_variant_batch_symmetric<
         CovFunc, SubCaller>(cov_func, xs, pool);
@@ -1938,10 +1955,13 @@ template <typename SubCaller> struct BatchCaller {
                 int>::type = 0>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr) {
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy mirror = MirrorPolicy::Mirror) {
     Eigen::MatrixXd result = cov_func._call_impl_vector(xs, pool);
-    result.triangularView<Eigen::StrictlyUpper>() =
-        result.transpose().triangularView<Eigen::StrictlyUpper>();
+    if (mirror == MirrorPolicy::Mirror) {
+      result.triangularView<Eigen::StrictlyUpper>() =
+          result.transpose().triangularView<Eigen::StrictlyUpper>();
+    }
     return result;
   }
 
@@ -1953,7 +1973,8 @@ template <typename SubCaller> struct BatchCaller {
                 int>::type = 0>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr) {
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy = MirrorPolicy::Mirror) {
     return cov_func._call_impl_vector(xs, xs, pool);  // Two-vector call
   }
 
@@ -1966,7 +1987,8 @@ template <typename SubCaller> struct BatchCaller {
                 int>::type = 0>
   static Eigen::MatrixXd call_vector(const CovFunc &cov_func,
                                      const std::vector<X> &xs,
-                                     ThreadPool *pool = nullptr) {
+                                     ThreadPool *pool = nullptr,
+                                     MirrorPolicy = MirrorPolicy::Mirror) {
     auto caller = [&](const auto &x, const auto &y) {
       return SubCaller::call(cov_func, x, y);
     };

--- a/include/albatross/src/covariance_functions/callers.hpp
+++ b/include/albatross/src/covariance_functions/callers.hpp
@@ -149,7 +149,7 @@ inline Eigen::MatrixXd compute_covariance_matrix_lower_triangle(
   const auto apply_block = [&](const auto indices) {
     for (Eigen::Index col = indices.first; col < indices.second; ++col) {
       const auto vcol = cast::to_size(col);
-      for (Eigen::Index row = 0; row <= col; ++row) {
+      for (Eigen::Index row = col; row < size; ++row) {
         const auto vrow = cast::to_size(row);
         output(row, col) = caller(xs[vrow], xs[vcol]);
       }
@@ -158,9 +158,15 @@ inline Eigen::MatrixXd compute_covariance_matrix_lower_triangle(
 
   const auto block_count = cast::to_index(pool->thread_count());
   const auto blocks = detail::partition_triangular(size, block_count);
-  apply(blocks, apply_block, pool);
+  // Reflect: convert upper-triangle-growing partitions to lower-triangle-shrinking
+  std::vector<std::pair<Eigen::Index, Eigen::Index>> lower_blocks;
+  lower_blocks.reserve(blocks.size());
+  for (auto it = blocks.rbegin(); it != blocks.rend(); ++it) {
+    lower_blocks.emplace_back(size - it->second, size - it->first);
+  }
+  apply(lower_blocks, apply_block, pool);
 
-  return output.transpose();
+  return output;
 }
 
 /*

--- a/include/albatross/src/covariance_functions/callers.hpp
+++ b/include/albatross/src/covariance_functions/callers.hpp
@@ -2001,26 +2001,25 @@ template <typename SubCaller> struct BatchCaller {
     return compute_covariance_matrix(caller, xs, pool);
   }
 
-  // Primary: use batch when available (synthesize scalar from batch)
-  // This ensures consistency between scalar and matrix calls.
-  template <
-      typename CovFunc, typename X, typename Y,
-      typename std::enable_if<has_valid_call_impl_vector<CovFunc, X, Y>::value,
-                              int>::type = 0>
+  // Primary: use pointwise when available
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                has_valid_cov_caller<CovFunc, SubCaller, X, Y>::value,
+                int>::type = 0>
+  static double call(const CovFunc &cov_func, const X &x, const Y &y) {
+    return SubCaller::call(cov_func, x, y);
+  }
+
+  // Fallback: synthesize scalar from two-arg batch when no pointwise exists
+  template <typename CovFunc, typename X, typename Y,
+            typename std::enable_if<
+                (!has_valid_cov_caller<CovFunc, SubCaller, X, Y>::value &&
+                 has_valid_call_impl_vector<CovFunc, X, Y>::value),
+                int>::type = 0>
   static double call(const CovFunc &cov_func, const X &x, const Y &y) {
     const std::vector<X> xs{x};
     const std::vector<Y> ys{y};
     return cov_func._call_impl_vector(xs, ys, nullptr)(0, 0);
-  }
-
-  // Fallback: use pointwise when batch is not available
-  template <typename CovFunc, typename X, typename Y,
-            typename std::enable_if<
-                (!has_valid_call_impl_vector<CovFunc, X, Y>::value &&
-                 has_valid_cov_caller<CovFunc, SubCaller, X, Y>::value),
-                int>::type = 0>
-  static double call(const CovFunc &cov_func, const X &x, const Y &y) {
-    return SubCaller::call(cov_func, x, y);
   }
 
   // Synthesize scalar from single-arg batch (for single-arg-only covariances)

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -456,7 +456,8 @@ public:
           int>::type = 0>
   Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
                                     ThreadPool *pool = nullptr) const {
-    Eigen::MatrixXd result;
+    Eigen::Index n{albatross::cast::to_index(xs.size())};
+    Eigen::MatrixXd result(n, n);
     result.triangularView<Eigen::Lower>() =
         DefaultCaller::call_vector(lhs_, xs, pool);
     result.triangularView<Eigen::Lower>() +=
@@ -688,7 +689,8 @@ public:
           int>::type = 0>
   Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
                                     ThreadPool *pool = nullptr) const {
-    Eigen::MatrixXd ret;
+    Eigen::Index n = albatross::cast::to_index(xs.size());
+    Eigen::MatrixXd ret(n, n);
     ret.triangularView<Eigen::Lower>() =
         DefaultCaller::call_vector(lhs_, xs, pool);
     ret.triangularView<Eigen::Lower>() =

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -447,12 +447,10 @@ public:
                                     ThreadPool *pool = nullptr) const {
     Eigen::Index n{albatross::cast::to_index(xs.size())};
     Eigen::MatrixXd result(n, n);
-    result.triangularView<Eigen::Lower>() =
-        DefaultCaller::call_vector(lhs_, xs, pool,
-                                   internal::MirrorPolicy::SkipMirror);
-    result.triangularView<Eigen::Lower>() +=
-        DefaultCaller::call_vector(rhs_, xs, pool,
-                                   internal::MirrorPolicy::SkipMirror);
+    result.triangularView<Eigen::Lower>() = DefaultCaller::call_vector(
+        lhs_, xs, pool, internal::MirrorPolicy::SkipMirror);
+    result.triangularView<Eigen::Lower>() += DefaultCaller::call_vector(
+        rhs_, xs, pool, internal::MirrorPolicy::SkipMirror);
     return result;
   }
 
@@ -680,14 +678,12 @@ public:
                                     ThreadPool *pool = nullptr) const {
     Eigen::Index n = albatross::cast::to_index(xs.size());
     Eigen::MatrixXd ret(n, n);
+    ret.triangularView<Eigen::Lower>() = DefaultCaller::call_vector(
+        lhs_, xs, pool, internal::MirrorPolicy::SkipMirror);
     ret.triangularView<Eigen::Lower>() =
-        DefaultCaller::call_vector(lhs_, xs, pool,
-                                   internal::MirrorPolicy::SkipMirror);
-    ret.triangularView<Eigen::Lower>() =
-        (ret.array() *
-         DefaultCaller::call_vector(rhs_, xs, pool,
-                                    internal::MirrorPolicy::SkipMirror)
-             .array())
+        (ret.array() * DefaultCaller::call_vector(
+                           rhs_, xs, pool, internal::MirrorPolicy::SkipMirror)
+                           .array())
             .matrix();
     return ret;
   }

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -443,11 +443,9 @@ public:
   // available path for each child independently (single-arg if available,
   // two-arg fallback otherwise).
   //
-  // Note: each child's result is mirrored by BatchCaller, so the sum is
-  // already a full symmetric matrix.  BatchCaller then mirrors *this*
-  // result again — a redundant O(n^2/2) write that we accept for
-  // simplicity (avoiding it would require a parallel non-mirroring
-  // dispatch path through the entire caller chain).
+  // We pass SkipMirror so that BatchCaller does not mirror each child's
+  // result — we only read the lower triangle here, and our own result
+  // will be mirrored by the outer BatchCaller.
   template <
       typename X,
       typename std::enable_if<
@@ -459,9 +457,11 @@ public:
     Eigen::Index n{albatross::cast::to_index(xs.size())};
     Eigen::MatrixXd result(n, n);
     result.triangularView<Eigen::Lower>() =
-        DefaultCaller::call_vector(lhs_, xs, pool);
+        DefaultCaller::call_vector(lhs_, xs, pool,
+                                   internal::MirrorPolicy::SkipMirror);
     result.triangularView<Eigen::Lower>() +=
-        DefaultCaller::call_vector(rhs_, xs, pool);
+        DefaultCaller::call_vector(rhs_, xs, pool,
+                                   internal::MirrorPolicy::SkipMirror);
     return result;
   }
 
@@ -676,11 +676,9 @@ public:
   // available path for each child independently (single-arg if available,
   // two-arg fallback otherwise).
   //
-  // Note: each child's result is mirrored by BatchCaller, so the product
-  // is already a full symmetric matrix.  BatchCaller then mirrors *this*
-  // result again — a redundant O(n^2/2) write that we accept for
-  // simplicity (avoiding it would require a parallel non-mirroring
-  // dispatch path through the entire caller chain).
+  // We pass SkipMirror so that BatchCaller does not mirror each child's
+  // result — we only read the lower triangle here, and our own result
+  // will be mirrored by the outer BatchCaller.
   template <
       typename X,
       typename std::enable_if<
@@ -692,13 +690,15 @@ public:
     Eigen::Index n = albatross::cast::to_index(xs.size());
     Eigen::MatrixXd ret(n, n);
     ret.triangularView<Eigen::Lower>() =
-        DefaultCaller::call_vector(lhs_, xs, pool);
+        DefaultCaller::call_vector(lhs_, xs, pool,
+                                   internal::MirrorPolicy::SkipMirror);
     ret.triangularView<Eigen::Lower>() =
-        (ret.array() * DefaultCaller::call_vector(rhs_, xs, pool).array())
+        (ret.array() *
+         DefaultCaller::call_vector(rhs_, xs, pool,
+                                    internal::MirrorPolicy::SkipMirror)
+             .array())
             .matrix();
     return ret;
-    // return DefaultCaller::call_vector(lhs_, xs, pool).array() *
-    // DefaultCaller::call_vector(rhs_, xs, pool).array();
   }
 
 protected:

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -109,33 +109,24 @@ public:
     return ss.str();
   }
 
-  /*
-   * Scalar covariance evaluation.
-   *
-   * When _call_impl_vector exists, we ALWAYS use it (synthesizing scalar
-   * from batch). This ensures consistency between scalar and matrix calls.
-   * Only when batch is not available do we fall back to pointwise _call_impl.
-   */
+  // Primary: use pointwise when available
+  template <typename X, typename Y,
+            typename std::enable_if<has_valid_caller<Derived, X, Y>::value,
+                                    int>::type = 0>
+  auto operator()(const X &x, const Y &y) const {
+    return call(x, y);
+  }
 
-  // Primary: use batch when available (synthesize scalar from batch)
-  template <
-      typename X, typename Y,
-      typename std::enable_if<has_valid_call_impl_vector<Derived, X, Y>::value,
-                              int>::type = 0>
+  // Fallback: synthesize scalar from batch when no pointwise exists
+  template <typename X, typename Y,
+            typename std::enable_if<
+                (!has_valid_caller<Derived, X, Y>::value &&
+                 has_valid_call_impl_vector<Derived, X, Y>::value),
+                int>::type = 0>
   double operator()(const X &x, const Y &y) const {
     const std::vector<X> xs{x};
     const std::vector<Y> ys{y};
     return derived()._call_impl_vector(xs, ys, nullptr)(0, 0);
-  }
-
-  // Fallback: use pointwise when batch is not available
-  template <typename X, typename Y,
-            typename std::enable_if<
-                (!has_valid_call_impl_vector<Derived, X, Y>::value &&
-                 has_valid_caller<Derived, X, Y>::value),
-                int>::type = 0>
-  auto operator()(const X &x, const Y &y) const {
-    return call(x, y);
   }
 
   /*

--- a/include/albatross/src/covariance_functions/radial.hpp
+++ b/include/albatross/src/covariance_functions/radial.hpp
@@ -44,12 +44,12 @@ namespace expr {
 //  - The same caveats apply as in any other time you assign an Eigen
 //    expression to type `auto`: it's easy to accidentally follow
 //    dangling references and blow everything up
-// 
+//
 //  - You are at the mercy of Eigen's dispatch system when you use
 //    this; if your matrix is not big enough, it may be faster to do
 //    the full matrix via SIMD than to do a (non-vectorised) loop
 //    through the triangle
-// 
+//
 // Handle with care!  Benchmark twice, commit once!
 
 template <typename Derived>

--- a/include/albatross/src/covariance_functions/scaling_function.hpp
+++ b/include/albatross/src/covariance_functions/scaling_function.hpp
@@ -124,11 +124,12 @@ public:
   }
 
   // Diagonal batch: squared scaling factors
-  template <typename X,
-            typename std::enable_if<
-                has_valid_call_impl<ScalingFunction, X &>::value, int>::type = 0>
-  Eigen::VectorXd _call_impl_vector_diagonal(const std::vector<X> &xs,
-                                             ThreadPool * /*pool*/ = nullptr) const {
+  template <typename X, typename std::enable_if<
+                            has_valid_call_impl<ScalingFunction, X &>::value,
+                            int>::type = 0>
+  Eigen::VectorXd
+  _call_impl_vector_diagonal(const std::vector<X> &xs,
+                             ThreadPool * /*pool*/ = nullptr) const {
     const Eigen::VectorXd scale_x = compute_scale_vector(xs);
     return scale_x.array().square().matrix();
   }
@@ -267,9 +268,8 @@ public:
   Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
                                     ThreadPool *pool = nullptr) const {
     const Eigen::VectorXd s = this->lhs_.compute_scale_vector(xs);
-    Eigen::MatrixXd result =
-        DefaultCaller::call_vector(this->rhs_, xs, pool,
-                                   internal::MirrorPolicy::SkipMirror);
+    Eigen::MatrixXd result = DefaultCaller::call_vector(
+        this->rhs_, xs, pool, internal::MirrorPolicy::SkipMirror);
     result.array().colwise() *= s.array();
     result.array().rowwise() *= s.transpose().array();
     return result;
@@ -423,9 +423,8 @@ public:
   Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
                                     ThreadPool *pool = nullptr) const {
     const Eigen::VectorXd s = this->rhs_.compute_scale_vector(xs);
-    Eigen::MatrixXd result =
-        DefaultCaller::call_vector(this->lhs_, xs, pool,
-                                   internal::MirrorPolicy::SkipMirror);
+    Eigen::MatrixXd result = DefaultCaller::call_vector(
+        this->lhs_, xs, pool, internal::MirrorPolicy::SkipMirror);
     result.array().colwise() *= s.array();
     result.array().rowwise() *= s.transpose().array();
     return result;

--- a/include/albatross/src/covariance_functions/scaling_function.hpp
+++ b/include/albatross/src/covariance_functions/scaling_function.hpp
@@ -277,15 +277,22 @@ public:
     return this->rhs_(xs, ys, pool);
   }
 
-  // Symmetric batch: both LHS and RHS apply
+  // Symmetric batch: both LHS and RHS apply.
+  // We pass SkipMirror to avoid redundant mirroring of each child's
+  // result — cwiseProduct only reads the lower triangle (the upper
+  // triangle is garbage), and our caller will mirror the final result.
   template <typename X,
             typename std::enable_if<(has_equivalent_caller<LHS, X, X>::value &&
                                      has_equivalent_caller<RHS, X, X>::value),
                                     int>::type = 0>
   Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
                                     ThreadPool *pool = nullptr) const {
-    const Eigen::MatrixXd scale_mat = this->lhs_(xs, pool);
-    const Eigen::MatrixXd cov_mat = this->rhs_(xs, pool);
+    const Eigen::MatrixXd scale_mat =
+        DefaultCaller::call_vector(this->lhs_, xs, pool,
+                                   internal::MirrorPolicy::SkipMirror);
+    const Eigen::MatrixXd cov_mat =
+        DefaultCaller::call_vector(this->rhs_, xs, pool,
+                                   internal::MirrorPolicy::SkipMirror);
     return scale_mat.cwiseProduct(cov_mat);
   }
 
@@ -393,15 +400,22 @@ public:
     return this->lhs_(xs, ys, pool);
   }
 
-  // Symmetric batch: both LHS and RHS apply
+  // Symmetric batch: both LHS and RHS apply.
+  // We pass SkipMirror to avoid redundant mirroring of each child's
+  // result — cwiseProduct only reads the lower triangle (the upper
+  // triangle is garbage), and our caller will mirror the final result.
   template <typename X,
             typename std::enable_if<(has_equivalent_caller<LHS, X, X>::value &&
                                      has_equivalent_caller<RHS, X, X>::value),
                                     int>::type = 0>
   Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
                                     ThreadPool *pool = nullptr) const {
-    const Eigen::MatrixXd cov_mat = this->lhs_(xs, pool);
-    const Eigen::MatrixXd scale_mat = this->rhs_(xs, pool);
+    const Eigen::MatrixXd cov_mat =
+        DefaultCaller::call_vector(this->lhs_, xs, pool,
+                                   internal::MirrorPolicy::SkipMirror);
+    const Eigen::MatrixXd scale_mat =
+        DefaultCaller::call_vector(this->rhs_, xs, pool,
+                                   internal::MirrorPolicy::SkipMirror);
     return cov_mat.cwiseProduct(scale_mat);
   }
 

--- a/include/albatross/src/covariance_functions/scaling_function.hpp
+++ b/include/albatross/src/covariance_functions/scaling_function.hpp
@@ -123,60 +123,6 @@ public:
     return scales;
   }
 
-  // Both X and Y have scaling: outer product of scale vectors
-  template <typename X, typename Y,
-            typename std::enable_if<
-                (has_valid_call_impl<ScalingFunction, X &>::value &&
-                 has_valid_call_impl<ScalingFunction, Y &>::value),
-                int>::type = 0>
-  Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
-                                    const std::vector<Y> &ys,
-                                    ThreadPool * /*pool*/ = nullptr) const {
-    const Eigen::VectorXd scale_x = compute_scale_vector(xs);
-    const Eigen::VectorXd scale_y = compute_scale_vector(ys);
-    return scale_x * scale_y.transpose();
-  }
-
-  // Only X has scaling: replicate scale_x across columns
-  template <typename X, typename Y,
-            typename std::enable_if<
-                (has_valid_call_impl<ScalingFunction, X &>::value &&
-                 !has_valid_call_impl<ScalingFunction, Y &>::value),
-                int>::type = 0>
-  Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
-                                    const std::vector<Y> &ys,
-                                    ThreadPool * /*pool*/ = nullptr) const {
-    const Eigen::VectorXd scale_x = compute_scale_vector(xs);
-    const Eigen::Index m = cast::to_index(ys.size());
-    // Each row i is filled with scale_x[i]
-    return scale_x.replicate(1, m);
-  }
-
-  // Only Y has scaling: replicate scale_y across rows
-  template <typename X, typename Y,
-            typename std::enable_if<
-                (!has_valid_call_impl<ScalingFunction, X &>::value &&
-                 has_valid_call_impl<ScalingFunction, Y &>::value),
-                int>::type = 0>
-  Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
-                                    const std::vector<Y> &ys,
-                                    ThreadPool * /*pool*/ = nullptr) const {
-    const Eigen::VectorXd scale_y = compute_scale_vector(ys);
-    const Eigen::Index n = cast::to_index(xs.size());
-    // Each column j is filled with scale_y[j]
-    return scale_y.transpose().replicate(n, 1);
-  }
-
-  // Symmetric batch: outer product of scale vector with itself
-  template <typename X,
-            typename std::enable_if<
-                has_valid_call_impl<ScalingFunction, X &>::value, int>::type = 0>
-  Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
-                                    ThreadPool * /*pool*/ = nullptr) const {
-    const Eigen::VectorXd scale_x = compute_scale_vector(xs);
-    return scale_x * scale_x.transpose();
-  }
-
   // Diagonal batch: squared scaling factors
   template <typename X,
             typename std::enable_if<
@@ -250,20 +196,54 @@ public:
    * These delegate to the RHS batch method and then apply scaling element-wise.
    */
 
-  // Cross-covariance batch: both LHS and RHS apply
+  // Cross-covariance batch: both X and Y have scaling
   template <typename X, typename Y,
-            typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
-                                     has_equivalent_caller<RHS, X, Y>::value),
-                                    int>::type = 0>
+            typename std::enable_if<
+                (has_valid_call_impl<ScalingFunction, X &>::value &&
+                 has_valid_call_impl<ScalingFunction, Y &>::value &&
+                 has_equivalent_caller<RHS, X, Y>::value),
+                int>::type = 0>
   Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
                                     const std::vector<Y> &ys,
                                     ThreadPool *pool = nullptr) const {
-    // Get the scaling matrix from LHS
-    const Eigen::MatrixXd scale_mat = this->lhs_(xs, ys, pool);
-    // Get the covariance matrix from RHS
-    const Eigen::MatrixXd cov_mat = this->rhs_(xs, ys, pool);
-    // Element-wise product
-    return scale_mat.cwiseProduct(cov_mat);
+    const Eigen::VectorXd s_x = this->lhs_.compute_scale_vector(xs);
+    const Eigen::VectorXd s_y = this->lhs_.compute_scale_vector(ys);
+    Eigen::MatrixXd result = this->rhs_(xs, ys, pool);
+    result.array().colwise() *= s_x.array();
+    result.array().rowwise() *= s_y.transpose().array();
+    return result;
+  }
+
+  // Cross-covariance batch: only X has scaling
+  template <typename X, typename Y,
+            typename std::enable_if<
+                (has_valid_call_impl<ScalingFunction, X &>::value &&
+                 !has_valid_call_impl<ScalingFunction, Y &>::value &&
+                 has_equivalent_caller<RHS, X, Y>::value),
+                int>::type = 0>
+  Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
+                                    const std::vector<Y> &ys,
+                                    ThreadPool *pool = nullptr) const {
+    const Eigen::VectorXd s_x = this->lhs_.compute_scale_vector(xs);
+    Eigen::MatrixXd result = this->rhs_(xs, ys, pool);
+    result.array().colwise() *= s_x.array();
+    return result;
+  }
+
+  // Cross-covariance batch: only Y has scaling
+  template <typename X, typename Y,
+            typename std::enable_if<
+                (!has_valid_call_impl<ScalingFunction, X &>::value &&
+                 has_valid_call_impl<ScalingFunction, Y &>::value &&
+                 has_equivalent_caller<RHS, X, Y>::value),
+                int>::type = 0>
+  Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
+                                    const std::vector<Y> &ys,
+                                    ThreadPool *pool = nullptr) const {
+    const Eigen::VectorXd s_y = this->lhs_.compute_scale_vector(ys);
+    Eigen::MatrixXd result = this->rhs_(xs, ys, pool);
+    result.array().rowwise() *= s_y.transpose().array();
+    return result;
   }
 
   // Cross-covariance batch: only RHS applies (LHS doesn't apply to these types)
@@ -278,22 +258,21 @@ public:
   }
 
   // Symmetric batch: both LHS and RHS apply.
-  // We pass SkipMirror to avoid redundant mirroring of each child's
-  // result — cwiseProduct only reads the lower triangle (the upper
-  // triangle is garbage), and our caller will mirror the final result.
+  // We compute the scale vector once and apply it in-place to avoid
+  // materializing the full n-by-n scale matrix.
   template <typename X,
             typename std::enable_if<(has_equivalent_caller<LHS, X, X>::value &&
                                      has_equivalent_caller<RHS, X, X>::value),
                                     int>::type = 0>
   Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
                                     ThreadPool *pool = nullptr) const {
-    const Eigen::MatrixXd scale_mat =
-        DefaultCaller::call_vector(this->lhs_, xs, pool,
-                                   internal::MirrorPolicy::SkipMirror);
-    const Eigen::MatrixXd cov_mat =
+    const Eigen::VectorXd s = this->lhs_.compute_scale_vector(xs);
+    Eigen::MatrixXd result =
         DefaultCaller::call_vector(this->rhs_, xs, pool,
                                    internal::MirrorPolicy::SkipMirror);
-    return scale_mat.cwiseProduct(cov_mat);
+    result.array().colwise() *= s.array();
+    result.array().rowwise() *= s.transpose().array();
+    return result;
   }
 
   // Diagonal batch: both LHS and RHS apply
@@ -373,20 +352,54 @@ public:
    * These delegate to the LHS batch method and then apply scaling element-wise.
    */
 
-  // Cross-covariance batch: both LHS and RHS apply
+  // Cross-covariance batch: both X and Y have scaling
   template <typename X, typename Y,
-            typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
-                                     has_equivalent_caller<RHS, X, Y>::value),
-                                    int>::type = 0>
+            typename std::enable_if<
+                (has_valid_call_impl<ScalingFunction, X &>::value &&
+                 has_valid_call_impl<ScalingFunction, Y &>::value &&
+                 has_equivalent_caller<LHS, X, Y>::value),
+                int>::type = 0>
   Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
                                     const std::vector<Y> &ys,
                                     ThreadPool *pool = nullptr) const {
-    // Get the covariance matrix from LHS
-    const Eigen::MatrixXd cov_mat = this->lhs_(xs, ys, pool);
-    // Get the scaling matrix from RHS
-    const Eigen::MatrixXd scale_mat = this->rhs_(xs, ys, pool);
-    // Element-wise product
-    return cov_mat.cwiseProduct(scale_mat);
+    const Eigen::VectorXd s_x = this->rhs_.compute_scale_vector(xs);
+    const Eigen::VectorXd s_y = this->rhs_.compute_scale_vector(ys);
+    Eigen::MatrixXd result = this->lhs_(xs, ys, pool);
+    result.array().colwise() *= s_x.array();
+    result.array().rowwise() *= s_y.transpose().array();
+    return result;
+  }
+
+  // Cross-covariance batch: only X has scaling
+  template <typename X, typename Y,
+            typename std::enable_if<
+                (has_valid_call_impl<ScalingFunction, X &>::value &&
+                 !has_valid_call_impl<ScalingFunction, Y &>::value &&
+                 has_equivalent_caller<LHS, X, Y>::value),
+                int>::type = 0>
+  Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
+                                    const std::vector<Y> &ys,
+                                    ThreadPool *pool = nullptr) const {
+    const Eigen::VectorXd s_x = this->rhs_.compute_scale_vector(xs);
+    Eigen::MatrixXd result = this->lhs_(xs, ys, pool);
+    result.array().colwise() *= s_x.array();
+    return result;
+  }
+
+  // Cross-covariance batch: only Y has scaling
+  template <typename X, typename Y,
+            typename std::enable_if<
+                (!has_valid_call_impl<ScalingFunction, X &>::value &&
+                 has_valid_call_impl<ScalingFunction, Y &>::value &&
+                 has_equivalent_caller<LHS, X, Y>::value),
+                int>::type = 0>
+  Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
+                                    const std::vector<Y> &ys,
+                                    ThreadPool *pool = nullptr) const {
+    const Eigen::VectorXd s_y = this->rhs_.compute_scale_vector(ys);
+    Eigen::MatrixXd result = this->lhs_(xs, ys, pool);
+    result.array().rowwise() *= s_y.transpose().array();
+    return result;
   }
 
   // Cross-covariance batch: only LHS applies (RHS doesn't apply to these types)
@@ -401,22 +414,21 @@ public:
   }
 
   // Symmetric batch: both LHS and RHS apply.
-  // We pass SkipMirror to avoid redundant mirroring of each child's
-  // result — cwiseProduct only reads the lower triangle (the upper
-  // triangle is garbage), and our caller will mirror the final result.
+  // We compute the scale vector once and apply it in-place to avoid
+  // materializing the full n-by-n scale matrix.
   template <typename X,
             typename std::enable_if<(has_equivalent_caller<LHS, X, X>::value &&
                                      has_equivalent_caller<RHS, X, X>::value),
                                     int>::type = 0>
   Eigen::MatrixXd _call_impl_vector(const std::vector<X> &xs,
                                     ThreadPool *pool = nullptr) const {
-    const Eigen::MatrixXd cov_mat =
+    const Eigen::VectorXd s = this->rhs_.compute_scale_vector(xs);
+    Eigen::MatrixXd result =
         DefaultCaller::call_vector(this->lhs_, xs, pool,
                                    internal::MirrorPolicy::SkipMirror);
-    const Eigen::MatrixXd scale_mat =
-        DefaultCaller::call_vector(this->rhs_, xs, pool,
-                                   internal::MirrorPolicy::SkipMirror);
-    return cov_mat.cwiseProduct(scale_mat);
+    result.array().colwise() *= s.array();
+    result.array().rowwise() *= s.transpose().array();
+    return result;
   }
 
   // Diagonal batch: both LHS and RHS apply

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -22,6 +22,10 @@ template <typename U> class has_any_call_impl : public has_any__call_impl<U> {};
 
 DEFINE_CLASS_METHOD_TRAITS(_call_impl);
 
+// Batch covariance method traits
+DEFINE_CLASS_METHOD_TRAITS(_call_impl_vector);
+DEFINE_CLASS_METHOD_TRAITS(_call_impl_vector_diagonal);
+
 template <typename U, typename... Args>
 class has_valid_call_impl
     : public has__call_impl_with_return_type<
@@ -31,16 +35,127 @@ template <typename U, typename... Args>
 class has_possible_call_impl : public has__call_impl<U, Args &...> {};
 
 /*
+ * Batch covariance traits - detect _call_impl_vector methods
+ */
+
+// Detect _call_impl_vector for cross-covariance (different types)
+template <typename U, typename X, typename Y>
+class has_valid_call_impl_vector
+    : public has__call_impl_vector_with_return_type<
+          const U, Eigen::MatrixXd, typename const_ref<std::vector<X>>::type,
+          typename const_ref<std::vector<Y>>::type, ThreadPool *> {};
+
+// Detect _call_impl_vector for symmetric case (same type, two vector args)
+template <typename U, typename X>
+class has_valid_call_impl_vector_symmetric
+    : public has__call_impl_vector_with_return_type<
+          const U, Eigen::MatrixXd, typename const_ref<std::vector<X>>::type,
+          typename const_ref<std::vector<X>>::type, ThreadPool *> {};
+
+// Detect _call_impl_vector for optimized symmetric case (single vector arg)
+// Signature: Eigen::MatrixXd _call_impl_vector(const std::vector<X>&, ThreadPool*) const
+template <typename U, typename X>
+class has_valid_call_impl_vector_single_arg
+    : public has__call_impl_vector_with_return_type<
+          const U, Eigen::MatrixXd, typename const_ref<std::vector<X>>::type,
+          ThreadPool *> {};
+
+// Detect _call_impl_vector_diagonal for diagonal extraction
+template <typename U, typename X>
+class has_valid_call_impl_vector_diagonal
+    : public has__call_impl_vector_diagonal_with_return_type<
+          const U, Eigen::VectorXd, typename const_ref<std::vector<X>>::type,
+          ThreadPool *> {};
+
+/*
+ * Measurement inner type extraction - extracts X from Measurement<X>
+ * For non-Measurement types, returns the type itself.
+ */
+template <typename T, typename = void> struct measurement_inner {
+  using type = T;
+};
+
+template <typename X>
+struct measurement_inner<Measurement<X>, void> {
+  using type = X;
+};
+
+template <typename T>
+using measurement_inner_t = typename measurement_inner<T>::type;
+
+/*
+ * has_valid_batch_or_measurement_batch
+ *
+ * Checks if a covariance function has batch support for types X, Y, either:
+ * 1. Directly via _call_impl_vector(vector<X>, vector<Y>, pool), OR
+ * 2. Via Measurement unwrapping: if X=Measurement<X'> and/or Y=Measurement<Y'>,
+ *    check for _call_impl_vector(vector<X'>, vector<Y'>, pool)
+ *
+ * This trait is used by Sum/Product compositions to enable batch methods
+ * when the underlying covariance has batch support for unwrapped types.
+ */
+template <typename CovFunc, typename X, typename Y>
+class has_valid_batch_or_measurement_batch {
+  // Get the inner types (same type if not a Measurement)
+  using InnerX = measurement_inner_t<X>;
+  using InnerY = measurement_inner_t<Y>;
+
+public:
+  static constexpr bool value =
+      // Direct batch support for X, Y
+      has_valid_call_impl_vector<CovFunc, X, Y>::value ||
+      // Batch support for unwrapped types (only relevant if X or Y is a
+      // Measurement) Note: if neither is a Measurement, InnerX=X and InnerY=Y,
+      // so this duplicates the first check, which is fine.
+      ((!std::is_same<X, InnerX>::value || !std::is_same<Y, InnerY>::value) &&
+       has_valid_call_impl_vector<CovFunc, InnerX, InnerY>::value);
+};
+
+/*
+ * has_valid_batch_or_measurement_batch_single_arg
+ *
+ * Checks if a covariance function has single-arg symmetric batch support for type X, either:
+ * 1. Directly via _call_impl_vector(vector<X>, pool), OR
+ * 2. Via Measurement unwrapping: if X=Measurement<X'>,
+ *    check for _call_impl_vector(vector<X'>, pool)
+ *
+ * This trait is used by Sum/Product compositions to enable single-arg batch methods
+ * when the underlying covariance has single-arg batch support for unwrapped types.
+ */
+template <typename CovFunc, typename X>
+class has_valid_batch_or_measurement_batch_single_arg {
+  // Get the inner type (same type if not a Measurement)
+  using InnerX = measurement_inner_t<X>;
+
+public:
+  static constexpr bool value =
+      // Direct single-arg batch support for X
+      has_valid_call_impl_vector_single_arg<CovFunc, X>::value ||
+      // Single-arg batch support for unwrapped type (only relevant if X is a Measurement)
+      (!std::is_same<X, InnerX>::value &&
+       has_valid_call_impl_vector_single_arg<CovFunc, InnerX>::value);
+};
+
+/*
  * has_valid_cov_caller
  */
 
 DEFINE_CLASS_METHOD_TRAITS(call);
+DEFINE_CLASS_METHOD_TRAITS(call_vector);
 
 template <typename CovFunc, typename Caller, typename... Args>
 class has_valid_cov_caller
     : public has_call_with_return_type<Caller, double,
                                        typename const_ref<CovFunc>::type,
                                        typename const_ref<Args>::type...> {};
+
+// Detect if caller supports batch operations (call_vector)
+template <typename CovFunc, typename Caller, typename X, typename Y>
+class has_valid_cov_caller_vector
+    : public has_call_vector_with_return_type<
+          Caller, Eigen::MatrixXd, typename const_ref<CovFunc>::type,
+          typename const_ref<std::vector<X>>::type,
+          typename const_ref<std::vector<Y>>::type, ThreadPool *> {};
 
 /*
  * has_valid_cross_cov_caller
@@ -199,6 +314,65 @@ struct has_valid_variant_cov_caller<U, Caller, variant<Ts...>, variant<Ts...>> {
 };
 
 /*
+ * Batch variant traits - checks if a caller has valid batch (call_vector)
+ * support for any of the types in a variant.
+ *
+ * These mirror the pointwise variant traits above, but check for call_vector
+ * instead of call.
+ */
+template <typename U, typename Caller, typename A, typename B, typename = void>
+struct has_valid_variant_cov_caller_vector : public std::false_type {};
+
+// Base case: single element variant (right side)
+template <typename U, typename Caller, typename A, typename B>
+struct has_valid_variant_cov_caller_vector<
+    U, Caller, A, variant<B>, std::enable_if_t<!is_variant<A>::value>> {
+  static constexpr bool value =
+      has_valid_cov_caller_vector<U, Caller, A, B>::value;
+};
+
+// Recursive case: check first element, then rest (right side)
+template <typename U, typename Caller, typename A, typename B, typename... Ts>
+struct has_valid_variant_cov_caller_vector<
+    U, Caller, A, variant<B, Ts...>, std::enable_if_t<!is_variant<A>::value>> {
+  static constexpr bool value =
+      has_valid_cov_caller_vector<U, Caller, A, B>::value ||
+      has_valid_variant_cov_caller_vector<U, Caller, A, variant<Ts...>>::value;
+};
+
+// Base case: single element variant (left side)
+template <typename U, typename Caller, typename A, typename B>
+struct has_valid_variant_cov_caller_vector<
+    U, Caller, variant<A>, B, std::enable_if_t<!is_variant<B>::value>> {
+  static constexpr bool value =
+      has_valid_cov_caller_vector<U, Caller, A, B>::value;
+};
+
+// Recursive case: check first element, then rest (left side)
+template <typename U, typename Caller, typename A, typename B, typename... Ts>
+struct has_valid_variant_cov_caller_vector<
+    U, Caller, variant<A, Ts...>, B, std::enable_if_t<!is_variant<B>::value>> {
+  static constexpr bool value =
+      has_valid_cov_caller_vector<U, Caller, A, B>::value ||
+      has_valid_variant_cov_caller_vector<U, Caller, variant<Ts...>, B>::value;
+};
+
+// Both sides are variants - check if any valid pair exists
+// This is used when both arguments are variant vectors
+template <typename U, typename Caller, typename XVariant, typename YVariant>
+struct has_valid_variant_cov_caller_vector_both : public std::false_type {};
+
+template <typename U, typename Caller, typename... Xs, typename... Ys>
+struct has_valid_variant_cov_caller_vector_both<U, Caller, variant<Xs...>,
+                                                variant<Ys...>> {
+  // Use same logic as single-sided: any valid pair is sufficient
+  // because we assert homogeneity at runtime
+  static constexpr bool value =
+      has_valid_variant_cov_caller_vector<U, Caller, variant<Xs...>,
+                                          variant<Ys...>>::value;
+};
+
+/*
  * Checks if a type has a valid mean call for any of the types in a variant.
  */
 template <typename U, typename Caller, typename A, typename = void>
@@ -231,6 +405,18 @@ struct has_valid_variant_mean_caller<U, Caller, variant<A, Ts...>,
  * be able to distinguish between a basic type and a composite type.
  */
 template <typename X> struct is_basic_type : std::true_type {};
+
+/*
+ * measurement_inner_type - extract the inner type from Measurement<X>
+ */
+template <typename T> struct measurement_inner_type;
+
+template <typename X> struct measurement_inner_type<Measurement<X>> {
+  using type = X;
+};
+
+template <typename T>
+using measurement_inner_type_t = typename measurement_inner_type<T>::type;
 
 template <typename X>
 struct is_basic_type<LinearCombination<X>> : std::false_type {};

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -53,7 +53,8 @@ class has_valid_call_impl_vector_symmetric
           typename const_ref<std::vector<X>>::type, ThreadPool *> {};
 
 // Detect _call_impl_vector for optimized symmetric case (single vector arg)
-// Signature: Eigen::MatrixXd _call_impl_vector(const std::vector<X>&, ThreadPool*) const
+// Signature: Eigen::MatrixXd _call_impl_vector(const std::vector<X>&,
+// ThreadPool*) const
 template <typename U, typename X>
 class has_valid_call_impl_vector_single_arg
     : public has__call_impl_vector_with_return_type<
@@ -75,8 +76,7 @@ template <typename T, typename = void> struct measurement_inner {
   using type = T;
 };
 
-template <typename X>
-struct measurement_inner<Measurement<X>, void> {
+template <typename X> struct measurement_inner<Measurement<X>, void> {
   using type = X;
 };
 
@@ -114,13 +114,15 @@ public:
 /*
  * has_valid_batch_or_measurement_batch_single_arg
  *
- * Checks if a covariance function has single-arg symmetric batch support for type X, either:
+ * Checks if a covariance function has single-arg symmetric batch support for
+ * type X, either:
  * 1. Directly via _call_impl_vector(vector<X>, pool), OR
  * 2. Via Measurement unwrapping: if X=Measurement<X'>,
  *    check for _call_impl_vector(vector<X'>, pool)
  *
- * This trait is used by Sum/Product compositions to enable single-arg batch methods
- * when the underlying covariance has single-arg batch support for unwrapped types.
+ * This trait is used by Sum/Product compositions to enable single-arg batch
+ * methods when the underlying covariance has single-arg batch support for
+ * unwrapped types.
  */
 template <typename CovFunc, typename X>
 class has_valid_batch_or_measurement_batch_single_arg {
@@ -131,7 +133,8 @@ public:
   static constexpr bool value =
       // Direct single-arg batch support for X
       has_valid_call_impl_vector_single_arg<CovFunc, X>::value ||
-      // Single-arg batch support for unwrapped type (only relevant if X is a Measurement)
+      // Single-arg batch support for unwrapped type (only relevant if X is a
+      // Measurement)
       (!std::is_same<X, InnerX>::value &&
        has_valid_call_impl_vector_single_arg<CovFunc, InnerX>::value);
 };

--- a/include/albatross/src/details/traits.hpp
+++ b/include/albatross/src/details/traits.hpp
@@ -217,6 +217,14 @@ template <typename T>
 struct is_measurement : public is_templated_type<Measurement, T> {};
 
 /*
+ * is_linear_combination
+ */
+
+template <typename T>
+struct is_linear_combination : public is_templated_type<LinearCombination, T> {
+};
+
+/*
  * is_streamable
  */
 

--- a/include/albatross/src/utils/async_utils.hpp
+++ b/include/albatross/src/utils/async_utils.hpp
@@ -220,6 +220,14 @@ make_shared_thread_pool(std::size_t num_threads = 0,
   return std::make_shared<ThreadPool>(num_threads, init, stack_size);
 }
 
+inline std::size_t get_thread_count(const ThreadPool *pool) {
+  if (nullptr == pool) {
+    return 1;
+  }
+
+  return pool->thread_count();
+}
+
 inline std::size_t get_thread_count(const std::shared_ptr<ThreadPool> &pool) {
   if (nullptr == pool) {
     return 1;

--- a/tests/test_batch_covariance.cc
+++ b/tests/test_batch_covariance.cc
@@ -1,0 +1,4092 @@
+/*
+ * Copyright (C) 2024 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/CovarianceFunctions>
+
+#include <gtest/gtest.h>
+
+namespace albatross {
+
+/*
+ * Test covariance function that implements batch computation.
+ * Returns a constant matrix to verify batch method is actually called.
+ */
+class BatchTestCovariance : public CovarianceFunction<BatchTestCovariance> {
+public:
+  BatchTestCovariance(double value = 42.0) : value_(value) {}
+
+  std::string name() const { return "batch_test"; }
+
+  // Pointwise implementation (should NOT be called if batch works)
+  double _call_impl(const double &x, const double &y) const {
+    // Return a different value so we can detect if pointwise was used
+    return -999.0;
+  }
+
+  // Batch implementation
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *pool) const {
+    const Eigen::Index m = cast::to_index(xs.size());
+    const Eigen::Index n = cast::to_index(ys.size());
+    return Eigen::MatrixXd::Constant(m, n, value_);
+  }
+
+private:
+  double value_;
+};
+
+/*
+ * Test that batch method is actually called when defined
+ */
+TEST(test_batch_covariance, test_batch_method_is_called) {
+  BatchTestCovariance cov(42.0);
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  std::vector<double> ys = {4.0, 5.0};
+
+  Eigen::MatrixXd result = cov(xs, ys);
+
+  // If batch was called, all values should be 42.0
+  // If pointwise was called, values would be -999.0
+  EXPECT_EQ(result.rows(), 3);
+  EXPECT_EQ(result.cols(), 2);
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_EQ(result(i, j), 42.0) << "Batch method was not called!";
+    }
+  }
+}
+
+/*
+ * Test covariance that implements both pointwise and batch for equivalence
+ * testing
+ */
+class EquivalenceTestCovariance
+    : public CovarianceFunction<EquivalenceTestCovariance> {
+public:
+  EquivalenceTestCovariance() = default;
+
+  std::string name() const { return "equivalence_test"; }
+
+  // Pointwise: simple squared distance
+  double _call_impl(const double &x, const double &y) const {
+    const double d = x - y;
+    return std::exp(-d * d);
+  }
+
+  // Batch: should give same result as pointwise
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *pool) const {
+    const Eigen::Index m = cast::to_index(xs.size());
+    const Eigen::Index n = cast::to_index(ys.size());
+    Eigen::MatrixXd result(m, n);
+
+    for (Eigen::Index i = 0; i < m; ++i) {
+      for (Eigen::Index j = 0; j < n; ++j) {
+        const double d = xs[cast::to_size(i)] - ys[cast::to_size(j)];
+        result(i, j) = std::exp(-d * d);
+      }
+    }
+
+    return result;
+  }
+};
+
+/*
+ * Test that batch and pointwise give equivalent results
+ */
+TEST(test_batch_covariance, test_batch_pointwise_equivalence) {
+  EquivalenceTestCovariance cov;
+
+  std::vector<double> xs = {1.0, 2.0, 3.0, 4.0};
+  std::vector<double> ys = {2.5, 3.5, 4.5};
+
+  // Get batch result
+  Eigen::MatrixXd batch_result = cov(xs, ys);
+
+  // Compute pointwise result manually
+  Eigen::MatrixXd pointwise_result(xs.size(), ys.size());
+  for (size_t i = 0; i < xs.size(); ++i) {
+    for (size_t j = 0; j < ys.size(); ++j) {
+      pointwise_result(i, j) = cov(xs[i], ys[j]);
+    }
+  }
+
+  // Check equivalence
+  EXPECT_EQ(batch_result.rows(), pointwise_result.rows());
+  EXPECT_EQ(batch_result.cols(), pointwise_result.cols());
+
+  for (Eigen::Index i = 0; i < batch_result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < batch_result.cols(); ++j) {
+      EXPECT_NEAR(batch_result(i, j), pointwise_result(i, j), 1e-10)
+          << "Mismatch at (" << i << ", " << j << ")";
+    }
+  }
+}
+
+/*
+ * Test that covariances without batch implementation still work
+ */
+TEST(test_batch_covariance, test_fallback_to_pointwise) {
+  // Use a simple covariance without batch implementation
+  class PointwiseOnlyCovariance
+      : public CovarianceFunction<PointwiseOnlyCovariance> {
+  public:
+    std::string name() const { return "pointwise_only"; }
+
+    double _call_impl(const double &x, const double &y) const { return x * y; }
+  };
+
+  PointwiseOnlyCovariance cov;
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  std::vector<double> ys = {4.0, 5.0};
+
+  Eigen::MatrixXd result = cov(xs, ys);
+
+  // Check that fallback to pointwise worked correctly
+  EXPECT_EQ(result.rows(), 3);
+  EXPECT_EQ(result.cols(), 2);
+  EXPECT_DOUBLE_EQ(result(0, 0), 1.0 * 4.0);
+  EXPECT_DOUBLE_EQ(result(0, 1), 1.0 * 5.0);
+  EXPECT_DOUBLE_EQ(result(1, 0), 2.0 * 4.0);
+  EXPECT_DOUBLE_EQ(result(1, 1), 2.0 * 5.0);
+  EXPECT_DOUBLE_EQ(result(2, 0), 3.0 * 4.0);
+  EXPECT_DOUBLE_EQ(result(2, 1), 3.0 * 5.0);
+}
+
+/*
+ * Test that batch-only covariances work (no _call_impl defined)
+ */
+TEST(test_batch_covariance, test_batch_only_covariance) {
+  // Covariance that defines ONLY batch, no pointwise
+  class BatchOnlyCovariance : public CovarianceFunction<BatchOnlyCovariance> {
+  public:
+    std::string name() const { return "batch_only"; }
+
+    // NO _call_impl defined!
+
+    // Only batch implementation
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 777.0);
+    }
+  };
+
+  BatchOnlyCovariance cov;
+
+  std::vector<double> xs = {1.0, 2.0};
+  std::vector<double> ys = {3.0, 4.0, 5.0};
+
+  Eigen::MatrixXd result = cov(xs, ys);
+
+  EXPECT_EQ(result.rows(), 2);
+  EXPECT_EQ(result.cols(), 3);
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_EQ(result(i, j), 777.0) << "Batch-only covariance should work";
+    }
+  }
+
+  // NOTE: Batch-only covariances with Measurements require the operator()
+  // to be enabled for Measurement types. This requires more sophisticated
+  // trait checking that accounts for unwrapping. For Phase 1, batch-only
+  // covariances work for simple (non-wrapper) types.
+}
+
+/*
+ * Test variant batch support
+ * Variants unwrap to their underlying type, which then uses batch if available.
+ * Since batch is preferred over pointwise, variants should use the batch
+ * method.
+ */
+TEST(test_batch_covariance, test_variant_uses_batch) {
+  BatchTestCovariance cov(42.0);
+
+  using DoubleVariant = variant<double>;
+
+  std::vector<DoubleVariant> xs;
+  xs.push_back(DoubleVariant(1.0));
+  xs.push_back(DoubleVariant(2.0));
+  xs.push_back(DoubleVariant(3.0));
+
+  std::vector<DoubleVariant> ys;
+  ys.push_back(DoubleVariant(4.0));
+  ys.push_back(DoubleVariant(5.0));
+
+  // Variants unwrap and use batch (batch is preferred over pointwise)
+  Eigen::MatrixXd result = cov(xs, ys);
+
+  EXPECT_EQ(result.rows(), 3);
+  EXPECT_EQ(result.cols(), 2);
+
+  // Batch returns 42.0 for all elements
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_EQ(result(i, j), 42.0) << "Variant should use batch method";
+    }
+  }
+}
+
+/*
+ * Test that Measurements are properly handled in batch operations
+ * Measurements unwrap to their underlying type, which then uses batch if
+ * available. Since batch is preferred over pointwise, measurements should use
+ * the batch method.
+ */
+TEST(test_batch_covariance, test_measurement_with_batch_covariance) {
+  BatchTestCovariance cov(100.0);
+
+  std::vector<double> xs_raw = {1.0, 2.0};
+  std::vector<double> ys_raw = {3.0, 4.0};
+
+  // Test with raw types first - should use batch
+  Eigen::MatrixXd raw_result = cov(xs_raw, ys_raw);
+
+  // All should be 100.0 from batch
+  for (Eigen::Index i = 0; i < raw_result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < raw_result.cols(); ++j) {
+      EXPECT_EQ(raw_result(i, j), 100.0) << "Raw should use batch";
+    }
+  }
+
+  // Test with Measurements - unwraps and uses batch (batch is preferred)
+  std::vector<Measurement<double>> xs;
+  xs.push_back(Measurement<double>{1.0});
+  xs.push_back(Measurement<double>{2.0});
+
+  std::vector<Measurement<double>> ys;
+  ys.push_back(Measurement<double>{3.0});
+  ys.push_back(Measurement<double>{4.0});
+
+  Eigen::MatrixXd result = cov(xs, ys);
+
+  // Measurements unwrap and use batch (batch is preferred over pointwise)
+  EXPECT_EQ(result.rows(), 2);
+  EXPECT_EQ(result.cols(), 2);
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_EQ(result(i, j), 100.0)
+          << "Measurement uses batch at (" << i << "," << j << ")";
+    }
+  }
+}
+
+/*
+ * Test homogeneous variant vector assertion
+ */
+TEST(test_batch_covariance, test_assert_homogeneous_variant_vector) {
+  using TestVariant = variant<double, int>;
+
+  // Homogeneous vector - should not assert
+  std::vector<TestVariant> homogeneous = {TestVariant(1.0), TestVariant(2.0),
+                                          TestVariant(3.0)};
+  EXPECT_NO_THROW(assert_homogeneous_variant_vector(homogeneous));
+
+  // Empty vector - should not assert
+  std::vector<TestVariant> empty;
+  EXPECT_NO_THROW(assert_homogeneous_variant_vector(empty));
+
+  // Heterogeneous vector - should assert
+  std::vector<TestVariant> heterogeneous = {TestVariant(1.0), TestVariant(2),
+                                            TestVariant(3.0)};
+  EXPECT_DEATH(assert_homogeneous_variant_vector(heterogeneous),
+               "All variants in a batch operation must hold the same type");
+}
+
+/*
+ * Test Sum with both batch
+ */
+TEST(test_batch_covariance, test_sum_both_batch) {
+  BatchTestCovariance batch1(10.0);
+  BatchTestCovariance batch2(5.0);
+  auto sum = batch1 + batch2;
+
+  std::vector<double> xs = {1.0, 2.0};
+  std::vector<double> ys = {3.0, 4.0};
+
+  Eigen::MatrixXd result = sum(xs, ys);
+
+  // Should be 10 + 5 = 15 for all elements
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_EQ(result(i, j), 15.0);
+    }
+  }
+}
+
+/*
+ * Test Sum with mixed batch/pointwise
+ */
+TEST(test_batch_covariance, test_sum_mixed_batch_pointwise) {
+  BatchTestCovariance batch(10.0);
+
+  class PointwiseOnly : public CovarianceFunction<PointwiseOnly> {
+  public:
+    std::string name() const { return "pointwise"; }
+    double _call_impl(const double &x, const double &y) const { return x + y; }
+  };
+
+  PointwiseOnly pointwise;
+  auto sum = batch + pointwise;
+
+  std::vector<double> xs = {1.0, 2.0};
+  std::vector<double> ys = {3.0, 4.0};
+
+  Eigen::MatrixXd result = sum(xs, ys);
+
+  // batch returns 10.0, pointwise returns x+y
+  EXPECT_EQ(result(0, 0), 10.0 + (1.0 + 3.0)); // 14.0
+  EXPECT_EQ(result(0, 1), 10.0 + (1.0 + 4.0)); // 15.0
+  EXPECT_EQ(result(1, 0), 10.0 + (2.0 + 3.0)); // 15.0
+  EXPECT_EQ(result(1, 1), 10.0 + (2.0 + 4.0)); // 16.0
+}
+
+/*
+ * Test Product with both batch
+ */
+TEST(test_batch_covariance, test_product_both_batch) {
+  BatchTestCovariance batch1(3.0);
+  BatchTestCovariance batch2(4.0);
+  auto product = batch1 * batch2;
+
+  std::vector<double> xs = {1.0, 2.0};
+  std::vector<double> ys = {3.0, 4.0};
+
+  Eigen::MatrixXd result = product(xs, ys);
+
+  // Should be 3 * 4 = 12 for all elements
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_EQ(result(i, j), 12.0);
+    }
+  }
+}
+
+/*
+ * Test Product with mixed batch/pointwise
+ */
+TEST(test_batch_covariance, test_product_mixed_batch_pointwise) {
+  BatchTestCovariance batch(2.0);
+
+  class PointwiseOnly : public CovarianceFunction<PointwiseOnly> {
+  public:
+    std::string name() const { return "pointwise"; }
+    double _call_impl(const double &x, const double &y) const { return x * y; }
+  };
+
+  PointwiseOnly pointwise;
+  auto product = batch * pointwise;
+
+  std::vector<double> xs = {1.0, 2.0};
+  std::vector<double> ys = {3.0, 4.0};
+
+  Eigen::MatrixXd result = product(xs, ys);
+
+  // batch returns 2.0, pointwise returns x*y
+  EXPECT_EQ(result(0, 0), 2.0 * (1.0 * 3.0)); // 6.0
+  EXPECT_EQ(result(0, 1), 2.0 * (1.0 * 4.0)); // 8.0
+  EXPECT_EQ(result(1, 0), 2.0 * (2.0 * 3.0)); // 12.0
+  EXPECT_EQ(result(1, 1), 2.0 * (2.0 * 4.0)); // 16.0
+}
+
+/*
+ * Test that dispatch produces valid (finite) results
+ */
+TEST(test_batch_covariance, test_no_inf_or_nan) {
+  EquivalenceTestCovariance cov;
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  std::vector<double> ys = {1.5, 2.5};
+
+  Eigen::MatrixXd result = cov(xs, ys);
+
+  // Check no inf or nan values
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_TRUE(std::isfinite(result(i, j)))
+          << "Result at (" << i << "," << j
+          << ") is not finite: " << result(i, j);
+    }
+  }
+}
+
+/*
+ * Test with real covariance functions (SquaredExponential)
+ */
+TEST(test_batch_covariance, test_real_covariance_function) {
+  SquaredExponential<EuclideanDistance> cov(100.0, 1.0);
+
+  std::vector<double> xs = {0.0, 1.0, 2.0};
+  std::vector<double> ys = {0.5, 1.5};
+
+  Eigen::MatrixXd result = cov(xs, ys);
+
+  // Check basic properties
+  EXPECT_EQ(result.rows(), 3);
+  EXPECT_EQ(result.cols(), 2);
+
+  // Check no inf or nan
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_TRUE(std::isfinite(result(i, j)))
+          << "Result at (" << i << "," << j << ") is not finite";
+    }
+  }
+
+  // Check positive values (covariance should be positive)
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_GT(result(i, j), 0.0) << "Covariance should be positive";
+    }
+  }
+}
+
+/*
+ * PHASE 2: Symmetric Batch Covariance Tests
+ */
+
+/*
+ * Test that symmetric batch method is called
+ */
+TEST(test_batch_covariance, test_symmetric_batch_called) {
+  // Covariance with ONLY symmetric batch (no cross-covariance batch)
+  class SymmetricBatchCovariance
+      : public CovarianceFunction<SymmetricBatchCovariance> {
+  public:
+    std::string name() const { return "symmetric_batch"; }
+
+    double _call_impl(const double &x, const double &y) const {
+      return -111.0; // Different value to detect if pointwise was used
+    }
+
+    // Symmetric batch implementation
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      // Return constant to verify batch is called
+      const Eigen::Index m = cast::to_index(xs.size());
+      const Eigen::Index n = cast::to_index(ys.size());
+      return Eigen::MatrixXd::Constant(m, n, 888.0);
+    }
+  };
+
+  SymmetricBatchCovariance cov;
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+
+  Eigen::MatrixXd result = cov(xs); // Symmetric call
+
+  EXPECT_EQ(result.rows(), 3);
+  EXPECT_EQ(result.cols(), 3);
+
+  // Should get 888.0 from batch, not -111.0 from pointwise
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_EQ(result(i, j), 888.0) << "Symmetric batch should be used";
+    }
+  }
+}
+
+/*
+ * Test symmetric batch-only covariance
+ */
+TEST(test_batch_covariance, test_symmetric_batch_only) {
+  // Covariance with ONLY batch, no pointwise
+  class SymmetricBatchOnlyCovariance
+      : public CovarianceFunction<SymmetricBatchOnlyCovariance> {
+  public:
+    std::string name() const { return "symmetric_batch_only"; }
+
+    // NO _call_impl defined!
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      const Eigen::Index m = cast::to_index(xs.size());
+      const Eigen::Index n = cast::to_index(ys.size());
+      return Eigen::MatrixXd::Constant(m, n, 999.0);
+    }
+  };
+
+  SymmetricBatchOnlyCovariance cov;
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+
+  Eigen::MatrixXd result = cov(xs);
+
+  EXPECT_EQ(result.rows(), 3);
+  EXPECT_EQ(result.cols(), 3);
+
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_EQ(result(i, j), 999.0) << "Batch-only symmetric works";
+    }
+  }
+}
+
+/*
+ * Test symmetric with Sum composite
+ */
+TEST(test_batch_covariance, test_symmetric_sum_both_batch) {
+  BatchTestCovariance batch1(10.0);
+  BatchTestCovariance batch2(5.0);
+  auto sum = batch1 + batch2;
+
+  std::vector<double> xs = {1.0, 2.0};
+
+  Eigen::MatrixXd result = sum(xs); // Symmetric
+
+  // Should be 10 + 5 = 15 for all elements
+  EXPECT_EQ(result.rows(), 2);
+  EXPECT_EQ(result.cols(), 2);
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_EQ(result(i, j), 15.0);
+    }
+  }
+}
+
+/*
+ * PHASE 3: Diagonal Batch Covariance Tests
+ */
+
+/*
+ * Test diagonal batch method is called
+ */
+TEST(test_batch_covariance, test_diagonal_batch_called) {
+  class DiagonalBatchCovariance
+      : public CovarianceFunction<DiagonalBatchCovariance> {
+  public:
+    std::string name() const { return "diagonal_batch"; }
+
+    double _call_impl(const double &x, const double &y) const {
+      return -222.0; // Different value to detect if pointwise was used
+    }
+
+    // Diagonal batch implementation
+    Eigen::VectorXd _call_impl_vector_diagonal(const std::vector<double> &xs,
+                                               ThreadPool *pool) const {
+      return Eigen::VectorXd::Constant(xs.size(), 555.0);
+    }
+  };
+
+  DiagonalBatchCovariance cov;
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+
+  Eigen::VectorXd result = cov.diagonal(xs);
+
+  EXPECT_EQ(result.size(), 3);
+  for (Eigen::Index i = 0; i < result.size(); ++i) {
+    EXPECT_EQ(result[i], 555.0) << "Diagonal batch should be used";
+  }
+}
+
+/*
+ * Test diagonal batch-only covariance
+ */
+TEST(test_batch_covariance, test_diagonal_batch_only) {
+  class DiagonalBatchOnlyCovariance
+      : public CovarianceFunction<DiagonalBatchOnlyCovariance> {
+  public:
+    std::string name() const { return "diagonal_batch_only"; }
+
+    // NO _call_impl defined!
+
+    Eigen::VectorXd _call_impl_vector_diagonal(const std::vector<double> &xs,
+                                               ThreadPool *pool) const {
+      return Eigen::VectorXd::Constant(xs.size(), 666.0);
+    }
+  };
+
+  DiagonalBatchOnlyCovariance cov;
+  std::vector<double> xs = {1.0, 2.0, 3.0, 4.0};
+
+  Eigen::VectorXd result = cov.diagonal(xs);
+
+  EXPECT_EQ(result.size(), 4);
+  for (Eigen::Index i = 0; i < result.size(); ++i) {
+    EXPECT_EQ(result[i], 666.0) << "Diagonal batch-only works";
+  }
+}
+
+/*
+ * Test diagonal with Sum composite
+ */
+TEST(test_batch_covariance, test_diagonal_sum_both_batch) {
+  class DiagBatch1 : public CovarianceFunction<DiagBatch1> {
+  public:
+    std::string name() const { return "diag1"; }
+    double _call_impl(const double &x, const double &y) const { return 0.0; }
+    Eigen::VectorXd _call_impl_vector_diagonal(const std::vector<double> &xs,
+                                               ThreadPool *pool) const {
+      return Eigen::VectorXd::Constant(xs.size(), 10.0);
+    }
+  };
+
+  class DiagBatch2 : public CovarianceFunction<DiagBatch2> {
+  public:
+    std::string name() const { return "diag2"; }
+    double _call_impl(const double &x, const double &y) const { return 0.0; }
+    Eigen::VectorXd _call_impl_vector_diagonal(const std::vector<double> &xs,
+                                               ThreadPool *pool) const {
+      return Eigen::VectorXd::Constant(xs.size(), 7.0);
+    }
+  };
+
+  DiagBatch1 cov1;
+  DiagBatch2 cov2;
+  auto sum = cov1 + cov2;
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  Eigen::VectorXd result = sum.diagonal(xs);
+
+  EXPECT_EQ(result.size(), 3);
+  for (Eigen::Index i = 0; i < result.size(); ++i) {
+    EXPECT_EQ(result[i], 17.0) << "Sum diagonal: 10 + 7 = 17";
+  }
+}
+
+/*
+ * Test diagonal with Product composite
+ */
+TEST(test_batch_covariance, test_diagonal_product_both_batch) {
+  class DiagBatch1 : public CovarianceFunction<DiagBatch1> {
+  public:
+    std::string name() const { return "diag1"; }
+    double _call_impl(const double &x, const double &y) const { return 0.0; }
+    Eigen::VectorXd _call_impl_vector_diagonal(const std::vector<double> &xs,
+                                               ThreadPool *pool) const {
+      return Eigen::VectorXd::Constant(xs.size(), 5.0);
+    }
+  };
+
+  class DiagBatch2 : public CovarianceFunction<DiagBatch2> {
+  public:
+    std::string name() const { return "diag2"; }
+    double _call_impl(const double &x, const double &y) const { return 0.0; }
+    Eigen::VectorXd _call_impl_vector_diagonal(const std::vector<double> &xs,
+                                               ThreadPool *pool) const {
+      return Eigen::VectorXd::Constant(xs.size(), 3.0);
+    }
+  };
+
+  DiagBatch1 cov1;
+  DiagBatch2 cov2;
+  auto product = cov1 * cov2;
+
+  std::vector<double> xs = {1.0, 2.0};
+  Eigen::VectorXd result = product.diagonal(xs);
+
+  EXPECT_EQ(result.size(), 2);
+  for (Eigen::Index i = 0; i < result.size(); ++i) {
+    EXPECT_EQ(result[i], 15.0) << "Product diagonal: 5 * 3 = 15";
+  }
+}
+
+/*
+ * COMPLETENESS TESTS: Edge Cases and Missing Coverage
+ */
+
+/*
+ * Test partial batch: only cross-covariance batch, no diagonal
+ */
+TEST(test_batch_covariance, test_cross_batch_only_no_diagonal) {
+  class CrossBatchOnlyCovariance
+      : public CovarianceFunction<CrossBatchOnlyCovariance> {
+  public:
+    std::string name() const { return "cross_batch_only"; }
+
+    double _call_impl(const double &x, const double &y) const {
+      return x + y; // Simple implementation for diagonal fallback
+    }
+
+    // Only cross-covariance batch, no diagonal batch
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 123.0);
+    }
+  };
+
+  CrossBatchOnlyCovariance cov;
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+
+  // Cross-covariance should use batch
+  Eigen::MatrixXd cross = cov(xs, xs);
+  EXPECT_EQ(cross(0, 0), 123.0) << "Cross batch works";
+
+  // Diagonal should fall back to pointwise _call_impl
+  Eigen::VectorXd diag = cov.diagonal(xs);
+  EXPECT_EQ(diag[0], 2.0) << "Diagonal falls back to pointwise: 1+1=2";
+  EXPECT_EQ(diag[1], 4.0) << "Diagonal falls back to pointwise: 2+2=4";
+  EXPECT_EQ(diag[2], 6.0) << "Diagonal falls back to pointwise: 3+3=6";
+}
+
+/*
+ * Test partial batch: only diagonal, no full matrix batch
+ */
+TEST(test_batch_covariance, test_diagonal_batch_only_no_matrix) {
+  class DiagonalBatchOnlyCovariance
+      : public CovarianceFunction<DiagonalBatchOnlyCovariance> {
+  public:
+    std::string name() const { return "diag_batch_only"; }
+
+    double _call_impl(const double &x, const double &y) const {
+      return x * y; // For matrix fallback
+    }
+
+    // Only diagonal batch, no full matrix batch
+    Eigen::VectorXd _call_impl_vector_diagonal(const std::vector<double> &xs,
+                                               ThreadPool *pool) const {
+      return Eigen::VectorXd::Constant(xs.size(), 456.0);
+    }
+  };
+
+  DiagonalBatchOnlyCovariance cov;
+  std::vector<double> xs = {2.0, 3.0};
+
+  // Diagonal should use batch
+  Eigen::VectorXd diag = cov.diagonal(xs);
+  EXPECT_EQ(diag[0], 456.0) << "Diagonal batch works";
+
+  // Full matrix should fall back to pointwise _call_impl
+  Eigen::MatrixXd mat = cov(xs);
+  EXPECT_EQ(mat(0, 0), 4.0) << "Matrix falls back: 2*2=4";
+  EXPECT_EQ(mat(1, 1), 9.0) << "Matrix falls back: 3*3=9";
+  EXPECT_EQ(mat(0, 1), 6.0) << "Matrix falls back: 2*3=6";
+}
+
+/*
+ * Test edge case: empty vectors
+ */
+TEST(test_batch_covariance, test_empty_vectors) {
+  BatchTestCovariance cov(100.0);
+
+  std::vector<double> empty;
+
+  // Empty cross-covariance
+  Eigen::MatrixXd cross = cov(empty, empty);
+  EXPECT_EQ(cross.rows(), 0);
+  EXPECT_EQ(cross.cols(), 0);
+
+  // Empty symmetric
+  Eigen::MatrixXd sym = cov(empty);
+  EXPECT_EQ(sym.rows(), 0);
+  EXPECT_EQ(sym.cols(), 0);
+
+  // Empty diagonal
+  Eigen::VectorXd diag = cov.diagonal(empty);
+  EXPECT_EQ(diag.size(), 0);
+}
+
+/*
+ * Test edge case: single element
+ */
+TEST(test_batch_covariance, test_single_element) {
+  BatchTestCovariance cov(100.0);
+
+  std::vector<double> single = {42.0};
+
+  // Matrix should use batch
+  Eigen::MatrixXd result = cov(single);
+  EXPECT_EQ(result.rows(), 1);
+  EXPECT_EQ(result.cols(), 1);
+  EXPECT_EQ(result(0, 0), 100.0) << "Single element matrix uses batch";
+
+  // Diagonal falls back to pointwise (BatchTestCovariance has no diagonal
+  // batch)
+  Eigen::VectorXd diag = cov.diagonal(single);
+  EXPECT_EQ(diag.size(), 1);
+  EXPECT_EQ(diag[0], -999.0)
+      << "Single element diagonal uses pointwise fallback";
+}
+
+/*
+ * Test that ThreadPool is passed through
+ */
+TEST(test_batch_covariance, test_threadpool_passed_through) {
+  class ThreadPoolAwareCovariance
+      : public CovarianceFunction<ThreadPoolAwareCovariance> {
+  public:
+    std::string name() const { return "threadpool_aware"; }
+
+    double _call_impl(const double &x, const double &y) const { return 0.0; }
+
+    mutable bool pool_was_nullptr = true;
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      pool_was_nullptr = (pool == nullptr);
+      return Eigen::MatrixXd::Zero(xs.size(), ys.size());
+    }
+  };
+
+  ThreadPoolAwareCovariance cov;
+  std::vector<double> xs = {1.0, 2.0};
+
+  // Call with nullptr
+  cov(xs, xs, nullptr);
+  EXPECT_TRUE(cov.pool_was_nullptr) << "nullptr should be passed through";
+
+  // Call with actual ThreadPool
+  ThreadPool pool(2);
+  cov(xs, xs, &pool);
+  EXPECT_FALSE(cov.pool_was_nullptr) << "ThreadPool should be passed through";
+}
+
+/*
+ * Test positive definiteness of batch covariance matrices
+ */
+TEST(test_batch_covariance, test_batch_positive_definite) {
+  // Use a real covariance that should be PD
+  SquaredExponential<EuclideanDistance> cov(100.0, 1.0);
+
+  std::vector<double> xs = {0.0, 1.0, 2.0, 3.0, 4.0};
+
+  Eigen::MatrixXd C = cov(xs);
+
+  // Verify positive definite by attempting inverse
+  EXPECT_NO_THROW(C.inverse())
+      << "Covariance matrix should be positive definite";
+
+  // Also check it's symmetric
+  EXPECT_LT((C - C.transpose()).norm(), 1e-10) << "Should be symmetric";
+}
+
+/*
+ * Test batch covariance with LinearCombination correctness
+ * Use a simple covariance that supports the types
+ */
+TEST(test_batch_covariance, test_batch_with_linear_combination_correctness) {
+  class SimpleBatchCov : public CovarianceFunction<SimpleBatchCov> {
+  public:
+    std::string name() const { return "simple_batch"; }
+
+    double _call_impl(const double &x, const double &y) const {
+      return std::exp(-(x - y) * (x - y));
+    }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      Eigen::MatrixXd result(xs.size(), ys.size());
+      for (size_t i = 0; i < xs.size(); ++i) {
+        for (size_t j = 0; j < ys.size(); ++j) {
+          result(i, j) = std::exp(-(xs[i] - ys[j]) * (xs[i] - ys[j]));
+        }
+      }
+      return result;
+    }
+  };
+
+  SimpleBatchCov cov;
+
+  std::vector<double> features = {1.0, 2.0, 3.0};
+
+  // Create a simple linear combination: mean of first two
+  std::vector<double> two_features = {features[0], features[1]};
+  auto mean_12 = linear_combination::mean(two_features);
+
+  // Batch computation
+  Eigen::MatrixXd C = cov(features);
+
+  // Manually compute what mean_12 covariance should be
+  // mean_12 = 0.5 * (1 + 2) with coefficients [0.5, 0.5, 0]
+  Eigen::Vector3d coeffs(0.5, 0.5, 0.0);
+  double expected_cov = coeffs.dot(C * coeffs);
+
+  // Compute using pointwise LinearCombination logic
+  double actual_cov = cov(mean_12, mean_12);
+
+  EXPECT_NEAR(actual_cov, expected_cov, 1e-10)
+      << "LinearCombination should use covariance matrix correctly";
+}
+
+/*
+ * Test batch covariance with MeasurementOnly wrapper
+ */
+TEST(test_batch_covariance, test_batch_with_measurement_only) {
+  SquaredExponential<EuclideanDistance> radial(100.0, 1.0);
+  IndependentNoise<double> noise(0.1);
+  auto meas_noise = measurement_only(noise);
+  auto sum = radial + meas_noise;
+
+  std::vector<double> features = {0., 1., 2.};
+  std::vector<Measurement<double>> measurements;
+  for (const auto &f : features) {
+    measurements.emplace_back(Measurement<double>(f));
+  }
+
+  const auto f = features[0];
+  const auto m = measurements[0];
+
+  // Build covariance matrices
+  Eigen::MatrixXd C_features = sum(features);
+  Eigen::MatrixXd C_measurements = sum(measurements);
+
+  // Measurement matrix should have larger diagonal (includes noise)
+  EXPECT_GT(C_measurements(0, 0), C_features(0, 0))
+      << "Measurements should include measurement noise";
+
+  // Off-diagonal should be the same (only radial, no measurement noise)
+  EXPECT_DOUBLE_EQ(C_measurements(0, 1), C_features(0, 1))
+      << "Off-diagonal should only have radial component";
+}
+
+/*
+ * Test batch matrix symmetry property
+ */
+TEST(test_batch_covariance, test_batch_matrix_symmetry) {
+  EquivalenceTestCovariance cov;
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  std::vector<double> ys = {1.5, 2.5};
+
+  Eigen::MatrixXd C_xy = cov(xs, ys);
+  Eigen::MatrixXd C_yx = cov(ys, xs);
+
+  // C(xs, ys) should equal C(ys, xs)^T
+  EXPECT_LT((C_xy - C_yx.transpose()).norm(), 1e-10)
+      << "Covariance should be symmetric";
+}
+
+/*
+ * Test that batch respects covariance function parameters
+ */
+TEST(test_batch_covariance, test_batch_respects_parameters) {
+  class ParameterizedBatchCovariance
+      : public CovarianceFunction<ParameterizedBatchCovariance> {
+  public:
+    ALBATROSS_DECLARE_PARAMS(scale_param)
+
+    ParameterizedBatchCovariance() { scale_param = {1.0, PositivePrior()}; }
+
+    std::string name() const { return "parameterized_batch"; }
+
+    double _call_impl(const double &x, const double &y) const {
+      return scale_param.value * std::exp(-(x - y) * (x - y));
+    }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      Eigen::MatrixXd result(xs.size(), ys.size());
+      for (size_t i = 0; i < xs.size(); ++i) {
+        for (size_t j = 0; j < ys.size(); ++j) {
+          result(i, j) =
+              scale_param.value * std::exp(-(xs[i] - ys[j]) * (xs[i] - ys[j]));
+        }
+      }
+      return result;
+    }
+  };
+
+  ParameterizedBatchCovariance cov;
+  std::vector<double> xs = {0.0, 1.0};
+
+  // Test with default parameter
+  Eigen::MatrixXd C1 = cov(xs);
+  EXPECT_DOUBLE_EQ(C1(0, 0), 1.0); // exp(0) * 1.0
+
+  // Change parameter
+  cov.scale_param.value = 5.0;
+  Eigen::MatrixXd C2 = cov(xs);
+  EXPECT_DOUBLE_EQ(C2(0, 0), 5.0) << "Batch should respect parameter changes";
+
+  // Verify batch and pointwise give same result with new parameter
+  EXPECT_DOUBLE_EQ(cov(xs[0], xs[0]), C2(0, 0));
+}
+
+/*
+ * BATCH-ONLY SCALAR SYNTHESIS TESTS
+ *
+ * These tests verify that covariance functions which define ONLY
+ * _call_impl_vector (no pointwise _call_impl) can still be used
+ * with scalar operator() calls. The scalar result is synthesized
+ * by calling the batch method with single-element vectors.
+ */
+
+/*
+ * Test scalar operator() synthesized from batch-only covariance
+ */
+TEST(test_batch_covariance, test_batch_only_scalar_synthesis) {
+  // Covariance that defines ONLY batch, no pointwise
+  class BatchOnlyScalarTestCovariance
+      : public CovarianceFunction<BatchOnlyScalarTestCovariance> {
+  public:
+    std::string name() const { return "batch_only_scalar_test"; }
+
+    // NO _call_impl defined!
+
+    // Only batch implementation - returns sum of x and y
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      const Eigen::Index m = cast::to_index(xs.size());
+      const Eigen::Index n = cast::to_index(ys.size());
+      Eigen::MatrixXd result(m, n);
+      for (Eigen::Index i = 0; i < m; ++i) {
+        for (Eigen::Index j = 0; j < n; ++j) {
+          result(i, j) = xs[cast::to_size(i)] + ys[cast::to_size(j)];
+        }
+      }
+      return result;
+    }
+  };
+
+  BatchOnlyScalarTestCovariance cov;
+
+  // Test scalar calls - should work even without _call_impl
+  EXPECT_DOUBLE_EQ(cov(1.0, 2.0), 3.0) << "Scalar synthesis: 1+2=3";
+  EXPECT_DOUBLE_EQ(cov(5.0, 7.0), 12.0) << "Scalar synthesis: 5+7=12";
+  EXPECT_DOUBLE_EQ(cov(0.0, 0.0), 0.0) << "Scalar synthesis: 0+0=0";
+  EXPECT_DOUBLE_EQ(cov(-1.0, 3.0), 2.0) << "Scalar synthesis: -1+3=2";
+}
+
+/*
+ * Test that batch-only covariance works with Sum composition (scalar calls)
+ */
+TEST(test_batch_covariance, test_batch_only_sum_scalar) {
+  class BatchOnlyCov1 : public CovarianceFunction<BatchOnlyCov1> {
+  public:
+    std::string name() const { return "batch_only_1"; }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 10.0);
+    }
+  };
+
+  class BatchOnlyCov2 : public CovarianceFunction<BatchOnlyCov2> {
+  public:
+    std::string name() const { return "batch_only_2"; }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 7.0);
+    }
+  };
+
+  BatchOnlyCov1 cov1;
+  BatchOnlyCov2 cov2;
+  auto sum = cov1 + cov2;
+
+  // Scalar call on sum of batch-only covariances
+  EXPECT_DOUBLE_EQ(sum(1.0, 2.0), 17.0) << "Sum of batch-only: 10+7=17";
+
+  // Vector call should also work
+  std::vector<double> xs = {1.0, 2.0};
+  Eigen::MatrixXd result = sum(xs);
+  for (Eigen::Index i = 0; i < result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < result.cols(); ++j) {
+      EXPECT_DOUBLE_EQ(result(i, j), 17.0);
+    }
+  }
+}
+
+/*
+ * Test that batch-only covariance works with Product composition (scalar calls)
+ */
+TEST(test_batch_covariance, test_batch_only_product_scalar) {
+  class BatchOnlyCov1 : public CovarianceFunction<BatchOnlyCov1> {
+  public:
+    std::string name() const { return "batch_only_prod_1"; }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 3.0);
+    }
+  };
+
+  class BatchOnlyCov2 : public CovarianceFunction<BatchOnlyCov2> {
+  public:
+    std::string name() const { return "batch_only_prod_2"; }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 5.0);
+    }
+  };
+
+  BatchOnlyCov1 cov1;
+  BatchOnlyCov2 cov2;
+  auto product = cov1 * cov2;
+
+  // Scalar call on product of batch-only covariances
+  EXPECT_DOUBLE_EQ(product(1.0, 2.0), 15.0) << "Product of batch-only: 3*5=15";
+}
+
+/*
+ * Test mixing batch-only with pointwise covariances in Sum (scalar)
+ */
+TEST(test_batch_covariance, test_batch_only_mixed_sum_scalar) {
+  class BatchOnlyCov : public CovarianceFunction<BatchOnlyCov> {
+  public:
+    std::string name() const { return "batch_only_mixed"; }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 100.0);
+    }
+  };
+
+  class PointwiseCov : public CovarianceFunction<PointwiseCov> {
+  public:
+    std::string name() const { return "pointwise_mixed"; }
+
+    double _call_impl(const double &x, const double &y) const { return x * y; }
+  };
+
+  BatchOnlyCov batch_cov;
+  PointwiseCov pointwise_cov;
+  auto sum = batch_cov + pointwise_cov;
+
+  // Scalar call: batch returns 100, pointwise returns x*y
+  EXPECT_DOUBLE_EQ(sum(2.0, 3.0), 106.0) << "Mixed sum: 100 + 2*3 = 106";
+  EXPECT_DOUBLE_EQ(sum(5.0, 4.0), 120.0) << "Mixed sum: 100 + 5*4 = 120";
+}
+
+/*
+ * Test mixing batch-only with pointwise covariances in Product (scalar)
+ */
+TEST(test_batch_covariance, test_batch_only_mixed_product_scalar) {
+  class BatchOnlyCov : public CovarianceFunction<BatchOnlyCov> {
+  public:
+    std::string name() const { return "batch_only_mixed_prod"; }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 2.0);
+    }
+  };
+
+  class PointwiseCov : public CovarianceFunction<PointwiseCov> {
+  public:
+    std::string name() const { return "pointwise_mixed_prod"; }
+
+    double _call_impl(const double &x, const double &y) const { return x + y; }
+  };
+
+  BatchOnlyCov batch_cov;
+  PointwiseCov pointwise_cov;
+  auto product = batch_cov * pointwise_cov;
+
+  // Scalar call: batch returns 2, pointwise returns x+y
+  EXPECT_DOUBLE_EQ(product(3.0, 4.0), 14.0) << "Mixed product: 2 * (3+4) = 14";
+}
+
+/*
+ * Test diagonal extraction from batch-only covariance (no
+ * _call_impl_vector_diagonal)
+ */
+TEST(test_batch_covariance, test_batch_only_diagonal_synthesis) {
+  class BatchOnlyNoDiagonalCovariance
+      : public CovarianceFunction<BatchOnlyNoDiagonalCovariance> {
+  public:
+    std::string name() const { return "batch_only_no_diag"; }
+
+    // NO _call_impl defined!
+    // NO _call_impl_vector_diagonal defined!
+
+    // Only full batch implementation
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      const Eigen::Index m = cast::to_index(xs.size());
+      const Eigen::Index n = cast::to_index(ys.size());
+      Eigen::MatrixXd result(m, n);
+      for (Eigen::Index i = 0; i < m; ++i) {
+        for (Eigen::Index j = 0; j < n; ++j) {
+          // Return x*y so diagonal is x*x = x^2
+          result(i, j) = xs[cast::to_size(i)] * ys[cast::to_size(j)];
+        }
+      }
+      return result;
+    }
+  };
+
+  BatchOnlyNoDiagonalCovariance cov;
+
+  std::vector<double> xs = {2.0, 3.0, 5.0};
+
+  // Diagonal should be extracted from full matrix
+  Eigen::VectorXd diag = cov.diagonal(xs);
+
+  EXPECT_EQ(diag.size(), 3);
+  EXPECT_DOUBLE_EQ(diag[0], 4.0) << "Diagonal[0]: 2*2=4";
+  EXPECT_DOUBLE_EQ(diag[1], 9.0) << "Diagonal[1]: 3*3=9";
+  EXPECT_DOUBLE_EQ(diag[2], 25.0) << "Diagonal[2]: 5*5=25";
+}
+
+/*
+ * Test batch-only with different X and Y types
+ */
+TEST(test_batch_covariance, test_batch_only_different_types) {
+  struct TypeA {
+    double value;
+  };
+  struct TypeB {
+    double value;
+  };
+
+  class BatchOnlyDifferentTypesCovariance
+      : public CovarianceFunction<BatchOnlyDifferentTypesCovariance> {
+  public:
+    std::string name() const { return "batch_only_diff_types"; }
+
+    // Only batch for A-B cross-covariance
+    Eigen::MatrixXd _call_impl_vector(const std::vector<TypeA> &xs,
+                                      const std::vector<TypeB> &ys,
+                                      ThreadPool *pool) const {
+      const Eigen::Index m = cast::to_index(xs.size());
+      const Eigen::Index n = cast::to_index(ys.size());
+      Eigen::MatrixXd result(m, n);
+      for (Eigen::Index i = 0; i < m; ++i) {
+        for (Eigen::Index j = 0; j < n; ++j) {
+          result(i, j) =
+              xs[cast::to_size(i)].value * ys[cast::to_size(j)].value;
+        }
+      }
+      return result;
+    }
+  };
+
+  BatchOnlyDifferentTypesCovariance cov;
+
+  TypeA a{3.0};
+  TypeB b{4.0};
+
+  // Scalar call between different types
+  EXPECT_DOUBLE_EQ(cov(a, b), 12.0) << "Different types scalar: 3*4=12";
+
+  // Vector call
+  std::vector<TypeA> as = {TypeA{2.0}, TypeA{3.0}};
+  std::vector<TypeB> bs = {TypeB{5.0}, TypeB{7.0}};
+
+  Eigen::MatrixXd result = cov(as, bs);
+  EXPECT_DOUBLE_EQ(result(0, 0), 10.0); // 2*5
+  EXPECT_DOUBLE_EQ(result(0, 1), 14.0); // 2*7
+  EXPECT_DOUBLE_EQ(result(1, 0), 15.0); // 3*5
+  EXPECT_DOUBLE_EQ(result(1, 1), 21.0); // 3*7
+}
+
+/*
+ * Test batch-only covariance in three-way composition
+ */
+TEST(test_batch_covariance, test_batch_only_three_way_composition) {
+  class BatchOnlyA : public CovarianceFunction<BatchOnlyA> {
+  public:
+    std::string name() const { return "batch_a"; }
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 2.0);
+    }
+  };
+
+  class BatchOnlyB : public CovarianceFunction<BatchOnlyB> {
+  public:
+    std::string name() const { return "batch_b"; }
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 3.0);
+    }
+  };
+
+  class BatchOnlyC : public CovarianceFunction<BatchOnlyC> {
+  public:
+    std::string name() const { return "batch_c"; }
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 5.0);
+    }
+  };
+
+  BatchOnlyA a;
+  BatchOnlyB b;
+  BatchOnlyC c;
+
+  // (a + b) * c = (2 + 3) * 5 = 25
+  auto composed = (a + b) * c;
+  EXPECT_DOUBLE_EQ(composed(1.0, 1.0), 25.0) << "Three-way: (2+3)*5=25";
+
+  // a * b + c = 2*3 + 5 = 11
+  auto composed2 = a * b + c;
+  EXPECT_DOUBLE_EQ(composed2(1.0, 1.0), 11.0) << "Three-way: 2*3+5=11";
+}
+
+/*
+ * Test that has_valid_caller trait works for batch-only covariances
+ */
+TEST(test_batch_covariance, test_batch_only_has_valid_caller) {
+  class BatchOnlyTraitTestCovariance
+      : public CovarianceFunction<BatchOnlyTraitTestCovariance> {
+  public:
+    std::string name() const { return "batch_only_trait_test"; }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      return Eigen::MatrixXd::Constant(xs.size(), ys.size(), 1.0);
+    }
+  };
+
+  // This test verifies compilation - if has_valid_caller didn't work for
+  // batch-only covariances, the operator() wouldn't be enabled and this
+  // wouldn't compile.
+  BatchOnlyTraitTestCovariance cov;
+
+  // These calls should compile and work
+  double scalar_result = cov(1.0, 2.0);
+  EXPECT_DOUBLE_EQ(scalar_result, 1.0);
+
+  std::vector<double> xs = {1.0};
+  Eigen::MatrixXd matrix_result = cov(xs);
+  EXPECT_DOUBLE_EQ(matrix_result(0, 0), 1.0);
+
+  Eigen::VectorXd diag_result = cov.diagonal(xs);
+  EXPECT_DOUBLE_EQ(diag_result[0], 1.0);
+}
+
+/*
+ * VECTORIZATION TESTS: Verify batch methods are called with full vectors
+ *
+ * These tests verify that the CRTP machinery properly delegates to
+ * _call_impl_vector with the full training data vector, rather than
+ * calling it element-by-element in a loop.
+ */
+
+/*
+ * MockBatchCovariance: tracks call count, dimensions, and thread pool
+ * to verify batch methods are called correctly.
+ */
+struct BatchCallStats {
+  mutable std::atomic<int> call_count{0};
+  mutable std::atomic<int> last_xs_size{0};
+  mutable std::atomic<int> last_ys_size{0};
+  mutable std::atomic<bool> pool_was_nonnull{false};
+  mutable std::atomic<std::size_t> pool_thread_count{0};
+
+  void reset() {
+    call_count = 0;
+    last_xs_size = 0;
+    last_ys_size = 0;
+    pool_was_nonnull = false;
+    pool_thread_count = 0;
+  }
+};
+
+class MockBatchCovariance : public CovarianceFunction<MockBatchCovariance> {
+public:
+  std::string name() const { return "mock_batch"; }
+
+  // Shared stats object (survives copies)
+  std::shared_ptr<BatchCallStats> stats = std::make_shared<BatchCallStats>();
+
+  // NO _call_impl - batch only!
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *pool) const {
+    stats->call_count++;
+    stats->last_xs_size = static_cast<int>(xs.size());
+    stats->last_ys_size = static_cast<int>(ys.size());
+    stats->pool_was_nonnull = (pool != nullptr);
+    if (pool)
+      stats->pool_thread_count = pool->thread_count();
+    return Eigen::MatrixXd::Constant(cast::to_index(xs.size()),
+                                     cast::to_index(ys.size()), 42.0);
+  }
+};
+
+/*
+ * Test: variant batch calls _call_impl_vector exactly once with full dimensions
+ */
+TEST(test_vectorization, test_variant_batch_single_call) {
+  MockBatchCovariance mock;
+  mock.stats->reset();
+
+  using DoubleVariant = variant<double>;
+  std::vector<DoubleVariant> xs(50, DoubleVariant(1.0));
+
+  Eigen::MatrixXd result = mock(xs);
+
+  EXPECT_EQ(mock.stats->call_count, 1) << "Batch should be called exactly once";
+  EXPECT_EQ(mock.stats->last_xs_size, 50) << "Should receive full vector";
+  EXPECT_EQ(mock.stats->last_ys_size, 50);
+  EXPECT_EQ(result.rows(), 50);
+  EXPECT_EQ(result.cols(), 50);
+}
+
+/*
+ * Test: cross-covariance with variant on left side
+ */
+TEST(test_vectorization, test_variant_cross_batch_single_call_left) {
+  MockBatchCovariance mock;
+  mock.stats->reset();
+
+  using DoubleVariant = variant<double>;
+  std::vector<DoubleVariant> xs(30, DoubleVariant(1.0));
+  std::vector<double> ys(40, 2.0);
+
+  Eigen::MatrixXd result = mock(xs, ys);
+
+  EXPECT_EQ(mock.stats->call_count, 1);
+  EXPECT_EQ(mock.stats->last_xs_size, 30);
+  EXPECT_EQ(mock.stats->last_ys_size, 40);
+}
+
+/*
+ * Test: cross-covariance with variant on right side
+ */
+TEST(test_vectorization, test_variant_cross_batch_single_call_right) {
+  MockBatchCovariance mock;
+  mock.stats->reset();
+
+  using DoubleVariant = variant<double>;
+  std::vector<double> xs(25, 1.0);
+  std::vector<DoubleVariant> ys(35, DoubleVariant(2.0));
+
+  Eigen::MatrixXd result = mock(xs, ys);
+
+  EXPECT_EQ(mock.stats->call_count, 1);
+  EXPECT_EQ(mock.stats->last_xs_size, 25);
+  EXPECT_EQ(mock.stats->last_ys_size, 35);
+}
+
+/*
+ * Test: both sides are variants (independently homogeneous)
+ */
+TEST(test_vectorization, test_variant_both_sides_batch) {
+  MockBatchCovariance mock;
+  mock.stats->reset();
+
+  using DoubleVariant = variant<double>;
+  std::vector<DoubleVariant> xs(20, DoubleVariant(1.0));
+  std::vector<DoubleVariant> ys(25, DoubleVariant(2.0));
+
+  Eigen::MatrixXd result = mock(xs, ys);
+
+  EXPECT_EQ(mock.stats->call_count, 1);
+  EXPECT_EQ(mock.stats->last_xs_size, 20);
+  EXPECT_EQ(mock.stats->last_ys_size, 25);
+}
+
+/*
+ * Test: Measurement vectors should unwrap and use batch
+ */
+TEST(test_vectorization, test_measurement_batch_single_call) {
+  MockBatchCovariance mock;
+  mock.stats->reset();
+
+  std::vector<Measurement<double>> ms(100, Measurement<double>{1.0});
+
+  Eigen::MatrixXd result = mock(ms);
+
+  EXPECT_EQ(mock.stats->call_count, 1)
+      << "Measurement batch should be called exactly once";
+  EXPECT_EQ(mock.stats->last_xs_size, 100) << "Should receive full vector";
+  EXPECT_EQ(mock.stats->last_ys_size, 100);
+}
+
+/*
+ * Test: cross-covariance with Measurement on left side
+ */
+TEST(test_vectorization, test_measurement_cross_batch_left) {
+  MockBatchCovariance mock;
+  mock.stats->reset();
+
+  std::vector<Measurement<double>> xs(30, Measurement<double>{1.0});
+  std::vector<double> ys(40, 2.0);
+
+  Eigen::MatrixXd result = mock(xs, ys);
+
+  EXPECT_EQ(mock.stats->call_count, 1);
+  EXPECT_EQ(mock.stats->last_xs_size, 30);
+  EXPECT_EQ(mock.stats->last_ys_size, 40);
+}
+
+/*
+ * Test: cross-covariance with Measurement on right side
+ */
+TEST(test_vectorization, test_measurement_cross_batch_right) {
+  MockBatchCovariance mock;
+  mock.stats->reset();
+
+  std::vector<double> xs(25, 1.0);
+  std::vector<Measurement<double>> ys(35, Measurement<double>{2.0});
+
+  Eigen::MatrixXd result = mock(xs, ys);
+
+  EXPECT_EQ(mock.stats->call_count, 1);
+  EXPECT_EQ(mock.stats->last_xs_size, 25);
+  EXPECT_EQ(mock.stats->last_ys_size, 35);
+}
+
+/*
+ * Test: both sides Measurement
+ */
+TEST(test_vectorization, test_measurement_both_sides_batch) {
+  MockBatchCovariance mock;
+  mock.stats->reset();
+
+  std::vector<Measurement<double>> xs(15, Measurement<double>{1.0});
+  std::vector<Measurement<double>> ys(20, Measurement<double>{2.0});
+
+  Eigen::MatrixXd result = mock(xs, ys);
+
+  EXPECT_EQ(mock.stats->call_count, 1);
+  EXPECT_EQ(mock.stats->last_xs_size, 15);
+  EXPECT_EQ(mock.stats->last_ys_size, 20);
+}
+
+/*
+ * Test: diagonal extraction with variant
+ */
+TEST(test_vectorization, test_variant_diagonal_batch) {
+  // Need a covariance with both batch and diagonal batch
+  class MockDiagonalBatchCov : public CovarianceFunction<MockDiagonalBatchCov> {
+  public:
+    std::string name() const { return "mock_diag_batch"; }
+    mutable int vector_call_count = 0;
+    mutable int diagonal_call_count = 0;
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      vector_call_count++;
+      return Eigen::MatrixXd::Constant(cast::to_index(xs.size()),
+                                       cast::to_index(ys.size()), 42.0);
+    }
+
+    Eigen::VectorXd _call_impl_vector_diagonal(const std::vector<double> &xs,
+                                               ThreadPool *pool) const {
+      diagonal_call_count++;
+      return Eigen::VectorXd::Constant(cast::to_index(xs.size()), 99.0);
+    }
+  };
+
+  MockDiagonalBatchCov cov;
+
+  using DoubleVariant = variant<double>;
+  std::vector<DoubleVariant> xs(50, DoubleVariant(1.0));
+
+  Eigen::VectorXd result = cov.diagonal(xs);
+
+  EXPECT_EQ(cov.diagonal_call_count, 1) << "Diagonal batch should be called once";
+  EXPECT_EQ(cov.vector_call_count, 0) << "Full matrix batch should not be called";
+  EXPECT_EQ(result.size(), 50);
+  EXPECT_DOUBLE_EQ(result[0], 99.0);
+}
+
+/*
+ * Test: diagonal extraction with Measurement
+ */
+TEST(test_vectorization, test_measurement_diagonal_batch) {
+  class MockDiagonalBatchCov : public CovarianceFunction<MockDiagonalBatchCov> {
+  public:
+    std::string name() const { return "mock_diag_batch"; }
+    mutable int vector_call_count = 0;
+    mutable int diagonal_call_count = 0;
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *pool) const {
+      vector_call_count++;
+      return Eigen::MatrixXd::Constant(cast::to_index(xs.size()),
+                                       cast::to_index(ys.size()), 42.0);
+    }
+
+    Eigen::VectorXd _call_impl_vector_diagonal(const std::vector<double> &xs,
+                                               ThreadPool *pool) const {
+      diagonal_call_count++;
+      return Eigen::VectorXd::Constant(cast::to_index(xs.size()), 88.0);
+    }
+  };
+
+  MockDiagonalBatchCov cov;
+
+  std::vector<Measurement<double>> xs(60, Measurement<double>{1.0});
+
+  Eigen::VectorXd result = cov.diagonal(xs);
+
+  EXPECT_EQ(cov.diagonal_call_count, 1) << "Diagonal batch should be called once";
+  EXPECT_EQ(cov.vector_call_count, 0) << "Full matrix batch should not be called";
+  EXPECT_EQ(result.size(), 60);
+  EXPECT_DOUBLE_EQ(result[0], 88.0);
+}
+
+/*
+ * Test: multi-type variant with batch support
+ */
+TEST(test_vectorization, test_variant_multi_type_batch) {
+  class MultiTypeBatchCov : public CovarianceFunction<MultiTypeBatchCov> {
+  public:
+    std::string name() const { return "multi"; }
+    mutable int double_calls = 0;
+    mutable int int_calls = 0;
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *) const {
+      double_calls++;
+      return Eigen::MatrixXd::Constant(cast::to_index(xs.size()),
+                                       cast::to_index(ys.size()), 1.0);
+    }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                      const std::vector<int> &ys,
+                                      ThreadPool *) const {
+      int_calls++;
+      return Eigen::MatrixXd::Constant(cast::to_index(xs.size()),
+                                       cast::to_index(ys.size()), 2.0);
+    }
+  };
+
+  MultiTypeBatchCov cov;
+
+  using TestVariant = variant<double, int>;
+
+  // Test with doubles
+  std::vector<TestVariant> xs_double(20, TestVariant(1.0));
+  std::vector<TestVariant> ys_double(20, TestVariant(2.0));
+
+  Eigen::MatrixXd result_double = cov(xs_double, ys_double);
+  EXPECT_EQ(cov.double_calls, 1);
+  EXPECT_EQ(cov.int_calls, 0);
+  EXPECT_DOUBLE_EQ(result_double(0, 0), 1.0);
+
+  // Reset and test with ints
+  cov.double_calls = 0;
+  cov.int_calls = 0;
+
+  std::vector<TestVariant> xs_int(15, TestVariant(1));
+  std::vector<TestVariant> ys_int(15, TestVariant(2));
+
+  Eigen::MatrixXd result_int = cov(xs_int, ys_int);
+  EXPECT_EQ(cov.double_calls, 0);
+  EXPECT_EQ(cov.int_calls, 1);
+  EXPECT_DOUBLE_EQ(result_int(0, 0), 2.0);
+}
+
+/*
+ * ============================================================================
+ * Measurement<X> + Batch Covariance Tests
+ *
+ * These tests verify that MeasurementForwarder correctly unwraps Measurement
+ * types and uses batch dispatch when the covariance function has
+ * _call_impl_vector for the inner type but NOT explicit Measurement support.
+ * ============================================================================
+ */
+
+/*
+ * MockBatchCovarianceWithPointwise: has both batch and pointwise for plain
+ * types, but NO explicit Measurement support. When called with Measurement<X>,
+ * it should unwrap and use batch.
+ */
+class MockBatchCovarianceWithPointwise
+    : public CovarianceFunction<MockBatchCovarianceWithPointwise> {
+public:
+  std::string name() const { return "mock_batch_with_pointwise"; }
+
+  std::shared_ptr<BatchCallStats> stats = std::make_shared<BatchCallStats>();
+
+  // Pointwise for plain types
+  double _call_impl(const double &x, const double &y) const {
+    return x * y; // Different from batch to detect which path is used
+  }
+
+  // Batch for plain types
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *pool) const {
+    stats->call_count++;
+    stats->last_xs_size = static_cast<int>(xs.size());
+    stats->last_ys_size = static_cast<int>(ys.size());
+    stats->pool_was_nonnull = (pool != nullptr);
+    if (pool)
+      stats->pool_thread_count = pool->thread_count();
+    return Eigen::MatrixXd::Constant(cast::to_index(xs.size()),
+                                     cast::to_index(ys.size()), 42.0);
+  }
+};
+
+/*
+ * MeasurementAwareBatchCovariance: has explicit _call_impl for Measurement
+ * types. When called with Measurement<X>, it MUST use pointwise to respect the
+ * special Measurement handling.
+ */
+class MeasurementAwareBatchCovariance
+    : public CovarianceFunction<MeasurementAwareBatchCovariance> {
+public:
+  std::string name() const { return "measurement_aware_batch"; }
+
+  mutable int batch_call_count = 0;
+  mutable int measurement_pointwise_count = 0;
+
+  void reset() const {
+    batch_call_count = 0;
+    measurement_pointwise_count = 0;
+  }
+
+  // Pointwise for plain types
+  double _call_impl(const double &x, const double &y) const { return x * y; }
+
+  // Batch for plain types
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *) const {
+    batch_call_count++;
+    return Eigen::MatrixXd::Constant(cast::to_index(xs.size()),
+                                     cast::to_index(ys.size()), 1.0);
+  }
+
+  // EXPLICIT Measurement support - should be used instead of batch
+  // This simulates IndependentNoise behavior where Measurement matters
+  double _call_impl(const Measurement<double> &x,
+                    const Measurement<double> &y) const {
+    measurement_pointwise_count++;
+    // Special handling: return different value to detect this path
+    return 99.0;
+  }
+};
+
+/*
+ * Test: Measurement<X> with batch covariance (no explicit Measurement support)
+ * should unwrap and use batch dispatch (single call)
+ */
+TEST(test_measurement_batch, test_measurement_unwrap_uses_batch_symmetric) {
+  MockBatchCovarianceWithPointwise mock;
+  mock.stats->reset();
+
+  std::vector<Measurement<double>> ms;
+  for (int i = 0; i < 50; ++i) {
+    ms.push_back(Measurement<double>{static_cast<double>(i)});
+  }
+
+  Eigen::MatrixXd result = mock(ms);
+
+  EXPECT_EQ(mock.stats->call_count, 1) << "Batch should be called exactly once";
+  EXPECT_EQ(mock.stats->last_xs_size, 50) << "Should receive full vector";
+  EXPECT_EQ(mock.stats->last_ys_size, 50);
+  EXPECT_EQ(result.rows(), 50);
+  EXPECT_EQ(result.cols(), 50);
+  // Verify batch value (42.0) not pointwise value
+  EXPECT_DOUBLE_EQ(result(0, 0), 42.0);
+}
+
+/*
+ * Test: Measurement<X> cross-covariance uses batch
+ */
+TEST(test_measurement_batch, test_measurement_unwrap_uses_batch_cross) {
+  MockBatchCovarianceWithPointwise mock;
+  mock.stats->reset();
+
+  std::vector<Measurement<double>> xs;
+  std::vector<Measurement<double>> ys;
+  for (int i = 0; i < 30; ++i) {
+    xs.push_back(Measurement<double>{static_cast<double>(i)});
+  }
+  for (int i = 0; i < 40; ++i) {
+    ys.push_back(Measurement<double>{static_cast<double>(i + 100)});
+  }
+
+  Eigen::MatrixXd result = mock(xs, ys);
+
+  EXPECT_EQ(mock.stats->call_count, 1) << "Batch should be called exactly once";
+  EXPECT_EQ(mock.stats->last_xs_size, 30);
+  EXPECT_EQ(mock.stats->last_ys_size, 40);
+  EXPECT_EQ(result.rows(), 30);
+  EXPECT_EQ(result.cols(), 40);
+  EXPECT_DOUBLE_EQ(result(0, 0), 42.0);
+}
+
+/*
+ * Test: Measurement on left, plain on right - should unwrap left and use batch
+ */
+TEST(test_measurement_batch, test_measurement_left_plain_right_uses_batch) {
+  MockBatchCovarianceWithPointwise mock;
+  mock.stats->reset();
+
+  std::vector<Measurement<double>> xs;
+  for (int i = 0; i < 20; ++i) {
+    xs.push_back(Measurement<double>{static_cast<double>(i)});
+  }
+  std::vector<double> ys(25, 1.0);
+
+  Eigen::MatrixXd result = mock(xs, ys);
+
+  EXPECT_EQ(mock.stats->call_count, 1);
+  EXPECT_EQ(mock.stats->last_xs_size, 20);
+  EXPECT_EQ(mock.stats->last_ys_size, 25);
+  EXPECT_DOUBLE_EQ(result(0, 0), 42.0);
+}
+
+/*
+ * Test: Plain on left, Measurement on right - should unwrap right and use batch
+ */
+TEST(test_measurement_batch, test_plain_left_measurement_right_uses_batch) {
+  MockBatchCovarianceWithPointwise mock;
+  mock.stats->reset();
+
+  std::vector<double> xs(15, 1.0);
+  std::vector<Measurement<double>> ys;
+  for (int i = 0; i < 22; ++i) {
+    ys.push_back(Measurement<double>{static_cast<double>(i)});
+  }
+
+  Eigen::MatrixXd result = mock(xs, ys);
+
+  EXPECT_EQ(mock.stats->call_count, 1);
+  EXPECT_EQ(mock.stats->last_xs_size, 15);
+  EXPECT_EQ(mock.stats->last_ys_size, 22);
+  EXPECT_DOUBLE_EQ(result(0, 0), 42.0);
+}
+
+/*
+ * Test: Covariance with explicit Measurement support MUST use pointwise
+ * to respect the special Measurement handling
+ */
+TEST(test_measurement_batch, test_explicit_measurement_support_uses_pointwise) {
+  MeasurementAwareBatchCovariance cov;
+  cov.reset();
+
+  std::vector<Measurement<double>> ms;
+  for (int i = 0; i < 5; ++i) {
+    ms.push_back(Measurement<double>{static_cast<double>(i)});
+  }
+
+  Eigen::MatrixXd result = cov(ms);
+
+  // Should NOT use batch since there's explicit Measurement support
+  EXPECT_EQ(cov.batch_call_count, 0)
+      << "Batch should NOT be called when explicit Measurement support exists";
+  // Should use pointwise (5x5 = 25 calls for symmetric, but symmetric compute
+  // only does upper triangle + diagonal = 5+4+3+2+1 = 15 pairs)
+  EXPECT_GT(cov.measurement_pointwise_count, 0)
+      << "Pointwise should be called for explicit Measurement support";
+  // Verify pointwise value (99.0)
+  EXPECT_DOUBLE_EQ(result(0, 0), 99.0);
+}
+
+/*
+ * Test: Measurement + batch with thread pool - pool should be passed through
+ */
+TEST(test_measurement_batch, test_measurement_batch_with_thread_pool) {
+  MockBatchCovarianceWithPointwise mock;
+  mock.stats->reset();
+
+  std::vector<Measurement<double>> ms;
+  for (int i = 0; i < 100; ++i) {
+    ms.push_back(Measurement<double>{static_cast<double>(i)});
+  }
+
+  ThreadPool pool(4);
+  Eigen::MatrixXd result = mock(ms, &pool);
+
+  EXPECT_EQ(mock.stats->call_count, 1);
+  EXPECT_TRUE(mock.stats->pool_was_nonnull) << "Thread pool should be passed";
+  EXPECT_EQ(mock.stats->pool_thread_count, 4);
+}
+
+/*
+ * Test: Sum composition with Measurement - both sides should use batch
+ */
+TEST(test_measurement_batch, test_sum_composition_measurement_batch) {
+  MockBatchCovarianceWithPointwise lhs;
+  MockBatchCovarianceWithPointwise rhs;
+  lhs.stats->reset();
+  rhs.stats->reset();
+
+  // Verify traits are satisfied
+  static_assert(
+      has_valid_call_impl_vector<MockBatchCovarianceWithPointwise, double,
+                                 double>::value,
+      "MockBatchCovarianceWithPointwise should have batch support");
+  static_assert(
+      has_valid_call_impl_vector_symmetric<MockBatchCovarianceWithPointwise,
+                                           double>::value,
+      "MockBatchCovarianceWithPointwise should have symmetric batch support");
+
+  auto sum = lhs + rhs;
+
+  // Verify Sum has batch support for double
+  using SumType = decltype(sum);
+  static_assert(has_valid_call_impl_vector<SumType, double, double>::value,
+                "Sum should have batch support for double");
+  static_assert(has_valid_call_impl_vector_symmetric<SumType, double>::value,
+                "Sum should have symmetric batch support for double");
+
+  // Verify Sum has batch support for Measurement<double>
+  static_assert(
+      has_valid_call_impl_vector<SumType, Measurement<double>,
+                                 Measurement<double>>::value,
+      "Sum should have batch support for Measurement<double>");
+  static_assert(
+      has_valid_call_impl_vector_symmetric<SumType, Measurement<double>>::value,
+      "Sum should have symmetric batch support for Measurement<double>");
+
+  std::vector<Measurement<double>> ms;
+  for (int i = 0; i < 25; ++i) {
+    ms.push_back(Measurement<double>{static_cast<double>(i)});
+  }
+
+  Eigen::MatrixXd result = sum(ms);
+
+  // Both sides should have been called exactly once with batch
+  EXPECT_EQ(lhs.stats->call_count, 1)
+      << "LHS batch should be called exactly once";
+  EXPECT_EQ(rhs.stats->call_count, 1)
+      << "RHS batch should be called exactly once";
+  EXPECT_EQ(lhs.stats->last_xs_size, 25);
+  EXPECT_EQ(rhs.stats->last_xs_size, 25);
+  // Result should be sum of batch values (42 + 42 = 84)
+  EXPECT_DOUBLE_EQ(result(0, 0), 84.0);
+}
+
+/*
+ * Test: Product composition with Measurement - both sides should use batch
+ */
+TEST(test_measurement_batch, test_product_composition_measurement_batch) {
+  MockBatchCovarianceWithPointwise lhs;
+  MockBatchCovarianceWithPointwise rhs;
+  lhs.stats->reset();
+  rhs.stats->reset();
+
+  auto product = lhs * rhs;
+
+  std::vector<Measurement<double>> ms;
+  for (int i = 0; i < 20; ++i) {
+    ms.push_back(Measurement<double>{static_cast<double>(i)});
+  }
+
+  Eigen::MatrixXd result = product(ms);
+
+  // Both sides should have been called exactly once with batch
+  EXPECT_EQ(lhs.stats->call_count, 1);
+  EXPECT_EQ(rhs.stats->call_count, 1);
+  // Result should be product of batch values (42 * 42 = 1764)
+  EXPECT_DOUBLE_EQ(result(0, 0), 42.0 * 42.0);
+}
+
+/*
+ * Test: Mixed composition - one side batch, one side pointwise-only
+ * The Measurement should still be unwrapped correctly
+ */
+TEST(test_measurement_batch, test_mixed_composition_measurement) {
+  MockBatchCovarianceWithPointwise batch_cov;
+  batch_cov.stats->reset();
+
+  // Create a pointwise-only covariance
+  class PointwiseOnlyCov : public CovarianceFunction<PointwiseOnlyCov> {
+  public:
+    std::string name() const { return "pointwise_only"; }
+    double _call_impl(const double &x, const double &y) const { return 1.0; }
+  };
+  PointwiseOnlyCov pointwise_cov;
+
+  auto sum = batch_cov + pointwise_cov;
+
+  std::vector<Measurement<double>> ms;
+  for (int i = 0; i < 10; ++i) {
+    ms.push_back(Measurement<double>{static_cast<double>(i)});
+  }
+
+  Eigen::MatrixXd result = sum(ms);
+
+  // Batch side should be called once
+  EXPECT_EQ(batch_cov.stats->call_count, 1);
+  EXPECT_EQ(batch_cov.stats->last_xs_size, 10);
+  // Result should be batch + pointwise (42 + 1 = 43)
+  EXPECT_DOUBLE_EQ(result(0, 0), 43.0);
+}
+
+/*
+ * ============================================================================
+ * PHASE 0: Permutation Infrastructure Tests
+ *
+ * These tests validate the sort-by-type and permutation logic used for
+ * heterogeneous variant batch covariance dispatch.
+ * ============================================================================
+ */
+
+/*
+ * Test 0a: sort_variants_by_type produces correct grouping
+ */
+TEST(test_variant_permutation, test_sort_groups_by_type) {
+  using V = variant<int, double, std::string>;
+  std::vector<V> input = {V(1.0), V(42), V(std::string("hello")),
+                          V(2.0), V(99), V(std::string("world"))};
+  // Types: [double, int, string, double, int, string]
+  // Indices: [0, 1, 2, 3, 4, 5]
+
+  auto sorted =
+      internal::variant_batch_detail::sort_variants_by_type(input);
+
+  // Verify block boundaries
+  // Order should be: all ints, then all doubles, then all strings (by type
+  // index) Type indices: int=0, double=1, string=2
+  EXPECT_EQ(sorted.block_starts[0], 0);  // int starts at 0
+  EXPECT_EQ(sorted.block_starts[1], 2);  // double starts at 2 (2 ints)
+  EXPECT_EQ(sorted.block_starts[2], 4);  // string starts at 4 (2 doubles)
+  EXPECT_EQ(sorted.block_starts[3], 6);  // end sentinel
+
+  // Verify sorted vector contains correct elements (grouped by type)
+  EXPECT_EQ(sorted.sorted[0].template get<int>(), 42);
+  EXPECT_EQ(sorted.sorted[1].template get<int>(), 99);
+  EXPECT_DOUBLE_EQ(sorted.sorted[2].template get<double>(), 1.0);
+  EXPECT_DOUBLE_EQ(sorted.sorted[3].template get<double>(), 2.0);
+  EXPECT_EQ(sorted.sorted[4].template get<std::string>(), "hello");
+  EXPECT_EQ(sorted.sorted[5].template get<std::string>(), "world");
+}
+
+/*
+ * Test 0b: Permutation matrix correctly maps sorted↔original
+ */
+TEST(test_variant_permutation, test_permutation_indices) {
+  using V = variant<int, double>;
+  std::vector<V> input = {V(1.0), V(42), V(2.0), V(99)};
+  // Types: [double, int, double, int]
+  // Original indices: [0, 1, 2, 3]
+
+  auto sorted =
+      internal::variant_batch_detail::sort_variants_by_type(input);
+
+  // Sorted order: [42, 99, 1.0, 2.0] (ints first, then doubles)
+  // Sorted indices: [0, 1, 2, 3]
+  // Eigen convention: indices[orig_idx] = sorted_idx means
+  // original element at orig_idx goes to sorted position sorted_idx
+  // So (P * original)[sorted_idx] = original[orig_idx]
+  //
+  // original[0]=1.0 (double) -> sorted[2]
+  // original[1]=42 (int) -> sorted[0]
+  // original[2]=2.0 (double) -> sorted[3]
+  // original[3]=99 (int) -> sorted[1]
+
+  EXPECT_EQ(sorted.to_sorted.indices()[0], 2); // original[0]=1.0 goes to sorted[2]
+  EXPECT_EQ(sorted.to_sorted.indices()[1], 0); // original[1]=42 goes to sorted[0]
+  EXPECT_EQ(sorted.to_sorted.indices()[2], 3); // original[2]=2.0 goes to sorted[3]
+  EXPECT_EQ(sorted.to_sorted.indices()[3], 1); // original[3]=99 goes to sorted[1]
+}
+
+/*
+ * Test 0c: Inverse permutation recovers original order
+ */
+TEST(test_variant_permutation, test_inverse_permutation_roundtrip) {
+  using V = variant<int, double, std::string>;
+  std::vector<V> input = {V(1.0), V(42), V(std::string("a")),
+                          V(2.0), V(99), V(std::string("b"))};
+
+  auto sorted =
+      internal::variant_batch_detail::sort_variants_by_type(input);
+
+  // Create a simple matrix in sorted order
+  const Eigen::Index n = cast::to_index(input.size());
+  Eigen::MatrixXd sorted_matrix(n, n);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    for (Eigen::Index j = 0; j < n; ++j) {
+      sorted_matrix(i, j) = static_cast<double>(i * 10 + j);
+    }
+  }
+
+  // Unpermute: result = P^{-1} * sorted_matrix * P^{-T}
+  // Note: We need to evaluate the inverse before calling transpose()
+  Eigen::PermutationMatrix<Eigen::Dynamic> P_inv = sorted.to_sorted.inverse();
+  Eigen::MatrixXd result = P_inv * sorted_matrix * P_inv.transpose();
+
+  // Verify: result(i,j) should equal sorted_matrix(sorted_idx[i], sorted_idx[j])
+  // where sorted_idx[orig_i] is the position of original[orig_i] in sorted order
+  // With Eigen convention: indices[orig_i] = sorted_i
+  for (Eigen::Index i = 0; i < n; ++i) {
+    for (Eigen::Index j = 0; j < n; ++j) {
+      // indices[orig_i] directly gives the sorted position
+      Eigen::Index sorted_i = sorted.to_sorted.indices()[i];
+      Eigen::Index sorted_j = sorted.to_sorted.indices()[j];
+      EXPECT_DOUBLE_EQ(result(i, j), sorted_matrix(sorted_i, sorted_j));
+    }
+  }
+}
+
+/*
+ * Test 0d: Empty vector edge case
+ */
+TEST(test_variant_permutation, test_empty_vector) {
+  using V = variant<int, double>;
+  std::vector<V> input = {};
+
+  auto sorted =
+      internal::variant_batch_detail::sort_variants_by_type(input);
+
+  EXPECT_EQ(sorted.sorted.size(), 0u);
+  EXPECT_EQ(sorted.block_starts[0], 0);
+  EXPECT_EQ(sorted.block_starts[1], 0);
+  EXPECT_EQ(sorted.block_starts[2], 0);
+}
+
+/*
+ * Test 0d: Single element edge case
+ */
+TEST(test_variant_permutation, test_single_element) {
+  using V = variant<int, double>;
+  std::vector<V> input = {V(42)};
+
+  auto sorted =
+      internal::variant_batch_detail::sort_variants_by_type(input);
+
+  EXPECT_EQ(sorted.sorted.size(), 1u);
+  EXPECT_EQ(sorted.sorted[0].template get<int>(), 42);
+  EXPECT_EQ(sorted.to_sorted.indices()[0], 0);
+}
+
+/*
+ * Test 0e: Homogeneous input (single type)
+ */
+TEST(test_variant_permutation, test_homogeneous_vector) {
+  using V = variant<int, double>;
+  std::vector<V> input = {V(1.0), V(2.0), V(3.0)};
+
+  auto sorted =
+      internal::variant_batch_detail::sort_variants_by_type(input);
+
+  // All doubles, so no reordering needed
+  EXPECT_EQ(sorted.block_starts[0], 0); // int: empty
+  EXPECT_EQ(sorted.block_starts[1], 0); // double starts at 0
+  EXPECT_EQ(sorted.block_starts[2], 3); // end
+
+  // Permutation should be identity for this portion
+  for (Eigen::Index i = 0; i < 3; ++i) {
+    EXPECT_EQ(sorted.to_sorted.indices()[i], i);
+  }
+}
+
+/*
+ * Test 0f: Random shuffle integration test with identity covariance
+ *
+ * This test verifies that heterogeneous variant batch dispatch produces
+ * the correct output matrix by using a covariance that returns distinguishable
+ * values based on element identity.
+ */
+class IdentityCovariance : public CovarianceFunction<IdentityCovariance> {
+public:
+  std::string name() const { return "identity"; }
+
+  double _call_impl(const int &x, const int &y) const {
+    return static_cast<double>(x * 1000 + y); // Encodes (x, y)
+  }
+  double _call_impl(const double &x, const double &y) const {
+    return x * 1000.0 + y; // Encodes (x, y)
+  }
+  // Cross-type: return negative to distinguish
+  double _call_impl(const int &x, const double &y) const {
+    return -(static_cast<double>(x) * 1000.0 + y);
+  }
+  double _call_impl(const double &x, const int &y) const {
+    return -(x * 1000.0 + static_cast<double>(y));
+  }
+
+  // Batch methods that use the scalar _call_impl
+  Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                    const std::vector<int> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<int> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+};
+
+TEST(test_variant_permutation, test_random_shuffle_covariance_correctness) {
+  IdentityCovariance cov;
+
+  // Create input with known values
+  using V = variant<int, double>;
+  std::vector<V> xs = {V(1), V(10.0), V(2), V(20.0), V(3)};
+  std::vector<V> ys = {V(100.0), V(4), V(200.0)};
+
+  // Compute via heterogeneous batch dispatch
+  Eigen::MatrixXd result = cov(xs, ys);
+
+  // Verify each element matches expected value
+  // result(i, j) should equal cov(xs[i], ys[j])
+  for (std::size_t i = 0; i < xs.size(); ++i) {
+    for (std::size_t j = 0; j < ys.size(); ++j) {
+      double expected = xs[i].match(
+          [&](int x) {
+            return ys[j].match([&](int y) { return cov._call_impl(x, y); },
+                               [&](double y) { return cov._call_impl(x, y); });
+          },
+          [&](double x) {
+            return ys[j].match([&](int y) { return cov._call_impl(x, y); },
+                               [&](double y) { return cov._call_impl(x, y); });
+          });
+      EXPECT_DOUBLE_EQ(result(cast::to_index(i), cast::to_index(j)), expected)
+          << "Mismatch at (" << i << ", " << j << ")";
+    }
+  }
+}
+
+/*
+ * Test heterogeneous symmetric covariance
+ *
+ * NOTE: Symmetric dispatch uses transpose optimization for off-diagonal blocks.
+ * This is correct for proper covariance functions where cov(X,Y) = cov(Y,X).
+ * We use a properly symmetric test covariance here.
+ */
+class SymmetricIdentityCovariance
+    : public CovarianceFunction<SymmetricIdentityCovariance> {
+public:
+  std::string name() const { return "symmetric_identity"; }
+
+  // Returns a symmetric value based on element identity
+  double _call_impl(const int &x, const int &y) const {
+    return static_cast<double>(x * y); // Symmetric: x*y = y*x
+  }
+  double _call_impl(const double &x, const double &y) const {
+    return x * y; // Symmetric
+  }
+  // Cross-type: use min/max to ensure symmetry
+  double _call_impl(const int &x, const double &y) const {
+    return static_cast<double>(x) * y; // Symmetric when called as (y, x)
+  }
+  double _call_impl(const double &x, const int &y) const {
+    return x * static_cast<double>(y); // Same as (int, double) version
+  }
+
+  // Batch methods
+  Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                    const std::vector<int> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<int> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+};
+
+TEST(test_variant_heterogeneous, test_heterogeneous_symmetric) {
+  SymmetricIdentityCovariance cov;
+
+  using V = variant<int, double>;
+  std::vector<V> xs = {V(1), V(10.0), V(2), V(20.0), V(3)};
+
+  // Compute via heterogeneous batch dispatch
+  Eigen::MatrixXd result = cov(xs);
+
+  // Verify each element matches expected value
+  for (std::size_t i = 0; i < xs.size(); ++i) {
+    for (std::size_t j = 0; j < xs.size(); ++j) {
+      double expected = xs[i].match(
+          [&](int x) {
+            return xs[j].match([&](int y) { return cov._call_impl(x, y); },
+                               [&](double y) { return cov._call_impl(x, y); });
+          },
+          [&](double x) {
+            return xs[j].match([&](int y) { return cov._call_impl(x, y); },
+                               [&](double y) { return cov._call_impl(x, y); });
+          });
+      EXPECT_DOUBLE_EQ(result(cast::to_index(i), cast::to_index(j)), expected)
+          << "Mismatch at (" << i << ", " << j << ")";
+    }
+  }
+
+  // Also verify the matrix is symmetric
+  for (std::size_t i = 0; i < xs.size(); ++i) {
+    for (std::size_t j = i + 1; j < xs.size(); ++j) {
+      EXPECT_DOUBLE_EQ(result(cast::to_index(i), cast::to_index(j)),
+                       result(cast::to_index(j), cast::to_index(i)))
+          << "Result should be symmetric at (" << i << ", " << j << ")";
+    }
+  }
+}
+
+/*
+ * Test element ordering is preserved (most critical test)
+ *
+ * This uses the symmetric covariance since the symmetric dispatch path
+ * uses transpose optimization which is valid for proper covariance functions.
+ */
+TEST(test_variant_heterogeneous, test_element_ordering_preserved) {
+  SymmetricIdentityCovariance cov;
+
+  using V = variant<int, double>;
+  // xs = [A(1), B(2.0), A(3)] where A=int, B=double
+  std::vector<V> xs = {V(1), V(2.0), V(3)};
+
+  Eigen::MatrixXd result = cov(xs);
+
+  // Verify result(0,0) corresponds to cov(1, 1), not cov(3, 1) or something else
+  EXPECT_DOUBLE_EQ(result(0, 0), cov._call_impl(1, 1))
+      << "result(0,0) should be cov(xs[0], xs[0]) = cov(1, 1)";
+  EXPECT_DOUBLE_EQ(result(0, 1), cov._call_impl(1, 2.0))
+      << "result(0,1) should be cov(xs[0], xs[1]) = cov(1, 2.0)";
+  EXPECT_DOUBLE_EQ(result(0, 2), cov._call_impl(1, 3))
+      << "result(0,2) should be cov(xs[0], xs[2]) = cov(1, 3)";
+  EXPECT_DOUBLE_EQ(result(1, 0), cov._call_impl(2.0, 1))
+      << "result(1,0) should be cov(xs[1], xs[0]) = cov(2.0, 1)";
+  EXPECT_DOUBLE_EQ(result(1, 1), cov._call_impl(2.0, 2.0))
+      << "result(1,1) should be cov(xs[1], xs[1]) = cov(2.0, 2.0)";
+  EXPECT_DOUBLE_EQ(result(2, 2), cov._call_impl(3, 3))
+      << "result(2,2) should be cov(xs[2], xs[2]) = cov(3, 3)";
+}
+
+/*
+ * Test that batch methods are called with correct block sizes
+ */
+/*
+ * BATCH VS POINTWISE EQUIVALENCE TESTS
+ *
+ * These tests verify that heterogeneous variant batch dispatch produces
+ * the same results as pointwise computation. We use a helper that forces
+ * pointwise evaluation to create a reference result.
+ */
+
+namespace {
+
+// Helper to compute covariance matrix using only pointwise calls
+// This bypasses all batch dispatch to create a reference result
+template <typename CovFunc, typename... Ts>
+Eigen::MatrixXd compute_pointwise_reference(
+    const CovFunc &cov, const std::vector<variant<Ts...>> &xs,
+    const std::vector<variant<Ts...>> &ys) {
+  const auto m = cast::to_index(xs.size());
+  const auto n = cast::to_index(ys.size());
+  Eigen::MatrixXd result(m, n);
+  for (Eigen::Index i = 0; i < m; ++i) {
+    for (Eigen::Index j = 0; j < n; ++j) {
+      // Use scalar operator() which goes through visitor dispatch
+      result(i, j) = cov(xs[cast::to_size(i)], ys[cast::to_size(j)]);
+    }
+  }
+  return result;
+}
+
+template <typename CovFunc, typename... Ts>
+Eigen::MatrixXd compute_pointwise_reference_symmetric(
+    const CovFunc &cov, const std::vector<variant<Ts...>> &xs) {
+  return compute_pointwise_reference(cov, xs, xs);
+}
+
+template <typename CovFunc, typename... Ts>
+Eigen::VectorXd compute_pointwise_reference_diagonal(
+    const CovFunc &cov, const std::vector<variant<Ts...>> &xs) {
+  const auto n = cast::to_index(xs.size());
+  Eigen::VectorXd result(n);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    result(i) = cov(xs[cast::to_size(i)], xs[cast::to_size(i)]);
+  }
+  return result;
+}
+
+} // anonymous namespace
+
+/*
+ * Test with a realistic multi-type covariance function
+ * Uses different formulas for different type combinations
+ */
+class MultiTypeCovariance : public CovarianceFunction<MultiTypeCovariance> {
+public:
+  std::string name() const { return "multi_type"; }
+
+  // int-int: squared exponential with length scale 10
+  double _call_impl(const int &x, const int &y) const {
+    double d = static_cast<double>(x - y);
+    return std::exp(-d * d / 100.0);
+  }
+
+  // double-double: squared exponential with length scale 5
+  double _call_impl(const double &x, const double &y) const {
+    double d = x - y;
+    return std::exp(-d * d / 25.0);
+  }
+
+  // int-double cross: linear covariance
+  double _call_impl(const int &x, const double &y) const {
+    return 0.1 * static_cast<double>(x) * y;
+  }
+
+  // double-int cross: symmetric with int-double
+  double _call_impl(const double &x, const int &y) const {
+    return 0.1 * x * static_cast<double>(y);
+  }
+
+  // Batch implementations that compute the same thing
+  Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                    const std::vector<int> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i) {
+      for (std::size_t j = 0; j < ys.size(); ++j) {
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+      }
+    }
+    return result;
+  }
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i) {
+      for (std::size_t j = 0; j < ys.size(); ++j) {
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+      }
+    }
+    return result;
+  }
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i) {
+      for (std::size_t j = 0; j < ys.size(); ++j) {
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+      }
+    }
+    return result;
+  }
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<int> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i) {
+      for (std::size_t j = 0; j < ys.size(); ++j) {
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+      }
+    }
+    return result;
+  }
+};
+
+TEST(test_batch_vs_pointwise, test_heterogeneous_cross_equivalence) {
+  MultiTypeCovariance cov;
+
+  using V = variant<int, double>;
+
+  // Create heterogeneous vectors with interleaved types
+  std::vector<V> xs = {V(1), V(2.5), V(3), V(4.5), V(5), V(6.5)};
+  std::vector<V> ys = {V(10.0), V(2), V(3.0), V(4)};
+
+  // Compute using batch dispatch
+  Eigen::MatrixXd batch_result = cov(xs, ys);
+
+  // Compute using pointwise reference
+  Eigen::MatrixXd pointwise_result = compute_pointwise_reference(cov, xs, ys);
+
+  // Verify dimensions
+  ASSERT_EQ(batch_result.rows(), pointwise_result.rows());
+  ASSERT_EQ(batch_result.cols(), pointwise_result.cols());
+
+  // Verify all elements match
+  for (Eigen::Index i = 0; i < batch_result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < batch_result.cols(); ++j) {
+      EXPECT_NEAR(batch_result(i, j), pointwise_result(i, j), 1e-12)
+          << "Mismatch at (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(test_batch_vs_pointwise, test_heterogeneous_symmetric_equivalence) {
+  MultiTypeCovariance cov;
+
+  using V = variant<int, double>;
+
+  // Create heterogeneous vector
+  std::vector<V> xs = {V(1), V(2.5), V(3), V(4.5), V(5)};
+
+  // Compute using batch dispatch (symmetric)
+  Eigen::MatrixXd batch_result = cov(xs);
+
+  // Compute using pointwise reference
+  Eigen::MatrixXd pointwise_result =
+      compute_pointwise_reference_symmetric(cov, xs);
+
+  // Verify dimensions
+  ASSERT_EQ(batch_result.rows(), pointwise_result.rows());
+  ASSERT_EQ(batch_result.cols(), pointwise_result.cols());
+
+  // Verify all elements match
+  for (Eigen::Index i = 0; i < batch_result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < batch_result.cols(); ++j) {
+      EXPECT_NEAR(batch_result(i, j), pointwise_result(i, j), 1e-12)
+          << "Mismatch at (" << i << ", " << j << ")";
+    }
+  }
+}
+
+TEST(test_batch_vs_pointwise, test_heterogeneous_diagonal_equivalence) {
+  MultiTypeCovariance cov;
+
+  using V = variant<int, double>;
+
+  std::vector<V> xs = {V(1), V(2.5), V(3), V(4.5), V(5), V(6.5), V(7)};
+
+  // Compute using batch dispatch (diagonal)
+  Eigen::VectorXd batch_result = cov.diagonal(xs);
+
+  // Compute using pointwise reference
+  Eigen::VectorXd pointwise_result =
+      compute_pointwise_reference_diagonal(cov, xs);
+
+  // Verify dimensions
+  ASSERT_EQ(batch_result.size(), pointwise_result.size());
+
+  // Verify all elements match
+  for (Eigen::Index i = 0; i < batch_result.size(); ++i) {
+    EXPECT_NEAR(batch_result(i), pointwise_result(i), 1e-12)
+        << "Mismatch at index " << i;
+  }
+}
+
+/*
+ * Test with Sum composite covariance
+ */
+TEST(test_batch_vs_pointwise, test_sum_heterogeneous_equivalence) {
+  MultiTypeCovariance cov1;
+  SymmetricIdentityCovariance cov2;
+  auto sum = cov1 + cov2;
+
+  using V = variant<int, double>;
+  std::vector<V> xs = {V(1), V(2.0), V(3), V(4.0)};
+  std::vector<V> ys = {V(5.0), V(6), V(7.0)};
+
+  // Batch computation
+  Eigen::MatrixXd batch_result = sum(xs, ys);
+
+  // Pointwise reference
+  Eigen::MatrixXd pointwise_result = compute_pointwise_reference(sum, xs, ys);
+
+  ASSERT_EQ(batch_result.rows(), pointwise_result.rows());
+  ASSERT_EQ(batch_result.cols(), pointwise_result.cols());
+
+  for (Eigen::Index i = 0; i < batch_result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < batch_result.cols(); ++j) {
+      EXPECT_NEAR(batch_result(i, j), pointwise_result(i, j), 1e-12)
+          << "Sum mismatch at (" << i << ", " << j << ")";
+    }
+  }
+}
+
+/*
+ * Test with Product composite covariance
+ */
+TEST(test_batch_vs_pointwise, test_product_heterogeneous_equivalence) {
+  MultiTypeCovariance cov1;
+  SymmetricIdentityCovariance cov2;
+  auto product = cov1 * cov2;
+
+  using V = variant<int, double>;
+  std::vector<V> xs = {V(1), V(2.0), V(3)};
+  std::vector<V> ys = {V(4.0), V(5)};
+
+  // Batch computation
+  Eigen::MatrixXd batch_result = product(xs, ys);
+
+  // Pointwise reference
+  Eigen::MatrixXd pointwise_result =
+      compute_pointwise_reference(product, xs, ys);
+
+  ASSERT_EQ(batch_result.rows(), pointwise_result.rows());
+  ASSERT_EQ(batch_result.cols(), pointwise_result.cols());
+
+  for (Eigen::Index i = 0; i < batch_result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < batch_result.cols(); ++j) {
+      EXPECT_NEAR(batch_result(i, j), pointwise_result(i, j), 1e-12)
+          << "Product mismatch at (" << i << ", " << j << ")";
+    }
+  }
+}
+
+/*
+ * Test with three types in the variant
+ */
+class ThreeTypeCovariance : public CovarianceFunction<ThreeTypeCovariance> {
+public:
+  std::string name() const { return "three_type"; }
+
+  // All type combinations for int, double, std::string
+  double _call_impl(const int &x, const int &y) const {
+    return static_cast<double>(x * y);
+  }
+  double _call_impl(const double &x, const double &y) const { return x * y; }
+  double _call_impl(const std::string &x, const std::string &y) const {
+    return static_cast<double>(x.size() * y.size());
+  }
+  double _call_impl(const int &x, const double &y) const {
+    return static_cast<double>(x) * y;
+  }
+  double _call_impl(const double &x, const int &y) const {
+    return x * static_cast<double>(y);
+  }
+  double _call_impl(const int &x, const std::string &y) const {
+    return static_cast<double>(x * static_cast<int>(y.size()));
+  }
+  double _call_impl(const std::string &x, const int &y) const {
+    return static_cast<double>(static_cast<int>(x.size()) * y);
+  }
+  double _call_impl(const double &x, const std::string &y) const {
+    return x * static_cast<double>(y.size());
+  }
+  double _call_impl(const std::string &x, const double &y) const {
+    return static_cast<double>(x.size()) * y;
+  }
+
+  // Batch for int-int
+  Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                    const std::vector<int> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  // Batch for double-double
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  // Batch for string-string
+  Eigen::MatrixXd _call_impl_vector(const std::vector<std::string> &xs,
+                                    const std::vector<std::string> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  // Batch for int-double
+  Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  // Batch for double-int
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<int> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  // Batch for int-string
+  Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                    const std::vector<std::string> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  // Batch for string-int
+  Eigen::MatrixXd _call_impl_vector(const std::vector<std::string> &xs,
+                                    const std::vector<int> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  // Batch for double-string
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<std::string> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+
+  // Batch for string-double
+  Eigen::MatrixXd _call_impl_vector(const std::vector<std::string> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *) const {
+    Eigen::MatrixXd result(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+    for (std::size_t i = 0; i < xs.size(); ++i)
+      for (std::size_t j = 0; j < ys.size(); ++j)
+        result(cast::to_index(i), cast::to_index(j)) = _call_impl(xs[i], ys[j]);
+    return result;
+  }
+};
+
+TEST(test_batch_vs_pointwise, test_three_type_heterogeneous_equivalence) {
+  ThreeTypeCovariance cov;
+
+  using V = variant<int, double, std::string>;
+
+  // Mix all three types
+  std::vector<V> xs = {V(1),     V(2.0),   V(std::string("abc")),
+                       V(3),     V(4.0),   V(std::string("de")),
+                       V(std::string("f"))};
+  std::vector<V> ys = {V(std::string("gh")), V(5), V(6.0), V(std::string("ijk")), V(7)};
+
+  // Batch computation
+  Eigen::MatrixXd batch_result = cov(xs, ys);
+
+  // Pointwise reference
+  Eigen::MatrixXd pointwise_result = compute_pointwise_reference(cov, xs, ys);
+
+  ASSERT_EQ(batch_result.rows(), pointwise_result.rows());
+  ASSERT_EQ(batch_result.cols(), pointwise_result.cols());
+
+  for (Eigen::Index i = 0; i < batch_result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < batch_result.cols(); ++j) {
+      EXPECT_NEAR(batch_result(i, j), pointwise_result(i, j), 1e-12)
+          << "Three-type mismatch at (" << i << ", " << j << ")";
+    }
+  }
+
+  // Also test symmetric
+  Eigen::MatrixXd sym_batch = cov(xs);
+  Eigen::MatrixXd sym_pointwise = compute_pointwise_reference_symmetric(cov, xs);
+
+  for (Eigen::Index i = 0; i < sym_batch.rows(); ++i) {
+    for (Eigen::Index j = 0; j < sym_batch.cols(); ++j) {
+      EXPECT_NEAR(sym_batch(i, j), sym_pointwise(i, j), 1e-12)
+          << "Three-type symmetric mismatch at (" << i << ", " << j << ")";
+    }
+  }
+}
+
+/*
+ * Test edge cases: empty partitions (some types have no elements)
+ */
+TEST(test_batch_vs_pointwise, test_empty_partitions_equivalence) {
+  ThreeTypeCovariance cov;
+
+  using V = variant<int, double, std::string>;
+
+  // Only ints in xs, mix in ys (double partition empty in xs)
+  std::vector<V> xs = {V(1), V(2), V(3)};
+  std::vector<V> ys = {V(4.0), V(5), V(std::string("ab"))};
+
+  Eigen::MatrixXd batch_result = cov(xs, ys);
+  Eigen::MatrixXd pointwise_result = compute_pointwise_reference(cov, xs, ys);
+
+  for (Eigen::Index i = 0; i < batch_result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < batch_result.cols(); ++j) {
+      EXPECT_NEAR(batch_result(i, j), pointwise_result(i, j), 1e-12)
+          << "Empty partition mismatch at (" << i << ", " << j << ")";
+    }
+  }
+}
+
+/*
+ * Test with Measurement wrapper
+ */
+TEST(test_batch_vs_pointwise, test_measurement_heterogeneous_equivalence) {
+  MultiTypeCovariance cov;
+
+  using V = variant<int, double>;
+  using MV = variant<Measurement<int>, Measurement<double>>;
+
+  // Create measurements
+  std::vector<MV> xs = {MV(Measurement<int>{1}), MV(Measurement<double>{2.0}),
+                        MV(Measurement<int>{3}), MV(Measurement<double>{4.0})};
+  std::vector<MV> ys = {MV(Measurement<double>{5.0}), MV(Measurement<int>{6}),
+                        MV(Measurement<double>{7.0})};
+
+  // Batch computation
+  Eigen::MatrixXd batch_result = cov(xs, ys);
+
+  // Pointwise reference
+  Eigen::MatrixXd pointwise_result = compute_pointwise_reference(cov, xs, ys);
+
+  ASSERT_EQ(batch_result.rows(), pointwise_result.rows());
+  ASSERT_EQ(batch_result.cols(), pointwise_result.cols());
+
+  for (Eigen::Index i = 0; i < batch_result.rows(); ++i) {
+    for (Eigen::Index j = 0; j < batch_result.cols(); ++j) {
+      EXPECT_NEAR(batch_result(i, j), pointwise_result(i, j), 1e-12)
+          << "Measurement mismatch at (" << i << ", " << j << ")";
+    }
+  }
+}
+
+/*
+ * Test large heterogeneous vectors (stress test)
+ */
+TEST(test_batch_vs_pointwise, test_large_heterogeneous_equivalence) {
+  MultiTypeCovariance cov;
+
+  using V = variant<int, double>;
+
+  // Create larger vectors with random-ish interleaving
+  std::vector<V> xs;
+  std::vector<V> ys;
+
+  for (int i = 0; i < 50; ++i) {
+    if (i % 3 == 0) {
+      xs.push_back(V(i));
+    } else {
+      xs.push_back(V(static_cast<double>(i) * 0.5));
+    }
+  }
+
+  for (int j = 0; j < 40; ++j) {
+    if (j % 2 == 0) {
+      ys.push_back(V(j * 2));
+    } else {
+      ys.push_back(V(static_cast<double>(j) * 1.5));
+    }
+  }
+
+  // Batch computation
+  Eigen::MatrixXd batch_result = cov(xs, ys);
+
+  // Pointwise reference
+  Eigen::MatrixXd pointwise_result = compute_pointwise_reference(cov, xs, ys);
+
+  ASSERT_EQ(batch_result.rows(), cast::to_index(xs.size()));
+  ASSERT_EQ(batch_result.cols(), cast::to_index(ys.size()));
+
+  double max_diff = (batch_result - pointwise_result).cwiseAbs().maxCoeff();
+  EXPECT_LT(max_diff, 1e-12)
+      << "Large heterogeneous test: max difference = " << max_diff;
+}
+
+/*
+ * Test that batch methods are called with correct block sizes
+ */
+TEST(test_variant_heterogeneous, test_batch_call_counts) {
+  class BlockCountingCovariance
+      : public CovarianceFunction<BlockCountingCovariance> {
+  public:
+    std::string name() const { return "block_counting"; }
+
+    mutable int int_int_calls = 0;
+    mutable int double_double_calls = 0;
+    mutable int int_double_calls = 0;
+    mutable int double_int_calls = 0;
+
+    void reset() const {
+      int_int_calls = 0;
+      double_double_calls = 0;
+      int_double_calls = 0;
+      double_int_calls = 0;
+    }
+
+    double _call_impl(const int &x, const int &y) const {
+      return static_cast<double>(x + y);
+    }
+    double _call_impl(const double &x, const double &y) const { return x + y; }
+    double _call_impl(const int &x, const double &y) const {
+      return static_cast<double>(x) + y;
+    }
+    double _call_impl(const double &x, const int &y) const {
+      return x + static_cast<double>(y);
+    }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                      const std::vector<int> &ys,
+                                      ThreadPool *) const {
+      int_int_calls++;
+      Eigen::MatrixXd result(cast::to_index(xs.size()),
+                             cast::to_index(ys.size()));
+      for (std::size_t i = 0; i < xs.size(); ++i)
+        for (std::size_t j = 0; j < ys.size(); ++j)
+          result(cast::to_index(i), cast::to_index(j)) =
+              _call_impl(xs[i], ys[j]);
+      return result;
+    }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *) const {
+      double_double_calls++;
+      Eigen::MatrixXd result(cast::to_index(xs.size()),
+                             cast::to_index(ys.size()));
+      for (std::size_t i = 0; i < xs.size(); ++i)
+        for (std::size_t j = 0; j < ys.size(); ++j)
+          result(cast::to_index(i), cast::to_index(j)) =
+              _call_impl(xs[i], ys[j]);
+      return result;
+    }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<int> &xs,
+                                      const std::vector<double> &ys,
+                                      ThreadPool *) const {
+      int_double_calls++;
+      Eigen::MatrixXd result(cast::to_index(xs.size()),
+                             cast::to_index(ys.size()));
+      for (std::size_t i = 0; i < xs.size(); ++i)
+        for (std::size_t j = 0; j < ys.size(); ++j)
+          result(cast::to_index(i), cast::to_index(j)) =
+              _call_impl(xs[i], ys[j]);
+      return result;
+    }
+
+    Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                      const std::vector<int> &ys,
+                                      ThreadPool *) const {
+      double_int_calls++;
+      Eigen::MatrixXd result(cast::to_index(xs.size()),
+                             cast::to_index(ys.size()));
+      for (std::size_t i = 0; i < xs.size(); ++i)
+        for (std::size_t j = 0; j < ys.size(); ++j)
+          result(cast::to_index(i), cast::to_index(j)) =
+              _call_impl(xs[i], ys[j]);
+      return result;
+    }
+  };
+
+  BlockCountingCovariance cov;
+
+  using V = variant<int, double>;
+  // 3 ints, 2 doubles
+  std::vector<V> xs = {V(1), V(10.0), V(2), V(20.0), V(3)};
+
+  // Test symmetric case: cov(xs, xs)
+  cov.reset();
+  Eigen::MatrixXd sym_result = cov(xs);
+
+  // For symmetric heterogeneous with transpose optimization:
+  // - 1 call for int-int diagonal block (3x3)
+  // - 1 call for double-double diagonal block (2x2)
+  // - 1 call for int-double off-diagonal block (3x2), transposed for double-int
+  // - 0 calls for double-int (filled by transpose of int-double)
+  EXPECT_EQ(cov.int_int_calls, 1) << "int-int batch should be called once";
+  EXPECT_EQ(cov.double_double_calls, 1)
+      << "double-double batch should be called once";
+  EXPECT_EQ(cov.int_double_calls, 1)
+      << "int-double batch should be called exactly once";
+  EXPECT_EQ(cov.double_int_calls, 0)
+      << "double-int should NOT be called (filled by transpose)";
+
+  // Test cross-covariance case: cov(xs, ys) where ys is different
+  std::vector<V> ys = {V(100), V(200.0), V(300)};  // 2 ints, 1 double
+
+  cov.reset();
+  Eigen::MatrixXd cross_result = cov(xs, ys);
+
+  // For cross-covariance (no transpose optimization):
+  // - 1 call for int-int block (3x2)
+  // - 1 call for double-double block (2x1)
+  // - 1 call for int-double block (3x1)
+  // - 1 call for double-int block (2x2)
+  EXPECT_EQ(cov.int_int_calls, 1) << "cross: int-int batch should be called once";
+  EXPECT_EQ(cov.double_double_calls, 1)
+      << "cross: double-double batch should be called once";
+  EXPECT_EQ(cov.int_double_calls, 1)
+      << "cross: int-double batch should be called once";
+  EXPECT_EQ(cov.double_int_calls, 1)
+      << "cross: double-int batch should be called once";
+}
+
+/*
+ * ============================================================================
+ * THREAD POOL PROPAGATION TESTS
+ *
+ * These tests verify that ThreadPool* is correctly propagated through:
+ * - Sum/Product compositions
+ * - Nested compositions
+ * - Measurement unwrapping
+ * - Variant unwrapping
+ * - diagonal() calls
+ * ============================================================================
+ */
+
+/*
+ * PoolCallRecord: captures information about a single pool-related call
+ */
+struct PoolCallRecord {
+  ThreadPool *pool_received;
+  std::size_t thread_count;
+  bool was_nonnull;
+  std::string call_type;  // "vector", "diagonal", "symmetric"
+};
+
+/*
+ * PoolTrackingCovariance: records pool information for each batch call.
+ * Uses shared_ptr to survive copies in Sum/Product compositions.
+ */
+class PoolTrackingCovariance
+    : public CovarianceFunction<PoolTrackingCovariance> {
+public:
+  std::string name() const { return "pool_tracking"; }
+
+  // Shared record storage that survives copies
+  std::shared_ptr<std::vector<PoolCallRecord>> records =
+      std::make_shared<std::vector<PoolCallRecord>>();
+
+  void reset() const { records->clear(); }
+
+  // Batch implementation that records pool info
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *pool) const {
+    PoolCallRecord record;
+    record.pool_received = pool;
+    record.was_nonnull = (pool != nullptr);
+    record.thread_count = pool ? pool->thread_count() : 0;
+    record.call_type = (xs.data() == ys.data()) ? "symmetric" : "vector";
+    records->push_back(record);
+    return Eigen::MatrixXd::Constant(cast::to_index(xs.size()),
+                                     cast::to_index(ys.size()), 1.0);
+  }
+
+  // Diagonal batch implementation that records pool info
+  Eigen::VectorXd _call_impl_vector_diagonal(const std::vector<double> &xs,
+                                             ThreadPool *pool) const {
+    PoolCallRecord record;
+    record.pool_received = pool;
+    record.was_nonnull = (pool != nullptr);
+    record.thread_count = pool ? pool->thread_count() : 0;
+    record.call_type = "diagonal";
+    records->push_back(record);
+    return Eigen::VectorXd::Constant(cast::to_index(xs.size()), 1.0);
+  }
+};
+
+/*
+ * Test 1: Basic pool propagation - verify pool reaches batch method
+ */
+TEST(test_pool_propagation, test_basic_pool_propagation) {
+  PoolTrackingCovariance cov;
+  cov.reset();
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+
+  // Call without pool
+  cov(xs);
+  ASSERT_EQ(cov.records->size(), 1u);
+  EXPECT_FALSE(cov.records->at(0).was_nonnull) << "nullptr should propagate";
+
+  // Call with pool
+  cov.reset();
+  ThreadPool pool(4);
+  cov(xs, &pool);
+  ASSERT_EQ(cov.records->size(), 1u);
+  EXPECT_TRUE(cov.records->at(0).was_nonnull) << "Pool should propagate";
+  EXPECT_EQ(cov.records->at(0).thread_count, 4u);
+}
+
+/*
+ * Test 2: Sum composition - both children receive pool
+ */
+TEST(test_pool_propagation, test_sum_both_batch_receives_pool) {
+  PoolTrackingCovariance lhs;
+  PoolTrackingCovariance rhs;
+  lhs.reset();
+  rhs.reset();
+
+  auto sum = lhs + rhs;
+
+  std::vector<double> xs = {1.0, 2.0};
+  ThreadPool pool(8);
+
+  sum(xs, &pool);
+
+  // Both sides should receive the pool
+  ASSERT_EQ(lhs.records->size(), 1u);
+  ASSERT_EQ(rhs.records->size(), 1u);
+  EXPECT_TRUE(lhs.records->at(0).was_nonnull) << "LHS should receive pool";
+  EXPECT_TRUE(rhs.records->at(0).was_nonnull) << "RHS should receive pool";
+  EXPECT_EQ(lhs.records->at(0).thread_count, 8u);
+  EXPECT_EQ(rhs.records->at(0).thread_count, 8u);
+}
+
+/*
+ * Test 3: Product composition - both children receive pool
+ */
+TEST(test_pool_propagation, test_product_both_batch_receives_pool) {
+  PoolTrackingCovariance lhs;
+  PoolTrackingCovariance rhs;
+  lhs.reset();
+  rhs.reset();
+
+  auto product = lhs * rhs;
+
+  std::vector<double> xs = {1.0, 2.0};
+  ThreadPool pool(6);
+
+  product(xs, &pool);
+
+  // Both sides should receive the pool
+  ASSERT_EQ(lhs.records->size(), 1u);
+  ASSERT_EQ(rhs.records->size(), 1u);
+  EXPECT_TRUE(lhs.records->at(0).was_nonnull) << "LHS should receive pool";
+  EXPECT_TRUE(rhs.records->at(0).was_nonnull) << "RHS should receive pool";
+  EXPECT_EQ(lhs.records->at(0).thread_count, 6u);
+  EXPECT_EQ(rhs.records->at(0).thread_count, 6u);
+}
+
+/*
+ * Test 4: Nested composition - all covariances receive pool
+ */
+TEST(test_pool_propagation, test_nested_composition_receives_pool) {
+  PoolTrackingCovariance cov1;
+  PoolTrackingCovariance cov2;
+  PoolTrackingCovariance cov3;
+  cov1.reset();
+  cov2.reset();
+  cov3.reset();
+
+  // (cov1 + cov2) * cov3
+  auto composed = (cov1 + cov2) * cov3;
+
+  std::vector<double> xs = {1.0, 2.0};
+  ThreadPool pool(5);
+
+  composed(xs, &pool);
+
+  // All three should receive the pool
+  ASSERT_EQ(cov1.records->size(), 1u);
+  ASSERT_EQ(cov2.records->size(), 1u);
+  ASSERT_EQ(cov3.records->size(), 1u);
+  EXPECT_TRUE(cov1.records->at(0).was_nonnull) << "cov1 should receive pool";
+  EXPECT_TRUE(cov2.records->at(0).was_nonnull) << "cov2 should receive pool";
+  EXPECT_TRUE(cov3.records->at(0).was_nonnull) << "cov3 should receive pool";
+  EXPECT_EQ(cov1.records->at(0).thread_count, 5u);
+  EXPECT_EQ(cov2.records->at(0).thread_count, 5u);
+  EXPECT_EQ(cov3.records->at(0).thread_count, 5u);
+}
+
+/*
+ * Test 5: Sum with mixed batch/pointwise - batch side gets pool
+ */
+TEST(test_pool_propagation, test_sum_mixed_batch_pointwise) {
+  PoolTrackingCovariance batch_cov;
+  batch_cov.reset();
+
+  class PointwiseOnlyCov : public CovarianceFunction<PointwiseOnlyCov> {
+  public:
+    std::string name() const { return "pointwise_only"; }
+    double _call_impl(const double &x, const double &y) const { return x * y; }
+  };
+  PointwiseOnlyCov pointwise_cov;
+
+  auto sum = batch_cov + pointwise_cov;
+
+  std::vector<double> xs = {1.0, 2.0};
+  ThreadPool pool(3);
+
+  sum(xs, &pool);
+
+  // Batch side should receive the pool
+  ASSERT_EQ(batch_cov.records->size(), 1u);
+  EXPECT_TRUE(batch_cov.records->at(0).was_nonnull)
+      << "Batch side should receive pool";
+  EXPECT_EQ(batch_cov.records->at(0).thread_count, 3u);
+}
+
+/*
+ * Test 6: No pool propagates nullptr
+ */
+TEST(test_pool_propagation, test_no_pool_propagates_nullptr) {
+  PoolTrackingCovariance cov1;
+  PoolTrackingCovariance cov2;
+  cov1.reset();
+  cov2.reset();
+
+  auto sum = cov1 + cov2;
+
+  std::vector<double> xs = {1.0, 2.0};
+
+  sum(xs);  // No pool
+
+  // Both should receive nullptr
+  ASSERT_EQ(cov1.records->size(), 1u);
+  ASSERT_EQ(cov2.records->size(), 1u);
+  EXPECT_FALSE(cov1.records->at(0).was_nonnull) << "cov1 should receive nullptr";
+  EXPECT_FALSE(cov2.records->at(0).was_nonnull) << "cov2 should receive nullptr";
+}
+
+/*
+ * Test 7: Cross-covariance receives pool
+ */
+TEST(test_pool_propagation, test_cross_covariance_receives_pool) {
+  PoolTrackingCovariance cov;
+  cov.reset();
+
+  std::vector<double> xs = {1.0, 2.0};
+  std::vector<double> ys = {3.0, 4.0, 5.0};
+  ThreadPool pool(7);
+
+  cov(xs, ys, &pool);
+
+  ASSERT_EQ(cov.records->size(), 1u);
+  EXPECT_TRUE(cov.records->at(0).was_nonnull);
+  EXPECT_EQ(cov.records->at(0).thread_count, 7u);
+  EXPECT_EQ(cov.records->at(0).call_type, "vector");
+}
+
+/*
+ * Test 8: diagonal() receives pool (requires fix to diagonal signature)
+ */
+TEST(test_pool_propagation, test_diagonal_receives_pool) {
+  PoolTrackingCovariance cov;
+  cov.reset();
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  ThreadPool pool(4);
+
+  cov.diagonal(xs, &pool);
+
+  ASSERT_EQ(cov.records->size(), 1u);
+  EXPECT_TRUE(cov.records->at(0).was_nonnull)
+      << "diagonal() should pass pool to _call_impl_vector_diagonal";
+  EXPECT_EQ(cov.records->at(0).thread_count, 4u);
+  EXPECT_EQ(cov.records->at(0).call_type, "diagonal");
+}
+
+/*
+ * Test 9: Sum diagonal - both batch children receive pool
+ */
+TEST(test_pool_propagation, test_sum_diagonal_both_batch_receives_pool) {
+  PoolTrackingCovariance lhs;
+  PoolTrackingCovariance rhs;
+  lhs.reset();
+  rhs.reset();
+
+  auto sum = lhs + rhs;
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  ThreadPool pool(4);
+
+  sum.diagonal(xs, &pool);
+
+  // Both sides should receive the pool for diagonal
+  ASSERT_EQ(lhs.records->size(), 1u);
+  ASSERT_EQ(rhs.records->size(), 1u);
+  EXPECT_TRUE(lhs.records->at(0).was_nonnull)
+      << "LHS diagonal should receive pool";
+  EXPECT_TRUE(rhs.records->at(0).was_nonnull)
+      << "RHS diagonal should receive pool";
+  EXPECT_EQ(lhs.records->at(0).thread_count, 4u);
+  EXPECT_EQ(rhs.records->at(0).thread_count, 4u);
+  EXPECT_EQ(lhs.records->at(0).call_type, "diagonal");
+  EXPECT_EQ(rhs.records->at(0).call_type, "diagonal");
+}
+
+/*
+ * Test 10: Measurement unwrap propagates pool
+ */
+TEST(test_pool_propagation, test_measurement_unwrap_propagates_pool) {
+  PoolTrackingCovariance cov;
+  cov.reset();
+
+  std::vector<Measurement<double>> ms;
+  for (int i = 0; i < 10; ++i) {
+    ms.push_back(Measurement<double>{static_cast<double>(i)});
+  }
+
+  ThreadPool pool(6);
+  cov(ms, &pool);
+
+  ASSERT_EQ(cov.records->size(), 1u);
+  EXPECT_TRUE(cov.records->at(0).was_nonnull)
+      << "Measurement unwrap should propagate pool";
+  EXPECT_EQ(cov.records->at(0).thread_count, 6u);
+}
+
+/*
+ * Test 11: Variant unwrap propagates pool
+ */
+TEST(test_pool_propagation, test_variant_unwrap_propagates_pool) {
+  PoolTrackingCovariance cov;
+  cov.reset();
+
+  using DoubleVariant = variant<double>;
+  std::vector<DoubleVariant> xs(10, DoubleVariant(1.0));
+
+  ThreadPool pool(5);
+  cov(xs, &pool);
+
+  ASSERT_EQ(cov.records->size(), 1u);
+  EXPECT_TRUE(cov.records->at(0).was_nonnull)
+      << "Variant unwrap should propagate pool";
+  EXPECT_EQ(cov.records->at(0).thread_count, 5u);
+}
+
+/*
+ * Test 12: Sum with variant<Measurement<double>> receives pool
+ * Complex type unwrapping: variant<Measurement<double>> -> Measurement<double> -> double
+ */
+TEST(test_pool_propagation, test_sum_with_variant_measurement_receives_pool) {
+  PoolTrackingCovariance lhs;
+  PoolTrackingCovariance rhs;
+  lhs.reset();
+  rhs.reset();
+
+  auto sum = lhs + rhs;
+
+  using VariantMeasurement = variant<Measurement<double>>;
+  std::vector<VariantMeasurement> ms;
+  for (int i = 0; i < 10; ++i) {
+    ms.push_back(VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
+  }
+
+  ThreadPool pool(4);
+  sum(ms, &pool);
+
+  // Both sides should receive the pool after unwrapping
+  ASSERT_EQ(lhs.records->size(), 1u);
+  ASSERT_EQ(rhs.records->size(), 1u);
+  EXPECT_TRUE(lhs.records->at(0).was_nonnull)
+      << "LHS should receive pool through variant<Measurement>";
+  EXPECT_TRUE(rhs.records->at(0).was_nonnull)
+      << "RHS should receive pool through variant<Measurement>";
+  EXPECT_EQ(lhs.records->at(0).thread_count, 4u);
+  EXPECT_EQ(rhs.records->at(0).thread_count, 4u);
+}
+
+/*
+ * Test 13: Product with variant<Measurement<double>> receives pool
+ */
+TEST(test_pool_propagation, test_product_with_variant_measurement_receives_pool) {
+  PoolTrackingCovariance lhs;
+  PoolTrackingCovariance rhs;
+  lhs.reset();
+  rhs.reset();
+
+  auto product = lhs * rhs;
+
+  using VariantMeasurement = variant<Measurement<double>>;
+  std::vector<VariantMeasurement> ms;
+  for (int i = 0; i < 8; ++i) {
+    ms.push_back(VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
+  }
+
+  ThreadPool pool(3);
+  product(ms, &pool);
+
+  ASSERT_EQ(lhs.records->size(), 1u);
+  ASSERT_EQ(rhs.records->size(), 1u);
+  EXPECT_TRUE(lhs.records->at(0).was_nonnull);
+  EXPECT_TRUE(rhs.records->at(0).was_nonnull);
+  EXPECT_EQ(lhs.records->at(0).thread_count, 3u);
+  EXPECT_EQ(rhs.records->at(0).thread_count, 3u);
+}
+
+/*
+ * Test 14: Nested Sum+Product with variant<Measurement<double>>
+ * (cov1 + cov2) * cov3 with complex types
+ */
+TEST(test_pool_propagation,
+     test_nested_sum_product_variant_measurement) {
+  PoolTrackingCovariance cov1;
+  PoolTrackingCovariance cov2;
+  PoolTrackingCovariance cov3;
+  cov1.reset();
+  cov2.reset();
+  cov3.reset();
+
+  auto composed = (cov1 + cov2) * cov3;
+
+  using VariantMeasurement = variant<Measurement<double>>;
+  std::vector<VariantMeasurement> ms;
+  for (int i = 0; i < 5; ++i) {
+    ms.push_back(VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
+  }
+
+  ThreadPool pool(7);
+  composed(ms, &pool);
+
+  ASSERT_EQ(cov1.records->size(), 1u);
+  ASSERT_EQ(cov2.records->size(), 1u);
+  ASSERT_EQ(cov3.records->size(), 1u);
+  EXPECT_TRUE(cov1.records->at(0).was_nonnull);
+  EXPECT_TRUE(cov2.records->at(0).was_nonnull);
+  EXPECT_TRUE(cov3.records->at(0).was_nonnull);
+  EXPECT_EQ(cov1.records->at(0).thread_count, 7u);
+  EXPECT_EQ(cov2.records->at(0).thread_count, 7u);
+  EXPECT_EQ(cov3.records->at(0).thread_count, 7u);
+}
+
+/*
+ * Test 15: Deep composition with variant<Measurement<double>>
+ * ((cov1 * cov2) + cov3) * cov4
+ */
+TEST(test_pool_propagation,
+     test_deep_composition_variant_measurement) {
+  PoolTrackingCovariance cov1;
+  PoolTrackingCovariance cov2;
+  PoolTrackingCovariance cov3;
+  PoolTrackingCovariance cov4;
+  cov1.reset();
+  cov2.reset();
+  cov3.reset();
+  cov4.reset();
+
+  auto composed = ((cov1 * cov2) + cov3) * cov4;
+
+  using VariantMeasurement = variant<Measurement<double>>;
+  std::vector<VariantMeasurement> ms;
+  for (int i = 0; i < 6; ++i) {
+    ms.push_back(VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
+  }
+
+  ThreadPool pool(9);
+  composed(ms, &pool);
+
+  ASSERT_EQ(cov1.records->size(), 1u);
+  ASSERT_EQ(cov2.records->size(), 1u);
+  ASSERT_EQ(cov3.records->size(), 1u);
+  ASSERT_EQ(cov4.records->size(), 1u);
+  EXPECT_TRUE(cov1.records->at(0).was_nonnull);
+  EXPECT_TRUE(cov2.records->at(0).was_nonnull);
+  EXPECT_TRUE(cov3.records->at(0).was_nonnull);
+  EXPECT_TRUE(cov4.records->at(0).was_nonnull);
+  EXPECT_EQ(cov1.records->at(0).thread_count, 9u);
+  EXPECT_EQ(cov2.records->at(0).thread_count, 9u);
+  EXPECT_EQ(cov3.records->at(0).thread_count, 9u);
+  EXPECT_EQ(cov4.records->at(0).thread_count, 9u);
+}
+
+/*
+ * Test 16: Sum cross-covariance with variant<Measurement<double>>
+ * sum(xs, ys, pool) where xs and ys are vectors of variant<Measurement<double>>
+ */
+TEST(test_pool_propagation,
+     test_sum_cross_covariance_variant_measurement) {
+  PoolTrackingCovariance lhs;
+  PoolTrackingCovariance rhs;
+  lhs.reset();
+  rhs.reset();
+
+  auto sum = lhs + rhs;
+
+  using VariantMeasurement = variant<Measurement<double>>;
+  std::vector<VariantMeasurement> xs;
+  std::vector<VariantMeasurement> ys;
+  for (int i = 0; i < 4; ++i) {
+    xs.push_back(VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
+  }
+  for (int i = 0; i < 6; ++i) {
+    ys.push_back(
+        VariantMeasurement(Measurement<double>{static_cast<double>(i + 10)}));
+  }
+
+  ThreadPool pool(5);
+  sum(xs, ys, &pool);
+
+  ASSERT_EQ(lhs.records->size(), 1u);
+  ASSERT_EQ(rhs.records->size(), 1u);
+  EXPECT_TRUE(lhs.records->at(0).was_nonnull)
+      << "LHS cross-cov should receive pool";
+  EXPECT_TRUE(rhs.records->at(0).was_nonnull)
+      << "RHS cross-cov should receive pool";
+  EXPECT_EQ(lhs.records->at(0).thread_count, 5u);
+  EXPECT_EQ(rhs.records->at(0).thread_count, 5u);
+}
+
+/*
+ * Test 17: Product diagonal receives pool
+ */
+TEST(test_pool_propagation, test_product_diagonal_both_batch_receives_pool) {
+  PoolTrackingCovariance lhs;
+  PoolTrackingCovariance rhs;
+  lhs.reset();
+  rhs.reset();
+
+  auto product = lhs * rhs;
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  ThreadPool pool(4);
+
+  product.diagonal(xs, &pool);
+
+  // Both sides should receive the pool for diagonal
+  ASSERT_EQ(lhs.records->size(), 1u);
+  ASSERT_EQ(rhs.records->size(), 1u);
+  EXPECT_TRUE(lhs.records->at(0).was_nonnull)
+      << "LHS product diagonal should receive pool";
+  EXPECT_TRUE(rhs.records->at(0).was_nonnull)
+      << "RHS product diagonal should receive pool";
+  EXPECT_EQ(lhs.records->at(0).thread_count, 4u);
+  EXPECT_EQ(rhs.records->at(0).thread_count, 4u);
+}
+
+/*
+ * Test 18: Diagonal with variant type receives pool
+ */
+TEST(test_pool_propagation, test_diagonal_with_variant_receives_pool) {
+  PoolTrackingCovariance cov;
+  cov.reset();
+
+  using DoubleVariant = variant<double>;
+  std::vector<DoubleVariant> xs(10, DoubleVariant(1.0));
+
+  ThreadPool pool(6);
+  cov.diagonal(xs, &pool);
+
+  ASSERT_EQ(cov.records->size(), 1u);
+  EXPECT_TRUE(cov.records->at(0).was_nonnull)
+      << "Diagonal with variant should receive pool";
+  EXPECT_EQ(cov.records->at(0).thread_count, 6u);
+  EXPECT_EQ(cov.records->at(0).call_type, "diagonal");
+}
+
+/*
+ * Test 19: Diagonal with Measurement type receives pool
+ */
+TEST(test_pool_propagation, test_diagonal_with_measurement_receives_pool) {
+  PoolTrackingCovariance cov;
+  cov.reset();
+
+  std::vector<Measurement<double>> ms;
+  for (int i = 0; i < 8; ++i) {
+    ms.push_back(Measurement<double>{static_cast<double>(i)});
+  }
+
+  ThreadPool pool(3);
+  cov.diagonal(ms, &pool);
+
+  ASSERT_EQ(cov.records->size(), 1u);
+  EXPECT_TRUE(cov.records->at(0).was_nonnull)
+      << "Diagonal with Measurement should receive pool";
+  EXPECT_EQ(cov.records->at(0).thread_count, 3u);
+  EXPECT_EQ(cov.records->at(0).call_type, "diagonal");
+}
+
+/*
+ * ============================================================================
+ * SINGLE-ARG SYMMETRIC BATCH TESTS
+ * Tests for _call_impl_vector(const std::vector<X>&, ThreadPool*) support
+ * ============================================================================
+ */
+
+// Stats for tracking single-arg vs two-arg batch calls
+struct SingleArgBatchCallStats {
+  int single_arg_count = 0;
+  int two_arg_count = 0;
+  int last_xs_size = 0;
+  bool pool_was_nonnull = false;
+  void reset() {
+    single_arg_count = two_arg_count = last_xs_size = 0;
+    pool_was_nonnull = false;
+  }
+};
+
+// Mock with BOTH single-arg and two-arg batch
+class MockSingleArgBatchCov : public CovarianceFunction<MockSingleArgBatchCov> {
+public:
+  std::string name() const { return "mock_single_arg_batch"; }
+  std::shared_ptr<SingleArgBatchCallStats> stats =
+      std::make_shared<SingleArgBatchCallStats>();
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    ThreadPool *pool) const {
+    stats->single_arg_count++;
+    stats->last_xs_size = static_cast<int>(xs.size());
+    stats->pool_was_nonnull = (pool != nullptr);
+    return Eigen::MatrixXd::Constant(cast::to_index(xs.size()),
+                                     cast::to_index(xs.size()), 777.0);
+  }
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    const std::vector<double> &ys,
+                                    ThreadPool *pool) const {
+    stats->two_arg_count++;
+    return Eigen::MatrixXd::Constant(cast::to_index(xs.size()),
+                                     cast::to_index(ys.size()), 888.0);
+  }
+};
+
+// Mock with ONLY single-arg batch (no pointwise, no two-arg)
+class MockSingleArgOnlyCov : public CovarianceFunction<MockSingleArgOnlyCov> {
+public:
+  std::string name() const { return "mock_single_arg_only"; }
+  std::shared_ptr<SingleArgBatchCallStats> stats =
+      std::make_shared<SingleArgBatchCallStats>();
+
+  Eigen::MatrixXd _call_impl_vector(const std::vector<double> &xs,
+                                    ThreadPool *pool) const {
+    stats->single_arg_count++;
+    stats->last_xs_size = static_cast<int>(xs.size());
+    stats->pool_was_nonnull = (pool != nullptr);
+    return Eigen::MatrixXd::Constant(cast::to_index(xs.size()),
+                                     cast::to_index(xs.size()), 333.0);
+  }
+};
+
+/*
+ * BASIC TEST 1: Single-arg should be preferred over two-arg for cov(xs)
+ */
+TEST(test_single_arg_symmetric, test_prefers_single_arg_over_two_arg) {
+  MockSingleArgBatchCov cov;
+  cov.stats->reset();
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  Eigen::MatrixXd result = cov(xs);  // Symmetric call
+
+  EXPECT_EQ(cov.stats->single_arg_count, 1) << "Single-arg should be called";
+  EXPECT_EQ(cov.stats->two_arg_count, 0) << "Two-arg should NOT be called";
+  EXPECT_EQ(result(0, 0), 777.0) << "Result should be from single-arg";
+}
+
+/*
+ * BASIC TEST 2: Single-arg-only covariance should work
+ */
+TEST(test_single_arg_symmetric, test_single_arg_only) {
+  MockSingleArgOnlyCov cov;
+  cov.stats->reset();
+
+  std::vector<double> xs = {1.0, 2.0};
+  Eigen::MatrixXd result = cov(xs);
+
+  EXPECT_EQ(cov.stats->single_arg_count, 1);
+  EXPECT_EQ(result(0, 0), 333.0);
+}
+
+/*
+ * BASIC TEST 3: Cross-covariance should still use two-arg
+ */
+TEST(test_single_arg_symmetric, test_cross_uses_two_arg) {
+  MockSingleArgBatchCov cov;
+  cov.stats->reset();
+
+  std::vector<double> xs = {1.0, 2.0};
+  std::vector<double> ys = {3.0, 4.0, 5.0};
+  Eigen::MatrixXd result = cov(xs, ys);  // Cross-covariance
+
+  EXPECT_EQ(cov.stats->single_arg_count, 0) << "Single-arg should NOT be called";
+  EXPECT_EQ(cov.stats->two_arg_count, 1) << "Two-arg should be called";
+  EXPECT_EQ(result(0, 0), 888.0);
+}
+
+/*
+ * BASIC TEST 4: Pool should be passed to single-arg method
+ */
+TEST(test_single_arg_symmetric, test_pool_propagation) {
+  MockSingleArgBatchCov cov;
+  cov.stats->reset();
+
+  ThreadPool pool(2);
+  std::vector<double> xs = {1.0, 2.0};
+  cov(xs, &pool);
+
+  EXPECT_TRUE(cov.stats->pool_was_nonnull) << "Pool should be passed";
+}
+
+/*
+ * EXTENDED TEST 5: variant<double> symmetric uses single-arg
+ */
+TEST(test_single_arg_symmetric, test_variant_symmetric_single_call) {
+  MockSingleArgBatchCov cov;
+  cov.stats->reset();
+
+  using DoubleVariant = variant<double>;
+  std::vector<DoubleVariant> xs(50, DoubleVariant(1.0));
+
+  Eigen::MatrixXd result = cov(xs);
+
+  EXPECT_EQ(cov.stats->single_arg_count, 1);
+  EXPECT_EQ(cov.stats->two_arg_count, 0);
+  EXPECT_EQ(cov.stats->last_xs_size, 50);
+}
+
+/*
+ * EXTENDED TEST 6: Single-arg-only with variants
+ */
+TEST(test_single_arg_symmetric, test_variant_single_arg_only) {
+  MockSingleArgOnlyCov cov;
+  cov.stats->reset();
+
+  using DoubleVariant = variant<double>;
+  std::vector<DoubleVariant> xs = {DoubleVariant(1.0), DoubleVariant(2.0)};
+
+  Eigen::MatrixXd result = cov(xs);
+
+  EXPECT_EQ(cov.stats->single_arg_count, 1);
+  EXPECT_EQ(result(0, 0), 333.0);
+}
+
+/*
+ * EXTENDED TEST 7: Measurement<double> symmetric uses single-arg
+ */
+TEST(test_single_arg_symmetric, test_measurement_symmetric_single_call) {
+  MockSingleArgBatchCov cov;
+  cov.stats->reset();
+
+  std::vector<Measurement<double>> ms(100, Measurement<double>{1.0});
+
+  Eigen::MatrixXd result = cov(ms);
+
+  EXPECT_EQ(cov.stats->single_arg_count, 1);
+  EXPECT_EQ(cov.stats->two_arg_count, 0);
+  EXPECT_EQ(cov.stats->last_xs_size, 100);
+}
+
+/*
+ * EXTENDED TEST 8: variant pool propagation
+ */
+TEST(test_single_arg_symmetric, test_variant_pool_propagation) {
+  MockSingleArgBatchCov cov;
+  cov.stats->reset();
+
+  ThreadPool pool(2);
+  using DoubleVariant = variant<double>;
+  std::vector<DoubleVariant> xs(10, DoubleVariant(1.0));
+
+  cov(xs, &pool);
+
+  EXPECT_TRUE(cov.stats->pool_was_nonnull);
+}
+
+/*
+ * EXTENDED TEST 9: measurement pool propagation
+ */
+TEST(test_single_arg_symmetric, test_measurement_pool_propagation) {
+  MockSingleArgBatchCov cov;
+  cov.stats->reset();
+
+  ThreadPool pool(2);
+  std::vector<Measurement<double>> ms(10, Measurement<double>{1.0});
+
+  cov(ms, &pool);
+
+  EXPECT_TRUE(cov.stats->pool_was_nonnull);
+}
+
+/*
+ * EXTENDED TEST 10: Sum composition propagates single-arg support
+ */
+TEST(test_single_arg_symmetric, test_sum_propagates_single_arg) {
+  MockSingleArgBatchCov cov1;
+  MockSingleArgBatchCov cov2;
+  cov1.stats->reset();
+  cov2.stats->reset();
+
+  auto sum = cov1 + cov2;
+
+  // Verify Sum has single-arg batch support
+  using SumType = decltype(sum);
+  static_assert(has_valid_call_impl_vector_single_arg<SumType, double>::value,
+                "Sum should have single-arg batch support");
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  Eigen::MatrixXd result = sum(xs);
+
+  // Both sides should use single-arg
+  EXPECT_EQ(cov1.stats->single_arg_count, 1) << "LHS should use single-arg";
+  EXPECT_EQ(cov1.stats->two_arg_count, 0) << "LHS should NOT use two-arg";
+  EXPECT_EQ(cov2.stats->single_arg_count, 1) << "RHS should use single-arg";
+  EXPECT_EQ(cov2.stats->two_arg_count, 0) << "RHS should NOT use two-arg";
+
+  // Result should be sum: 777 + 777 = 1554
+  EXPECT_EQ(result(0, 0), 1554.0);
+}
+
+/*
+ * EXTENDED TEST 11: Product composition propagates single-arg support
+ */
+TEST(test_single_arg_symmetric, test_product_propagates_single_arg) {
+  MockSingleArgBatchCov cov1;
+  MockSingleArgBatchCov cov2;
+  cov1.stats->reset();
+  cov2.stats->reset();
+
+  auto product = cov1 * cov2;
+
+  // Verify Product has single-arg batch support
+  using ProductType = decltype(product);
+  static_assert(has_valid_call_impl_vector_single_arg<ProductType, double>::value,
+                "Product should have single-arg batch support");
+
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  Eigen::MatrixXd result = product(xs);
+
+  // Both sides should use single-arg
+  EXPECT_EQ(cov1.stats->single_arg_count, 1) << "LHS should use single-arg";
+  EXPECT_EQ(cov1.stats->two_arg_count, 0) << "LHS should NOT use two-arg";
+  EXPECT_EQ(cov2.stats->single_arg_count, 1) << "RHS should use single-arg";
+  EXPECT_EQ(cov2.stats->two_arg_count, 0) << "RHS should NOT use two-arg";
+
+  // Result should be product: 777 * 777 = 603729
+  EXPECT_EQ(result(0, 0), 603729.0);
+}
+
+/*
+ * EXTENDED TEST 12: Nested composition propagates single-arg support
+ */
+TEST(test_single_arg_symmetric, test_nested_composition_single_arg) {
+  MockSingleArgBatchCov cov1;
+  MockSingleArgBatchCov cov2;
+  MockSingleArgBatchCov cov3;
+  cov1.stats->reset();
+  cov2.stats->reset();
+  cov3.stats->reset();
+
+  auto nested = (cov1 + cov2) * cov3;
+
+  // Verify nested composition has single-arg batch support
+  using NestedType = decltype(nested);
+  static_assert(has_valid_call_impl_vector_single_arg<NestedType, double>::value,
+                "Nested composition should have single-arg batch support");
+
+  std::vector<double> xs = {1.0, 2.0};
+  Eigen::MatrixXd result = nested(xs);
+
+  // All should use single-arg
+  EXPECT_EQ(cov1.stats->single_arg_count, 1);
+  EXPECT_EQ(cov2.stats->single_arg_count, 1);
+  EXPECT_EQ(cov3.stats->single_arg_count, 1);
+  EXPECT_EQ(cov1.stats->two_arg_count, 0);
+  EXPECT_EQ(cov2.stats->two_arg_count, 0);
+  EXPECT_EQ(cov3.stats->two_arg_count, 0);
+
+  // Result: (777 + 777) * 777 = 1554 * 777 = 1207458
+  EXPECT_EQ(result(0, 0), 1207458.0);
+}
+
+/*
+ * EXTENDED TEST 13: Mixed composition - one has single-arg, one has two-arg only
+ */
+TEST(test_single_arg_symmetric, test_mixed_sum_single_and_two_arg) {
+  MockSingleArgBatchCov single_arg_cov;  // Has single-arg
+  BatchTestCovariance two_arg_cov(100.0);  // Has only two-arg
+
+  single_arg_cov.stats->reset();
+
+  auto sum = single_arg_cov + two_arg_cov;
+
+  std::vector<double> xs = {1.0, 2.0};
+  Eigen::MatrixXd result = sum(xs);
+
+  // single_arg_cov should use single-arg, two_arg_cov uses two-arg
+  EXPECT_EQ(single_arg_cov.stats->single_arg_count, 1);
+  EXPECT_EQ(single_arg_cov.stats->two_arg_count, 0);
+
+  // Result: 777 + 100 = 877
+  EXPECT_EQ(result(0, 0), 877.0);
+}
+
+/*
+ * EXTENDED TEST 14: Neither child has single-arg (both two-arg only)
+ * Sum should NOT expose single-arg batch method.
+ */
+TEST(test_single_arg_symmetric, test_sum_neither_child_has_single_arg) {
+  MockBatchCovariance cov1;  // two-arg only
+  MockBatchCovariance cov2;  // two-arg only
+
+  auto sum = cov1 + cov2;
+
+  // Sum should NOT have single-arg batch support
+  using SumType = decltype(sum);
+  static_assert(!has_valid_call_impl_vector_single_arg<SumType, double>::value,
+                "Sum of two-arg-only children should NOT have single-arg");
+
+  // Should still work via two-arg path
+  std::vector<double> xs = {1.0, 2.0, 3.0};
+  Eigen::MatrixXd result = sum(xs);
+
+  // Both should use two-arg batch
+  EXPECT_EQ(cov1.stats->call_count, 1);
+  EXPECT_EQ(cov2.stats->call_count, 1);
+
+  // Result: 42 + 42 = 84
+  EXPECT_EQ(result(0, 0), 84.0);
+}
+
+/*
+ * EXTENDED TEST 15: Mixed product - one child has single-arg, other two-arg only
+ */
+TEST(test_single_arg_symmetric, test_mixed_product_single_and_two_arg) {
+  MockSingleArgBatchCov single_arg_cov;  // Has single-arg
+  BatchTestCovariance two_arg_cov(100.0);  // Has only two-arg
+
+  single_arg_cov.stats->reset();
+
+  auto product = single_arg_cov * two_arg_cov;
+
+  // Product should have single-arg batch support (at least one child has it)
+  using ProductType = decltype(product);
+  static_assert(has_valid_call_impl_vector_single_arg<ProductType, double>::value,
+                "Product should have single-arg when one child does");
+
+  std::vector<double> xs = {1.0, 2.0};
+  Eigen::MatrixXd result = product(xs);
+
+  // single_arg_cov should use single-arg
+  EXPECT_EQ(single_arg_cov.stats->single_arg_count, 1);
+  EXPECT_EQ(single_arg_cov.stats->two_arg_count, 0);
+
+  // Result: 777 * 100 = 77700
+  EXPECT_EQ(result(0, 0), 77700.0);
+}
+
+/*
+ * EXTENDED TEST 16: Single-arg-only child + two-arg-only child in Sum
+ */
+TEST(test_single_arg_symmetric, test_sum_single_arg_only_plus_two_arg_only) {
+  MockSingleArgOnlyCov single_only;  // only single-arg, no two-arg, no pointwise
+  MockBatchCovariance two_arg_only;  // only two-arg
+
+  single_only.stats->reset();
+
+  auto sum = single_only + two_arg_only;
+
+  // Sum should have single-arg batch support
+  using SumType = decltype(sum);
+  static_assert(has_valid_call_impl_vector_single_arg<SumType, double>::value,
+                "Sum should have single-arg when one child does");
+
+  std::vector<double> xs = {1.0, 2.0};
+  Eigen::MatrixXd result = sum(xs);
+
+  // single_only uses single-arg; two_arg_only uses two-arg fallback
+  EXPECT_EQ(single_only.stats->single_arg_count, 1);
+  EXPECT_EQ(two_arg_only.stats->call_count, 1);
+
+  // Result: 333 + 42 = 375
+  EXPECT_EQ(result(0, 0), 375.0);
+}
+
+/*
+ * EXTENDED TEST 17: Variant through Sum with mixed single-arg/two-arg children
+ */
+TEST(test_single_arg_symmetric, test_variant_through_mixed_sum) {
+  MockSingleArgBatchCov single_arg_cov;
+  BatchTestCovariance two_arg_cov(100.0);
+
+  single_arg_cov.stats->reset();
+
+  auto sum = single_arg_cov + two_arg_cov;
+
+  // Create variant vector
+  using V = variant<double>;
+  std::vector<V> xs;
+  xs.push_back(V(1.0));
+  xs.push_back(V(2.0));
+
+  Eigen::MatrixXd result = sum(xs);
+
+  // single_arg_cov should use single-arg through variant unwrapping
+  EXPECT_EQ(single_arg_cov.stats->single_arg_count, 1);
+  EXPECT_EQ(single_arg_cov.stats->two_arg_count, 0);
+
+  // Result: 777 + 100 = 877
+  EXPECT_EQ(result(0, 0), 877.0);
+}
+
+} // namespace albatross

--- a/tests/test_batch_covariance.cc
+++ b/tests/test_batch_covariance.cc
@@ -1598,8 +1598,10 @@ TEST(test_vectorization, test_variant_diagonal_batch) {
 
   Eigen::VectorXd result = cov.diagonal(xs);
 
-  EXPECT_EQ(cov.diagonal_call_count, 1) << "Diagonal batch should be called once";
-  EXPECT_EQ(cov.vector_call_count, 0) << "Full matrix batch should not be called";
+  EXPECT_EQ(cov.diagonal_call_count, 1)
+      << "Diagonal batch should be called once";
+  EXPECT_EQ(cov.vector_call_count, 0)
+      << "Full matrix batch should not be called";
   EXPECT_EQ(result.size(), 50);
   EXPECT_DOUBLE_EQ(result[0], 99.0);
 }
@@ -1635,8 +1637,10 @@ TEST(test_vectorization, test_measurement_diagonal_batch) {
 
   Eigen::VectorXd result = cov.diagonal(xs);
 
-  EXPECT_EQ(cov.diagonal_call_count, 1) << "Diagonal batch should be called once";
-  EXPECT_EQ(cov.vector_call_count, 0) << "Full matrix batch should not be called";
+  EXPECT_EQ(cov.diagonal_call_count, 1)
+      << "Diagonal batch should be called once";
+  EXPECT_EQ(cov.vector_call_count, 0)
+      << "Full matrix batch should not be called";
   EXPECT_EQ(result.size(), 60);
   EXPECT_DOUBLE_EQ(result[0], 88.0);
 }
@@ -1924,10 +1928,9 @@ TEST(test_measurement_batch, test_sum_composition_measurement_batch) {
   rhs.stats->reset();
 
   // Verify traits are satisfied
-  static_assert(
-      has_valid_call_impl_vector<MockBatchCovarianceWithPointwise, double,
-                                 double>::value,
-      "MockBatchCovarianceWithPointwise should have batch support");
+  static_assert(has_valid_call_impl_vector<MockBatchCovarianceWithPointwise,
+                                           double, double>::value,
+                "MockBatchCovarianceWithPointwise should have batch support");
   static_assert(
       has_valid_call_impl_vector_symmetric<MockBatchCovarianceWithPointwise,
                                            double>::value,
@@ -1943,10 +1946,9 @@ TEST(test_measurement_batch, test_sum_composition_measurement_batch) {
                 "Sum should have symmetric batch support for double");
 
   // Verify Sum has batch support for Measurement<double>
-  static_assert(
-      has_valid_call_impl_vector<SumType, Measurement<double>,
-                                 Measurement<double>>::value,
-      "Sum should have batch support for Measurement<double>");
+  static_assert(has_valid_call_impl_vector<SumType, Measurement<double>,
+                                           Measurement<double>>::value,
+                "Sum should have batch support for Measurement<double>");
   static_assert(
       has_valid_call_impl_vector_symmetric<SumType, Measurement<double>>::value,
       "Sum should have symmetric batch support for Measurement<double>");
@@ -2045,16 +2047,15 @@ TEST(test_variant_permutation, test_sort_groups_by_type) {
   // Types: [double, int, string, double, int, string]
   // Indices: [0, 1, 2, 3, 4, 5]
 
-  auto sorted =
-      internal::variant_batch_detail::sort_variants_by_type(input);
+  auto sorted = internal::variant_batch_detail::sort_variants_by_type(input);
 
   // Verify block boundaries
   // Order should be: all ints, then all doubles, then all strings (by type
   // index) Type indices: int=0, double=1, string=2
-  EXPECT_EQ(sorted.block_starts[0], 0);  // int starts at 0
-  EXPECT_EQ(sorted.block_starts[1], 2);  // double starts at 2 (2 ints)
-  EXPECT_EQ(sorted.block_starts[2], 4);  // string starts at 4 (2 doubles)
-  EXPECT_EQ(sorted.block_starts[3], 6);  // end sentinel
+  EXPECT_EQ(sorted.block_starts[0], 0); // int starts at 0
+  EXPECT_EQ(sorted.block_starts[1], 2); // double starts at 2 (2 ints)
+  EXPECT_EQ(sorted.block_starts[2], 4); // string starts at 4 (2 doubles)
+  EXPECT_EQ(sorted.block_starts[3], 6); // end sentinel
 
   // Verify sorted vector contains correct elements (grouped by type)
   EXPECT_EQ(sorted.sorted[0].template get<int>(), 42);
@@ -2074,8 +2075,7 @@ TEST(test_variant_permutation, test_permutation_indices) {
   // Types: [double, int, double, int]
   // Original indices: [0, 1, 2, 3]
 
-  auto sorted =
-      internal::variant_batch_detail::sort_variants_by_type(input);
+  auto sorted = internal::variant_batch_detail::sort_variants_by_type(input);
 
   // Sorted order: [42, 99, 1.0, 2.0] (ints first, then doubles)
   // Sorted indices: [0, 1, 2, 3]
@@ -2088,10 +2088,14 @@ TEST(test_variant_permutation, test_permutation_indices) {
   // original[2]=2.0 (double) -> sorted[3]
   // original[3]=99 (int) -> sorted[1]
 
-  EXPECT_EQ(sorted.to_sorted.indices()[0], 2); // original[0]=1.0 goes to sorted[2]
-  EXPECT_EQ(sorted.to_sorted.indices()[1], 0); // original[1]=42 goes to sorted[0]
-  EXPECT_EQ(sorted.to_sorted.indices()[2], 3); // original[2]=2.0 goes to sorted[3]
-  EXPECT_EQ(sorted.to_sorted.indices()[3], 1); // original[3]=99 goes to sorted[1]
+  EXPECT_EQ(sorted.to_sorted.indices()[0],
+            2); // original[0]=1.0 goes to sorted[2]
+  EXPECT_EQ(sorted.to_sorted.indices()[1],
+            0); // original[1]=42 goes to sorted[0]
+  EXPECT_EQ(sorted.to_sorted.indices()[2],
+            3); // original[2]=2.0 goes to sorted[3]
+  EXPECT_EQ(sorted.to_sorted.indices()[3],
+            1); // original[3]=99 goes to sorted[1]
 }
 
 /*
@@ -2102,8 +2106,7 @@ TEST(test_variant_permutation, test_inverse_permutation_roundtrip) {
   std::vector<V> input = {V(1.0), V(42), V(std::string("a")),
                           V(2.0), V(99), V(std::string("b"))};
 
-  auto sorted =
-      internal::variant_batch_detail::sort_variants_by_type(input);
+  auto sorted = internal::variant_batch_detail::sort_variants_by_type(input);
 
   // Create a simple matrix in sorted order
   const Eigen::Index n = cast::to_index(input.size());
@@ -2119,9 +2122,9 @@ TEST(test_variant_permutation, test_inverse_permutation_roundtrip) {
   Eigen::PermutationMatrix<Eigen::Dynamic> P_inv = sorted.to_sorted.inverse();
   Eigen::MatrixXd result = P_inv * sorted_matrix * P_inv.transpose();
 
-  // Verify: result(i,j) should equal sorted_matrix(sorted_idx[i], sorted_idx[j])
-  // where sorted_idx[orig_i] is the position of original[orig_i] in sorted order
-  // With Eigen convention: indices[orig_i] = sorted_i
+  // Verify: result(i,j) should equal sorted_matrix(sorted_idx[i],
+  // sorted_idx[j]) where sorted_idx[orig_i] is the position of original[orig_i]
+  // in sorted order With Eigen convention: indices[orig_i] = sorted_i
   for (Eigen::Index i = 0; i < n; ++i) {
     for (Eigen::Index j = 0; j < n; ++j) {
       // indices[orig_i] directly gives the sorted position
@@ -2139,8 +2142,7 @@ TEST(test_variant_permutation, test_empty_vector) {
   using V = variant<int, double>;
   std::vector<V> input = {};
 
-  auto sorted =
-      internal::variant_batch_detail::sort_variants_by_type(input);
+  auto sorted = internal::variant_batch_detail::sort_variants_by_type(input);
 
   EXPECT_EQ(sorted.sorted.size(), 0u);
   EXPECT_EQ(sorted.block_starts[0], 0);
@@ -2155,8 +2157,7 @@ TEST(test_variant_permutation, test_single_element) {
   using V = variant<int, double>;
   std::vector<V> input = {V(42)};
 
-  auto sorted =
-      internal::variant_batch_detail::sort_variants_by_type(input);
+  auto sorted = internal::variant_batch_detail::sort_variants_by_type(input);
 
   EXPECT_EQ(sorted.sorted.size(), 1u);
   EXPECT_EQ(sorted.sorted[0].template get<int>(), 42);
@@ -2170,8 +2171,7 @@ TEST(test_variant_permutation, test_homogeneous_vector) {
   using V = variant<int, double>;
   std::vector<V> input = {V(1.0), V(2.0), V(3.0)};
 
-  auto sorted =
-      internal::variant_batch_detail::sort_variants_by_type(input);
+  auto sorted = internal::variant_batch_detail::sort_variants_by_type(input);
 
   // All doubles, so no reordering needed
   EXPECT_EQ(sorted.block_starts[0], 0); // int: empty
@@ -2409,7 +2409,8 @@ TEST(test_variant_heterogeneous, test_element_ordering_preserved) {
 
   Eigen::MatrixXd result = cov(xs);
 
-  // Verify result(0,0) corresponds to cov(1, 1), not cov(3, 1) or something else
+  // Verify result(0,0) corresponds to cov(1, 1), not cov(3, 1) or something
+  // else
   EXPECT_DOUBLE_EQ(result(0, 0), cov._call_impl(1, 1))
       << "result(0,0) should be cov(xs[0], xs[0]) = cov(1, 1)";
   EXPECT_DOUBLE_EQ(result(0, 1), cov._call_impl(1, 2.0))
@@ -2440,9 +2441,10 @@ namespace {
 // Helper to compute covariance matrix using only pointwise calls
 // This bypasses all batch dispatch to create a reference result
 template <typename CovFunc, typename... Ts>
-Eigen::MatrixXd compute_pointwise_reference(
-    const CovFunc &cov, const std::vector<variant<Ts...>> &xs,
-    const std::vector<variant<Ts...>> &ys) {
+Eigen::MatrixXd
+compute_pointwise_reference(const CovFunc &cov,
+                            const std::vector<variant<Ts...>> &xs,
+                            const std::vector<variant<Ts...>> &ys) {
   const auto m = cast::to_index(xs.size());
   const auto n = cast::to_index(ys.size());
   Eigen::MatrixXd result(m, n);
@@ -2456,14 +2458,16 @@ Eigen::MatrixXd compute_pointwise_reference(
 }
 
 template <typename CovFunc, typename... Ts>
-Eigen::MatrixXd compute_pointwise_reference_symmetric(
-    const CovFunc &cov, const std::vector<variant<Ts...>> &xs) {
+Eigen::MatrixXd
+compute_pointwise_reference_symmetric(const CovFunc &cov,
+                                      const std::vector<variant<Ts...>> &xs) {
   return compute_pointwise_reference(cov, xs, xs);
 }
 
 template <typename CovFunc, typename... Ts>
-Eigen::VectorXd compute_pointwise_reference_diagonal(
-    const CovFunc &cov, const std::vector<variant<Ts...>> &xs) {
+Eigen::VectorXd
+compute_pointwise_reference_diagonal(const CovFunc &cov,
+                                     const std::vector<variant<Ts...>> &xs) {
   const auto n = cast::to_index(xs.size());
   Eigen::VectorXd result(n);
   for (Eigen::Index i = 0; i < n; ++i) {
@@ -2846,10 +2850,15 @@ TEST(test_batch_vs_pointwise, test_three_type_heterogeneous_equivalence) {
   using V = variant<int, double, std::string>;
 
   // Mix all three types
-  std::vector<V> xs = {V(1),     V(2.0),   V(std::string("abc")),
-                       V(3),     V(4.0),   V(std::string("de")),
+  std::vector<V> xs = {V(1),
+                       V(2.0),
+                       V(std::string("abc")),
+                       V(3),
+                       V(4.0),
+                       V(std::string("de")),
                        V(std::string("f"))};
-  std::vector<V> ys = {V(std::string("gh")), V(5), V(6.0), V(std::string("ijk")), V(7)};
+  std::vector<V> ys = {V(std::string("gh")), V(5), V(6.0),
+                       V(std::string("ijk")), V(7)};
 
   // Batch computation
   Eigen::MatrixXd batch_result = cov(xs, ys);
@@ -2869,7 +2878,8 @@ TEST(test_batch_vs_pointwise, test_three_type_heterogeneous_equivalence) {
 
   // Also test symmetric
   Eigen::MatrixXd sym_batch = cov(xs);
-  Eigen::MatrixXd sym_pointwise = compute_pointwise_reference_symmetric(cov, xs);
+  Eigen::MatrixXd sym_pointwise =
+      compute_pointwise_reference_symmetric(cov, xs);
 
   for (Eigen::Index i = 0; i < sym_batch.rows(); ++i) {
     for (Eigen::Index j = 0; j < sym_batch.cols(); ++j) {
@@ -3085,7 +3095,7 @@ TEST(test_variant_heterogeneous, test_batch_call_counts) {
       << "double-int should NOT be called (filled by transpose)";
 
   // Test cross-covariance case: cov(xs, ys) where ys is different
-  std::vector<V> ys = {V(100), V(200.0), V(300)};  // 2 ints, 1 double
+  std::vector<V> ys = {V(100), V(200.0), V(300)}; // 2 ints, 1 double
 
   cov.reset();
   Eigen::MatrixXd cross_result = cov(xs, ys);
@@ -3095,7 +3105,8 @@ TEST(test_variant_heterogeneous, test_batch_call_counts) {
   // - 1 call for double-double block (2x1)
   // - 1 call for int-double block (3x1)
   // - 1 call for double-int block (2x2)
-  EXPECT_EQ(cov.int_int_calls, 1) << "cross: int-int batch should be called once";
+  EXPECT_EQ(cov.int_int_calls, 1)
+      << "cross: int-int batch should be called once";
   EXPECT_EQ(cov.double_double_calls, 1)
       << "cross: double-double batch should be called once";
   EXPECT_EQ(cov.int_double_calls, 1)
@@ -3124,7 +3135,7 @@ struct PoolCallRecord {
   ThreadPool *pool_received;
   std::size_t thread_count;
   bool was_nonnull;
-  std::string call_type;  // "vector", "diagonal", "symmetric"
+  std::string call_type; // "vector", "diagonal", "symmetric"
 };
 
 /*
@@ -3314,13 +3325,15 @@ TEST(test_pool_propagation, test_no_pool_propagates_nullptr) {
 
   std::vector<double> xs = {1.0, 2.0};
 
-  sum(xs);  // No pool
+  sum(xs); // No pool
 
   // Both should receive nullptr
   ASSERT_EQ(cov1.records->size(), 1u);
   ASSERT_EQ(cov2.records->size(), 1u);
-  EXPECT_FALSE(cov1.records->at(0).was_nonnull) << "cov1 should receive nullptr";
-  EXPECT_FALSE(cov2.records->at(0).was_nonnull) << "cov2 should receive nullptr";
+  EXPECT_FALSE(cov1.records->at(0).was_nonnull)
+      << "cov1 should receive nullptr";
+  EXPECT_FALSE(cov2.records->at(0).was_nonnull)
+      << "cov2 should receive nullptr";
 }
 
 /*
@@ -3432,7 +3445,8 @@ TEST(test_pool_propagation, test_variant_unwrap_propagates_pool) {
 
 /*
  * Test 12: Sum with variant<Measurement<double>> receives pool
- * Complex type unwrapping: variant<Measurement<double>> -> Measurement<double> -> double
+ * Complex type unwrapping: variant<Measurement<double>> -> Measurement<double>
+ * -> double
  */
 TEST(test_pool_propagation, test_sum_with_variant_measurement_receives_pool) {
   PoolTrackingCovariance lhs;
@@ -3445,7 +3459,8 @@ TEST(test_pool_propagation, test_sum_with_variant_measurement_receives_pool) {
   using VariantMeasurement = variant<Measurement<double>>;
   std::vector<VariantMeasurement> ms;
   for (int i = 0; i < 10; ++i) {
-    ms.push_back(VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
+    ms.push_back(
+        VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
   }
 
   ThreadPool pool(4);
@@ -3465,7 +3480,8 @@ TEST(test_pool_propagation, test_sum_with_variant_measurement_receives_pool) {
 /*
  * Test 13: Product with variant<Measurement<double>> receives pool
  */
-TEST(test_pool_propagation, test_product_with_variant_measurement_receives_pool) {
+TEST(test_pool_propagation,
+     test_product_with_variant_measurement_receives_pool) {
   PoolTrackingCovariance lhs;
   PoolTrackingCovariance rhs;
   lhs.reset();
@@ -3476,7 +3492,8 @@ TEST(test_pool_propagation, test_product_with_variant_measurement_receives_pool)
   using VariantMeasurement = variant<Measurement<double>>;
   std::vector<VariantMeasurement> ms;
   for (int i = 0; i < 8; ++i) {
-    ms.push_back(VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
+    ms.push_back(
+        VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
   }
 
   ThreadPool pool(3);
@@ -3494,8 +3511,7 @@ TEST(test_pool_propagation, test_product_with_variant_measurement_receives_pool)
  * Test 14: Nested Sum+Product with variant<Measurement<double>>
  * (cov1 + cov2) * cov3 with complex types
  */
-TEST(test_pool_propagation,
-     test_nested_sum_product_variant_measurement) {
+TEST(test_pool_propagation, test_nested_sum_product_variant_measurement) {
   PoolTrackingCovariance cov1;
   PoolTrackingCovariance cov2;
   PoolTrackingCovariance cov3;
@@ -3508,7 +3524,8 @@ TEST(test_pool_propagation,
   using VariantMeasurement = variant<Measurement<double>>;
   std::vector<VariantMeasurement> ms;
   for (int i = 0; i < 5; ++i) {
-    ms.push_back(VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
+    ms.push_back(
+        VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
   }
 
   ThreadPool pool(7);
@@ -3529,8 +3546,7 @@ TEST(test_pool_propagation,
  * Test 15: Deep composition with variant<Measurement<double>>
  * ((cov1 * cov2) + cov3) * cov4
  */
-TEST(test_pool_propagation,
-     test_deep_composition_variant_measurement) {
+TEST(test_pool_propagation, test_deep_composition_variant_measurement) {
   PoolTrackingCovariance cov1;
   PoolTrackingCovariance cov2;
   PoolTrackingCovariance cov3;
@@ -3545,7 +3561,8 @@ TEST(test_pool_propagation,
   using VariantMeasurement = variant<Measurement<double>>;
   std::vector<VariantMeasurement> ms;
   for (int i = 0; i < 6; ++i) {
-    ms.push_back(VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
+    ms.push_back(
+        VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
   }
 
   ThreadPool pool(9);
@@ -3569,8 +3586,7 @@ TEST(test_pool_propagation,
  * Test 16: Sum cross-covariance with variant<Measurement<double>>
  * sum(xs, ys, pool) where xs and ys are vectors of variant<Measurement<double>>
  */
-TEST(test_pool_propagation,
-     test_sum_cross_covariance_variant_measurement) {
+TEST(test_pool_propagation, test_sum_cross_covariance_variant_measurement) {
   PoolTrackingCovariance lhs;
   PoolTrackingCovariance rhs;
   lhs.reset();
@@ -3582,7 +3598,8 @@ TEST(test_pool_propagation,
   std::vector<VariantMeasurement> xs;
   std::vector<VariantMeasurement> ys;
   for (int i = 0; i < 4; ++i) {
-    xs.push_back(VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
+    xs.push_back(
+        VariantMeasurement(Measurement<double>{static_cast<double>(i)}));
   }
   for (int i = 0; i < 6; ++i) {
     ys.push_back(
@@ -3750,7 +3767,7 @@ TEST(test_single_arg_symmetric, test_prefers_single_arg_over_two_arg) {
   cov.stats->reset();
 
   std::vector<double> xs = {1.0, 2.0, 3.0};
-  Eigen::MatrixXd result = cov(xs);  // Symmetric call
+  Eigen::MatrixXd result = cov(xs); // Symmetric call
 
   EXPECT_EQ(cov.stats->single_arg_count, 1) << "Single-arg should be called";
   EXPECT_EQ(cov.stats->two_arg_count, 0) << "Two-arg should NOT be called";
@@ -3780,9 +3797,10 @@ TEST(test_single_arg_symmetric, test_cross_uses_two_arg) {
 
   std::vector<double> xs = {1.0, 2.0};
   std::vector<double> ys = {3.0, 4.0, 5.0};
-  Eigen::MatrixXd result = cov(xs, ys);  // Cross-covariance
+  Eigen::MatrixXd result = cov(xs, ys); // Cross-covariance
 
-  EXPECT_EQ(cov.stats->single_arg_count, 0) << "Single-arg should NOT be called";
+  EXPECT_EQ(cov.stats->single_arg_count, 0)
+      << "Single-arg should NOT be called";
   EXPECT_EQ(cov.stats->two_arg_count, 1) << "Two-arg should be called";
   EXPECT_EQ(result(0, 0), 888.0);
 }
@@ -3923,8 +3941,9 @@ TEST(test_single_arg_symmetric, test_product_propagates_single_arg) {
 
   // Verify Product has single-arg batch support
   using ProductType = decltype(product);
-  static_assert(has_valid_call_impl_vector_single_arg<ProductType, double>::value,
-                "Product should have single-arg batch support");
+  static_assert(
+      has_valid_call_impl_vector_single_arg<ProductType, double>::value,
+      "Product should have single-arg batch support");
 
   std::vector<double> xs = {1.0, 2.0, 3.0};
   Eigen::MatrixXd result = product(xs);
@@ -3954,8 +3973,9 @@ TEST(test_single_arg_symmetric, test_nested_composition_single_arg) {
 
   // Verify nested composition has single-arg batch support
   using NestedType = decltype(nested);
-  static_assert(has_valid_call_impl_vector_single_arg<NestedType, double>::value,
-                "Nested composition should have single-arg batch support");
+  static_assert(
+      has_valid_call_impl_vector_single_arg<NestedType, double>::value,
+      "Nested composition should have single-arg batch support");
 
   std::vector<double> xs = {1.0, 2.0};
   Eigen::MatrixXd result = nested(xs);
@@ -3973,11 +3993,12 @@ TEST(test_single_arg_symmetric, test_nested_composition_single_arg) {
 }
 
 /*
- * EXTENDED TEST 13: Mixed composition - one has single-arg, one has two-arg only
+ * EXTENDED TEST 13: Mixed composition - one has single-arg, one has two-arg
+ * only
  */
 TEST(test_single_arg_symmetric, test_mixed_sum_single_and_two_arg) {
-  MockSingleArgBatchCov single_arg_cov;  // Has single-arg
-  BatchTestCovariance two_arg_cov(100.0);  // Has only two-arg
+  MockSingleArgBatchCov single_arg_cov;   // Has single-arg
+  BatchTestCovariance two_arg_cov(100.0); // Has only two-arg
 
   single_arg_cov.stats->reset();
 
@@ -3999,8 +4020,8 @@ TEST(test_single_arg_symmetric, test_mixed_sum_single_and_two_arg) {
  * Sum should NOT expose single-arg batch method.
  */
 TEST(test_single_arg_symmetric, test_sum_neither_child_has_single_arg) {
-  MockBatchCovariance cov1;  // two-arg only
-  MockBatchCovariance cov2;  // two-arg only
+  MockBatchCovariance cov1; // two-arg only
+  MockBatchCovariance cov2; // two-arg only
 
   auto sum = cov1 + cov2;
 
@@ -4022,11 +4043,12 @@ TEST(test_single_arg_symmetric, test_sum_neither_child_has_single_arg) {
 }
 
 /*
- * EXTENDED TEST 15: Mixed product - one child has single-arg, other two-arg only
+ * EXTENDED TEST 15: Mixed product - one child has single-arg, other two-arg
+ * only
  */
 TEST(test_single_arg_symmetric, test_mixed_product_single_and_two_arg) {
-  MockSingleArgBatchCov single_arg_cov;  // Has single-arg
-  BatchTestCovariance two_arg_cov(100.0);  // Has only two-arg
+  MockSingleArgBatchCov single_arg_cov;   // Has single-arg
+  BatchTestCovariance two_arg_cov(100.0); // Has only two-arg
 
   single_arg_cov.stats->reset();
 
@@ -4034,8 +4056,9 @@ TEST(test_single_arg_symmetric, test_mixed_product_single_and_two_arg) {
 
   // Product should have single-arg batch support (at least one child has it)
   using ProductType = decltype(product);
-  static_assert(has_valid_call_impl_vector_single_arg<ProductType, double>::value,
-                "Product should have single-arg when one child does");
+  static_assert(
+      has_valid_call_impl_vector_single_arg<ProductType, double>::value,
+      "Product should have single-arg when one child does");
 
   std::vector<double> xs = {1.0, 2.0};
   Eigen::MatrixXd result = product(xs);
@@ -4052,8 +4075,8 @@ TEST(test_single_arg_symmetric, test_mixed_product_single_and_two_arg) {
  * EXTENDED TEST 16: Single-arg-only child + two-arg-only child in Sum
  */
 TEST(test_single_arg_symmetric, test_sum_single_arg_only_plus_two_arg_only) {
-  MockSingleArgOnlyCov single_only;  // only single-arg, no two-arg, no pointwise
-  MockBatchCovariance two_arg_only;  // only two-arg
+  MockSingleArgOnlyCov single_only; // only single-arg, no two-arg, no pointwise
+  MockBatchCovariance two_arg_only; // only two-arg
 
   single_only.stats->reset();
 

--- a/tests/test_radial.cc
+++ b/tests/test_radial.cc
@@ -599,7 +599,7 @@ TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedSingleElement) {
     const Eigen::MatrixXd result = TypeParam::matrix(dist, ls, sigma);
     ASSERT_EQ(result.rows(), 1);
     ASSERT_EQ(result.cols(), 1);
-    EXPECT_DOUBLE_EQ(result(0, 0), TypeParam::scalar(d, ls, sigma));
+    EXPECT_NEAR(result(0, 0), TypeParam::scalar(d, ls, sigma), 1e-15);
   }
 }
 
@@ -610,7 +610,8 @@ TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedEmptyMatrix) {
   EXPECT_EQ(result.cols(), 0);
 }
 
-TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedEmptyMatrixZeroLengthScale) {
+TYPED_TEST(VectorisedRadialCovarianceTester,
+           VectorisedEmptyMatrixZeroLengthScale) {
   const Eigen::MatrixXd dist(0, 0);
   const Eigen::MatrixXd result = TypeParam::matrix(dist, 0.0, 1.0);
   EXPECT_EQ(result.rows(), 0);
@@ -621,8 +622,7 @@ TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedNonSquare) {
   const double ls = 3.0;
   const double sigma = 2.0;
   Eigen::MatrixXd dist(2, 5);
-  dist << 0.0, 1.1, 2.2, 3.3, 4.4,
-          5.5, 6.6, 7.7, 8.8, 9.9;
+  dist << 0.0, 1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9;
   const Eigen::MatrixXd result = TypeParam::matrix(dist, ls, sigma);
   ASSERT_EQ(result.rows(), 2);
   ASSERT_EQ(result.cols(), 5);
@@ -690,7 +690,8 @@ TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedSymmetryPreservation) {
   }
 }
 
-TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedDefaultSigmaMatchesExplicit) {
+TYPED_TEST(VectorisedRadialCovarianceTester,
+           VectorisedDefaultSigmaMatchesExplicit) {
   std::mt19937 gen(77);
   std::uniform_real_distribution<double> dist_d(0.0, 50.0);
 
@@ -743,8 +744,7 @@ TYPED_TEST(VectorisedRadialCovarianceTester, RvalueMatchesConstRef) {
     // Rvalue overloads may reuse the buffer with a different order of
     // operations, so use isApprox rather than exact equality.
     EXPECT_TRUE(rvalue_result.isApprox(constref_result))
-        << "Mismatch at trial=" << trial
-        << "\nmax error: "
+        << "Mismatch at trial=" << trial << "\nmax error: "
         << (rvalue_result - constref_result).cwiseAbs().maxCoeff();
   }
 }
@@ -771,8 +771,8 @@ static Eigen::MatrixXd oracle_distance_matrix() {
 }
 
 template <std::size_t N>
-static Eigen::MatrixXd oracle_expected_matrix(
-    const std::array<std::array<double, N>, N> &oracle) {
+static Eigen::MatrixXd
+oracle_expected_matrix(const std::array<std::array<double, N>, N> &oracle) {
   const Eigen::Index n = static_cast<Eigen::Index>(N);
   Eigen::MatrixXd expected(n, n);
   for (Eigen::Index i = 0; i < n; ++i) {
@@ -787,8 +787,7 @@ TEST(test_radial, VectorisedMatchesMatern52Oracle) {
   const Eigen::MatrixXd dist = oracle_distance_matrix();
   const Eigen::MatrixXd result =
       matern_52_covariance(dist, kMaternOracleLengthScale, kMaternOracleSigma);
-  const Eigen::MatrixXd expected =
-      oracle_expected_matrix(kOracleMatern52Y);
+  const Eigen::MatrixXd expected = oracle_expected_matrix(kOracleMatern52Y);
   ASSERT_EQ(result.rows(), expected.rows());
   ASSERT_EQ(result.cols(), expected.cols());
   EXPECT_TRUE(result.isApprox(expected, 1e-15));

--- a/tests/test_radial.cc
+++ b/tests/test_radial.cc
@@ -12,6 +12,7 @@
 
 #include <albatross/CovarianceFunctions>
 #include <array>
+#include <random>
 #include <gtest/gtest.h>
 
 #include "test_utils.h"
@@ -486,6 +487,322 @@ TEST(test_radial, test_matern_32_oracle) {
       EXPECT_LT(fabs(pointwise(i, j) - kOracleMatern32Y[i][j]), 1e-15);
     }
   }
+}
+
+// ======================================================================
+// Vectorised radial covariance free-function tests
+// ======================================================================
+
+struct SECovAdapter {
+  static double scalar(double d, double ls, double s) {
+    return squared_exponential_covariance(d, ls, s);
+  }
+  static Eigen::MatrixXd matrix(const Eigen::MatrixXd &d, double ls, double s) {
+    return squared_exponential_covariance(d, ls, s);
+  }
+  static Eigen::MatrixXd rvalue(Eigen::MatrixXd &&d, double ls, double s) {
+    return squared_exponential_covariance(std::move(d), ls, s);
+  }
+};
+
+struct ExpCovAdapter {
+  static double scalar(double d, double ls, double s) {
+    return exponential_covariance(d, ls, s);
+  }
+  static Eigen::MatrixXd matrix(const Eigen::MatrixXd &d, double ls, double s) {
+    return exponential_covariance(d, ls, s);
+  }
+  static Eigen::MatrixXd rvalue(Eigen::MatrixXd &&d, double ls, double s) {
+    return exponential_covariance(std::move(d), ls, s);
+  }
+};
+
+struct M32CovAdapter {
+  static double scalar(double d, double ls, double s) {
+    return matern_32_covariance(d, ls, s);
+  }
+  static Eigen::MatrixXd matrix(const Eigen::MatrixXd &d, double ls, double s) {
+    return matern_32_covariance(d, ls, s);
+  }
+  static Eigen::MatrixXd rvalue(Eigen::MatrixXd &&d, double ls, double s) {
+    return matern_32_covariance(std::move(d), ls, s);
+  }
+};
+
+struct M52CovAdapter {
+  static double scalar(double d, double ls, double s) {
+    return matern_52_covariance(d, ls, s);
+  }
+  static Eigen::MatrixXd matrix(const Eigen::MatrixXd &d, double ls, double s) {
+    return matern_52_covariance(d, ls, s);
+  }
+  static Eigen::MatrixXd rvalue(Eigen::MatrixXd &&d, double ls, double s) {
+    return matern_52_covariance(std::move(d), ls, s);
+  }
+};
+
+template <typename T>
+class VectorisedRadialCovarianceTester : public ::testing::Test {};
+
+using VectorisedTestCases =
+    ::testing::Types<SECovAdapter, ExpCovAdapter, M32CovAdapter, M52CovAdapter>;
+TYPED_TEST_SUITE(VectorisedRadialCovarianceTester, VectorisedTestCases);
+
+TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedZeroDistance) {
+  const double sigma = 3.7;
+  const double ls = 5.0;
+  const Eigen::MatrixXd dist = Eigen::MatrixXd::Zero(4, 4);
+  const Eigen::MatrixXd result = TypeParam::matrix(dist, ls, sigma);
+  ASSERT_EQ(result.rows(), 4);
+  ASSERT_EQ(result.cols(), 4);
+  EXPECT_TRUE(result.isApprox(
+      Eigen::MatrixXd::Constant(4, 4, sigma * sigma)));
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedLargeDistance) {
+  const double ls = 1.0;
+  const double sigma = 1.0;
+  Eigen::MatrixXd dist(2, 3);
+  dist << 1e8, 1e10, 1e12, 1e9, 1e11, 1e15;
+  const Eigen::MatrixXd result = TypeParam::matrix(dist, ls, sigma);
+  ASSERT_EQ(result.rows(), 2);
+  ASSERT_EQ(result.cols(), 3);
+  EXPECT_TRUE(result.isZero(1e-10));
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedZeroLengthScale) {
+  Eigen::MatrixXd dist(3, 3);
+  dist << 0, 1, 2, 3, 4, 5, 6, 7, 8;
+  for (double ls : {0.0, -1.0, -1e10}) {
+    const Eigen::MatrixXd result = TypeParam::matrix(dist, ls, 5.0);
+    ASSERT_EQ(result.rows(), 3);
+    ASSERT_EQ(result.cols(), 3);
+    EXPECT_TRUE(result.isZero());
+  }
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedZeroSigma) {
+  Eigen::MatrixXd dist(3, 3);
+  dist << 0, 1, 2, 3, 4, 5, 6, 7, 8;
+  const Eigen::MatrixXd result = TypeParam::matrix(dist, 5.0, 0.0);
+  ASSERT_EQ(result.rows(), 3);
+  ASSERT_EQ(result.cols(), 3);
+  EXPECT_TRUE(result.isZero());
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedSingleElement) {
+  const double ls = 2.5;
+  const double sigma = 1.3;
+  for (double d : {0.0, 0.5, 1.0, 10.0, 100.0}) {
+    Eigen::MatrixXd dist(1, 1);
+    dist(0, 0) = d;
+    const Eigen::MatrixXd result = TypeParam::matrix(dist, ls, sigma);
+    ASSERT_EQ(result.rows(), 1);
+    ASSERT_EQ(result.cols(), 1);
+    EXPECT_DOUBLE_EQ(result(0, 0), TypeParam::scalar(d, ls, sigma));
+  }
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedEmptyMatrix) {
+  const Eigen::MatrixXd dist(0, 0);
+  const Eigen::MatrixXd result = TypeParam::matrix(dist, 5.0, 1.0);
+  EXPECT_EQ(result.rows(), 0);
+  EXPECT_EQ(result.cols(), 0);
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedEmptyMatrixZeroLengthScale) {
+  const Eigen::MatrixXd dist(0, 0);
+  const Eigen::MatrixXd result = TypeParam::matrix(dist, 0.0, 1.0);
+  EXPECT_EQ(result.rows(), 0);
+  EXPECT_EQ(result.cols(), 0);
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedNonSquare) {
+  const double ls = 3.0;
+  const double sigma = 2.0;
+  Eigen::MatrixXd dist(2, 5);
+  dist << 0.0, 1.1, 2.2, 3.3, 4.4,
+          5.5, 6.6, 7.7, 8.8, 9.9;
+  const Eigen::MatrixXd result = TypeParam::matrix(dist, ls, sigma);
+  ASSERT_EQ(result.rows(), 2);
+  ASSERT_EQ(result.cols(), 5);
+  Eigen::MatrixXd expected(2, 5);
+  for (Eigen::Index i = 0; i < 2; ++i) {
+    for (Eigen::Index j = 0; j < 5; ++j) {
+      expected(i, j) = TypeParam::scalar(dist(i, j), ls, sigma);
+    }
+  }
+  EXPECT_TRUE(result.isApprox(expected));
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedMatchesScalar) {
+  std::mt19937 gen(42);
+  std::uniform_real_distribution<double> dist_d(0.0, 100.0);
+  std::uniform_real_distribution<double> dist_param(0.1, 50.0);
+  std::uniform_int_distribution<int> dist_dim(1, 20);
+
+  for (int trial = 0; trial < 20; ++trial) {
+    const int m = dist_dim(gen);
+    const int n = dist_dim(gen);
+    const double ls = dist_param(gen);
+    const double sigma = dist_param(gen);
+
+    Eigen::MatrixXd d(m, n);
+    for (int i = 0; i < m; ++i) {
+      for (int j = 0; j < n; ++j) {
+        d(i, j) = dist_d(gen);
+      }
+    }
+
+    const Eigen::MatrixXd result = TypeParam::matrix(d, ls, sigma);
+    ASSERT_EQ(result.rows(), m);
+    ASSERT_EQ(result.cols(), n);
+    Eigen::MatrixXd expected(m, n);
+    for (int i = 0; i < m; ++i) {
+      for (int j = 0; j < n; ++j) {
+        expected(i, j) = TypeParam::scalar(d(i, j), ls, sigma);
+      }
+    }
+    EXPECT_TRUE(result.isApprox(expected))
+        << "Mismatch at trial=" << trial
+        << "\nmax error: " << (result - expected).cwiseAbs().maxCoeff();
+  }
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedSymmetryPreservation) {
+  std::mt19937 gen(123);
+  std::uniform_real_distribution<double> dist_d(0.0, 100.0);
+
+  const double ls = 5.0;
+  const double sigma = 2.0;
+
+  for (int n = 1; n <= 10; ++n) {
+    Eigen::MatrixXd d(n, n);
+    for (int i = 0; i < n; ++i) {
+      for (int j = i; j < n; ++j) {
+        d(i, j) = dist_d(gen);
+        d(j, i) = d(i, j);
+      }
+    }
+    const Eigen::MatrixXd result = TypeParam::matrix(d, ls, sigma);
+    EXPECT_TRUE(result.isApprox(result.transpose()))
+        << "Asymmetric result for n=" << n;
+  }
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedDefaultSigmaMatchesExplicit) {
+  std::mt19937 gen(77);
+  std::uniform_real_distribution<double> dist_d(0.0, 50.0);
+
+  const double ls = 10.0;
+  const int n = 5;
+  Eigen::MatrixXd d(n, n);
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < n; ++j) {
+      d(i, j) = dist_d(gen);
+    }
+  }
+  const Eigen::MatrixXd with_sigma = TypeParam::matrix(d, ls, 1.0);
+  ASSERT_EQ(with_sigma.rows(), n);
+  ASSERT_EQ(with_sigma.cols(), n);
+  Eigen::MatrixXd expected(n, n);
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < n; ++j) {
+      expected(i, j) = TypeParam::scalar(d(i, j), ls, 1.0);
+    }
+  }
+  EXPECT_TRUE(with_sigma.isApprox(expected));
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, RvalueMatchesConstRef) {
+  std::mt19937 gen(99);
+  std::uniform_real_distribution<double> dist_d(0.0, 100.0);
+  std::uniform_real_distribution<double> dist_param(0.1, 50.0);
+  std::uniform_int_distribution<int> dist_dim(1, 15);
+
+  for (int trial = 0; trial < 10; ++trial) {
+    const int m = dist_dim(gen);
+    const int n = dist_dim(gen);
+    const double ls = dist_param(gen);
+    const double sigma = dist_param(gen);
+
+    Eigen::MatrixXd d(m, n);
+    for (int i = 0; i < m; ++i) {
+      for (int j = 0; j < n; ++j) {
+        d(i, j) = dist_d(gen);
+      }
+    }
+
+    const Eigen::MatrixXd constref_result = TypeParam::matrix(d, ls, sigma);
+    Eigen::MatrixXd d_copy = d;
+    const Eigen::MatrixXd rvalue_result =
+        TypeParam::rvalue(std::move(d_copy), ls, sigma);
+
+    ASSERT_EQ(rvalue_result.rows(), constref_result.rows());
+    ASSERT_EQ(rvalue_result.cols(), constref_result.cols());
+    // Rvalue overloads may reuse the buffer with a different order of
+    // operations, so use isApprox rather than exact equality.
+    EXPECT_TRUE(rvalue_result.isApprox(constref_result))
+        << "Mismatch at trial=" << trial
+        << "\nmax error: "
+        << (rvalue_result - constref_result).cwiseAbs().maxCoeff();
+  }
+}
+
+TYPED_TEST(VectorisedRadialCovarianceTester, RvalueZeroLengthScale) {
+  Eigen::MatrixXd dist(3, 4);
+  dist.setOnes();
+  const Eigen::MatrixXd result = TypeParam::rvalue(std::move(dist), 0.0, 5.0);
+  ASSERT_EQ(result.rows(), 3);
+  ASSERT_EQ(result.cols(), 4);
+  EXPECT_TRUE(result.isZero());
+}
+
+// Helper to build distance and expected matrices from oracle data.
+static Eigen::MatrixXd oracle_distance_matrix() {
+  const Eigen::Index n = static_cast<Eigen::Index>(kMaternNumOraclePoints);
+  Eigen::MatrixXd dist(n, n);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    for (Eigen::Index j = 0; j < n; ++j) {
+      dist(i, j) = fabs(kOracleMaternX[i] - kOracleMaternX[j]);
+    }
+  }
+  return dist;
+}
+
+template <std::size_t N>
+static Eigen::MatrixXd oracle_expected_matrix(
+    const std::array<std::array<double, N>, N> &oracle) {
+  const Eigen::Index n = static_cast<Eigen::Index>(N);
+  Eigen::MatrixXd expected(n, n);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    for (Eigen::Index j = 0; j < n; ++j) {
+      expected(i, j) = oracle[i][j];
+    }
+  }
+  return expected;
+}
+
+TEST(test_radial, VectorisedMatchesMatern52Oracle) {
+  const Eigen::MatrixXd dist = oracle_distance_matrix();
+  const Eigen::MatrixXd result =
+      matern_52_covariance(dist, kMaternOracleLengthScale, kMaternOracleSigma);
+  const Eigen::MatrixXd expected =
+      oracle_expected_matrix(kOracleMatern52Y);
+  ASSERT_EQ(result.rows(), expected.rows());
+  ASSERT_EQ(result.cols(), expected.cols());
+  EXPECT_TRUE(result.isApprox(expected, 1e-15));
+}
+
+TEST(test_radial, VectorisedMatchesMatern32Oracle) {
+  const Eigen::MatrixXd dist = oracle_distance_matrix();
+  const Eigen::MatrixXd result =
+      matern_32_covariance(dist, kMaternOracleLengthScale, kMaternOracleSigma);
+  const Eigen::MatrixXd expected =
+      oracle_expected_matrix(kOracleMatern32Y);
+  ASSERT_EQ(result.rows(), expected.rows());
+  ASSERT_EQ(result.cols(), expected.cols());
+  EXPECT_TRUE(result.isApprox(expected, 1e-15));
 }
 
 } // namespace albatross

--- a/tests/test_radial.cc
+++ b/tests/test_radial.cc
@@ -12,8 +12,8 @@
 
 #include <albatross/CovarianceFunctions>
 #include <array>
-#include <random>
 #include <gtest/gtest.h>
+#include <random>
 
 #include "test_utils.h"
 
@@ -555,8 +555,7 @@ TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedZeroDistance) {
   const Eigen::MatrixXd result = TypeParam::matrix(dist, ls, sigma);
   ASSERT_EQ(result.rows(), 4);
   ASSERT_EQ(result.cols(), 4);
-  EXPECT_TRUE(result.isApprox(
-      Eigen::MatrixXd::Constant(4, 4, sigma * sigma)));
+  EXPECT_TRUE(result.isApprox(Eigen::MatrixXd::Constant(4, 4, sigma * sigma)));
 }
 
 TYPED_TEST(VectorisedRadialCovarianceTester, VectorisedLargeDistance) {
@@ -797,8 +796,7 @@ TEST(test_radial, VectorisedMatchesMatern32Oracle) {
   const Eigen::MatrixXd dist = oracle_distance_matrix();
   const Eigen::MatrixXd result =
       matern_32_covariance(dist, kMaternOracleLengthScale, kMaternOracleSigma);
-  const Eigen::MatrixXd expected =
-      oracle_expected_matrix(kOracleMatern32Y);
+  const Eigen::MatrixXd expected = oracle_expected_matrix(kOracleMatern32Y);
   ASSERT_EQ(result.rows(), expected.rows());
   ASSERT_EQ(result.cols(), expected.cols());
   EXPECT_TRUE(result.isApprox(expected, 1e-15));


### PR DESCRIPTION
Previously the covariance machinery worked point-by-point -- users define covariance between scalar values using `_call_impl()`, and Albatross computes the required matrices.  In theory, this is typically correct, but in some cases, there may be a requirement to compute on batches of training data at once (for example, to perform an FFT and improve asymptotic scaling).

This commit adds an additional system to the covariance CRTP machinery, so that if a user defines `_call_impl_vector()`, which accepts `std::vector`s of feature types, this batch definition will be used instead, enabling things such as the FFT use case.