### PR TITLE
Introduce CHOLMOD integration and covariance representations

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,6 +17,7 @@ cc_library(
     hdrs = [
         "include/albatross/Common",
         "include/albatross/Core",
+        "include/albatross/CholmodSupport",
         "include/albatross/CovarianceFunctions",
         "include/albatross/Dataset",
         "include/albatross/Distribution",
@@ -43,6 +44,7 @@ cc_library(
         "include/albatross/serialize/Ransac",
         "include/albatross/src/cereal/ThreadPool.hpp",
         "include/albatross/src/cereal/block_utils.hpp",
+        "include/albatross/src/cereal/cholmod_representation.hpp",
         "include/albatross/src/cereal/dataset.hpp",
         "include/albatross/src/cereal/distribution.hpp",
         "include/albatross/src/cereal/eigen.hpp",
@@ -55,6 +57,7 @@ cc_library(
         "include/albatross/src/cereal/priors.hpp",
         "include/albatross/src/cereal/ransac.hpp",
         "include/albatross/src/cereal/representations.hpp",
+        "include/albatross/src/cereal/serializable_cholmod.hpp",
         "include/albatross/src/cereal/serializable_ldlt.hpp",
         "include/albatross/src/cereal/serializable_spqr.hpp",
         "include/albatross/src/cereal/suitesparse.hpp",
@@ -85,6 +88,7 @@ cc_library(
         "include/albatross/src/covariance_functions/nugget.hpp",
         "include/albatross/src/covariance_functions/polynomials.hpp",
         "include/albatross/src/covariance_functions/radial.hpp",
+        "include/albatross/src/covariance_functions/cholmod_representation.hpp",
         "include/albatross/src/covariance_functions/representations.hpp",
         "include/albatross/src/covariance_functions/scaling_function.hpp",
         "include/albatross/src/covariance_functions/traits.hpp",
@@ -93,6 +97,7 @@ cc_library(
         "include/albatross/src/details/traits.hpp",
         "include/albatross/src/details/typecast.hpp",
         "include/albatross/src/details/unused.hpp",
+        "include/albatross/src/eigen/serializable_cholmod.hpp",
         "include/albatross/src/eigen/serializable_ldlt.hpp",
         "include/albatross/src/eigen/serializable_spqr.hpp",
         "include/albatross/src/evaluation/cross_validation.hpp",
@@ -172,6 +177,7 @@ cc_library(
         "@zlib",
         "@variant",
         "@zstd",
+        "@suitesparse//:cholmod",
         "@suitesparse//:spqr",
     ],
 )
@@ -207,6 +213,7 @@ TEST_DEPS = [
     ":albatross-test-common",
     "@zlib",
     "@gtest//:gtest_main",
+    "@suitesparse//:cholmod",
     "@suitesparse//:spqr",
 ]
 
@@ -389,6 +396,7 @@ swift_cc_test(
 swift_cc_test(
     name = "albatross-test-serialization",
     srcs = [
+        "tests/test_cholmod_representation.cc",
         "tests/test_serialize.cc",
         "tests/test_serializable_ldlt.cc",
     ],

--- a/include/albatross/CholmodSupport
+++ b/include/albatross/CholmodSupport
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CHOLMOD_SUPPORT_H
+#define ALBATROSS_CHOLMOD_SUPPORT_H
+
+#include <cholmod.h>
+
+#include <Eigen/CholmodSupport>
+#include <Eigen/SparseCore>
+
+#include "GP"
+
+#include <albatross/src/eigen/serializable_cholmod.hpp>
+#include <albatross/src/covariance_functions/cholmod_representation.hpp>
+
+#endif

--- a/include/albatross/serialize/GP
+++ b/include/albatross/serialize/GP
@@ -15,11 +15,14 @@
 
 #include "Core"
 #include <albatross/SparseGP>
+#include <albatross/CholmodSupport>
 
 #include "../src/cereal/block_utils.hpp"
 #include "../src/cereal/serializable_ldlt.hpp"
 #include "../src/cereal/gp.hpp"
 #include "../src/cereal/representations.hpp"
 #include "../src/cereal/serializable_spqr.hpp"
+#include "../src/cereal/serializable_cholmod.hpp"
+#include "../src/cereal/cholmod_representation.hpp"
 
 #endif

--- a/include/albatross/src/cereal/cholmod_representation.hpp
+++ b/include/albatross/src/cereal/cholmod_representation.hpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CEREAL_CHOLMOD_REPRESENTATION_HPP_
+#define ALBATROSS_CEREAL_CHOLMOD_REPRESENTATION_HPP_
+
+#include <cereal/types/memory.hpp>
+
+namespace cereal {
+
+template <typename Archive, typename Solver>
+inline void serialize(Archive &archive,
+                      albatross::CholmodCovariance<Solver> &rep,
+                      const std::uint32_t) {
+  archive(cereal::make_nvp("sparse_A", rep.sparse_A_),
+          cereal::make_nvp("solver", rep.solver_));
+}
+
+} // namespace cereal
+
+#endif /* ALBATROSS_CEREAL_CHOLMOD_REPRESENTATION_HPP_ */

--- a/include/albatross/src/cereal/serializable_cholmod.hpp
+++ b/include/albatross/src/cereal/serializable_cholmod.hpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_CEREAL_SERIALIZABLE_CHOLMOD_H
+#define ALBATROSS_CEREAL_SERIALIZABLE_CHOLMOD_H
+
+// The three serializable-cholmod wrappers all share the same persistent
+// state: a couple of flags inherited from SparseSolverBase / CholmodBase,
+// the numeric shift, the cholmod_common configuration, and the factor
+// itself.  They differ only in what CHOLMOD mode flags the derived ctor's
+// init() sets -- that's captured by the `cholmod_common` save/load.
+//
+// Because the relevant fields are protected in the CHOLMOD bases, the
+// save/load bodies have to live inside the derived class, so they're
+// spelled out once per variant via these macros.
+// Base-qualified access bypasses the `using Base::m_cholmod` declaration
+// that Eigen's Cholmod derived classes have in their private section; the
+// underlying CholmodBase member is protected so our derived-class
+// save/load can reach it with explicit qualification.
+#define ALBATROSS_SERIALIZABLE_CHOLMOD_SAVE_BODY()                             \
+  const bool is_initialized = this->SolverBase::m_isInitialized;               \
+  ar(::cereal::make_nvp("m_isInitialized", is_initialized));                   \
+  if (!is_initialized) {                                                       \
+    return;                                                                    \
+  }                                                                            \
+  ar(::cereal::make_nvp("m_factorizationIsOk",                                 \
+                        this->SolverBase::m_factorizationIsOk));               \
+  ar(::cereal::make_nvp("m_analysisIsOk", this->SolverBase::m_analysisIsOk));  \
+  ar(::cereal::make_nvp("m_info", this->SolverBase::m_info));                  \
+  ar(::cereal::make_nvp("m_shiftOffset0",                                      \
+                        this->SolverBase::m_shiftOffset[0]));                  \
+  ar(::cereal::make_nvp("m_shiftOffset1",                                      \
+                        this->SolverBase::m_shiftOffset[1]));                  \
+  ar(::cereal::make_nvp("m_cholmod", this->SolverBase::m_cholmod));            \
+  ALBATROSS_ASSERT(this->SolverBase::m_cholmodFactor != nullptr);              \
+  ar(::cereal::make_nvp("m_cholmodFactor", *this->SolverBase::m_cholmodFactor));
+
+#define ALBATROSS_SERIALIZABLE_CHOLMOD_LOAD_BODY()                             \
+  bool is_initialized = false;                                                 \
+  ar(::cereal::make_nvp("m_isInitialized", is_initialized));                   \
+  if (this->SolverBase::m_cholmodFactor != nullptr) {                          \
+    cholmod_free_factor(&this->SolverBase::m_cholmodFactor,                    \
+                        &this->SolverBase::m_cholmod);                         \
+    this->SolverBase::m_cholmodFactor = nullptr;                               \
+  }                                                                            \
+  if (!is_initialized) {                                                       \
+    this->SolverBase::m_isInitialized = false;                                 \
+    this->SolverBase::m_factorizationIsOk = 0;                                 \
+    this->SolverBase::m_analysisIsOk = 0;                                      \
+    return;                                                                    \
+  }                                                                            \
+  ar(::cereal::make_nvp("m_factorizationIsOk",                                 \
+                        this->SolverBase::m_factorizationIsOk));               \
+  ar(::cereal::make_nvp("m_analysisIsOk", this->SolverBase::m_analysisIsOk));  \
+  ar(::cereal::make_nvp("m_info", this->SolverBase::m_info));                  \
+  ar(::cereal::make_nvp("m_shiftOffset0",                                      \
+                        this->SolverBase::m_shiftOffset[0]));                  \
+  ar(::cereal::make_nvp("m_shiftOffset1",                                      \
+                        this->SolverBase::m_shiftOffset[1]));                  \
+  ar(::cereal::make_nvp("m_cholmod", this->SolverBase::m_cholmod));            \
+  this->SolverBase::m_cholmodFactor =                                          \
+      cholmod_allocate_factor(1, &this->SolverBase::m_cholmod);                \
+  ALBATROSS_ASSERT(this->SolverBase::m_cholmodFactor != nullptr);              \
+  ar(::cereal::make_nvp("m_cholmodFactor",                                     \
+                        *this->SolverBase::m_cholmodFactor));                  \
+  this->SolverBase::m_isInitialized = true;
+
+namespace Eigen {
+
+template <typename _MatrixType, int _UpLo>
+template <class Archive>
+void SerializableCholmodSupernodalLLT<_MatrixType, _UpLo>::save(
+    Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) const {
+  ALBATROSS_SERIALIZABLE_CHOLMOD_SAVE_BODY();
+}
+
+template <typename _MatrixType, int _UpLo>
+template <class Archive>
+void SerializableCholmodSupernodalLLT<_MatrixType, _UpLo>::load(
+    Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) {
+  ALBATROSS_SERIALIZABLE_CHOLMOD_LOAD_BODY();
+}
+
+template <typename _MatrixType, int _UpLo>
+template <class Archive>
+void SerializableCholmodSimplicialLLT<_MatrixType, _UpLo>::save(
+    Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) const {
+  ALBATROSS_SERIALIZABLE_CHOLMOD_SAVE_BODY();
+}
+
+template <typename _MatrixType, int _UpLo>
+template <class Archive>
+void SerializableCholmodSimplicialLLT<_MatrixType, _UpLo>::load(
+    Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) {
+  ALBATROSS_SERIALIZABLE_CHOLMOD_LOAD_BODY();
+}
+
+template <typename _MatrixType, int _UpLo>
+template <class Archive>
+void SerializableCholmodSimplicialLDLT<_MatrixType, _UpLo>::save(
+    Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) const {
+  ALBATROSS_SERIALIZABLE_CHOLMOD_SAVE_BODY();
+}
+
+template <typename _MatrixType, int _UpLo>
+template <class Archive>
+void SerializableCholmodSimplicialLDLT<_MatrixType, _UpLo>::load(
+    Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) {
+  ALBATROSS_SERIALIZABLE_CHOLMOD_LOAD_BODY();
+}
+
+} // namespace Eigen
+
+#undef ALBATROSS_SERIALIZABLE_CHOLMOD_SAVE_BODY
+#undef ALBATROSS_SERIALIZABLE_CHOLMOD_LOAD_BODY
+
+#endif // ALBATROSS_CEREAL_SERIALIZABLE_CHOLMOD_H

--- a/include/albatross/src/cereal/suitesparse.hpp
+++ b/include/albatross/src/cereal/suitesparse.hpp
@@ -276,7 +276,15 @@ inline void load(Archive &ar, cholmod_common &cc,
   ar(CEREAL_NVP(cc.metis_dswitch));
   ar(CEREAL_NVP(cc.metis_nswitch));
   ar(CEREAL_NVP(cc.mark));
-  ALBATROSS_ASSERT(cholmod_l_free_work(&cc) == 1);
+  // Eigen's CholmodSupport runs cholmod_start (itype = CHOLMOD_INT);
+  // SPQR runs cholmod_l_start (itype = CHOLMOD_LONG). Pick the matching
+  // cleanup based on the common's current itype.
+  if (cc.itype == CHOLMOD_LONG) {
+    ALBATROSS_ASSERT(cholmod_l_free_work(&cc) == 1);
+  } else {
+    ALBATROSS_ASSERT(cc.itype == CHOLMOD_INT);
+    ALBATROSS_ASSERT(cholmod_free_work(&cc) == 1);
+  }
   ar(CEREAL_NVP(cc.itype));
 
 #if CHOLMOD_VERSION < CHOLMOD_VER_CODE(5, 0)
@@ -489,6 +497,160 @@ inline void load(Archive &ar, cholmod_dense &m,
   detail::decode_array(ar, "m.x", m.x, x_elements * element_size_bytes);
   // "zomplex" only
   ALBATROSS_ASSERT(nullptr == m.z);
+}
+
+// cholmod_factor holds an LL' or LDL' factor produced by CHOLMOD.  The layout
+// is a tagged union on `is_super`: in the simplicial branch columns of L are
+// stored as CSC (p / i / x, plus nz / next / prev when !is_monotonic); in the
+// supernodal branch L is stored as a packed list of dense column-major blocks
+// described by super / pi / px / s with values in x.  We serialize every
+// pointer that is part of the persistent state and leave workspace
+// (Flag/Head, only present in the `cholmod_common`) alone.
+template <class Archive>
+inline void save(Archive &ar, cholmod_factor const &f,
+                 std::uint32_t version ALBATROSS_UNUSED) {
+  assert((f.itype == CHOLMOD_INT || f.itype == CHOLMOD_LONG) &&
+         "we only support int and long indices");
+  ALBATROSS_ASSERT(f.xtype != CHOLMOD_COMPLEX &&
+                   "complex factors are not supported");
+  ALBATROSS_ASSERT(f.z == nullptr && "zomplex factors are not supported");
+
+  ar(CEREAL_NVP(f.n));
+  ar(CEREAL_NVP(f.minor));
+  ar(CEREAL_NVP(f.nzmax));
+  ar(CEREAL_NVP(f.nsuper));
+  ar(CEREAL_NVP(f.ssize));
+  ar(CEREAL_NVP(f.xsize));
+  ar(CEREAL_NVP(f.maxcsize));
+  ar(CEREAL_NVP(f.maxesize));
+  ar(CEREAL_NVP(f.ordering));
+  ar(CEREAL_NVP(f.is_ll));
+  ar(CEREAL_NVP(f.is_super));
+  ar(CEREAL_NVP(f.is_monotonic));
+  ar(CEREAL_NVP(f.itype));
+  ar(CEREAL_NVP(f.xtype));
+  ar(CEREAL_NVP(f.dtype));
+  ar(CEREAL_NVP(f.useGPU));
+
+  const std::size_t integer_size_bytes = get_integer_size_bytes(f);
+  const std::size_t element_size_bytes = get_element_size_bytes(f);
+
+  // Always-present symbolic state.
+  detail::encode_array(ar, "f.Perm", f.Perm, f.n * integer_size_bytes);
+  detail::encode_array(ar, "f.ColCount", f.ColCount, f.n * integer_size_bytes);
+
+  // IPerm is created lazily by cholmod_solve2; emit a presence flag so load
+  // can decide whether to allocate.
+  const bool have_iperm = (f.IPerm != nullptr);
+  ar(CEREAL_NVP(have_iperm));
+  if (have_iperm) {
+    detail::encode_array(ar, "f.IPerm", f.IPerm, f.n * integer_size_bytes);
+  }
+
+  if (f.is_super) {
+    // Supernodal layout.
+    detail::encode_array(ar, "f.super", f.super,
+                         (f.nsuper + 1) * integer_size_bytes);
+    detail::encode_array(ar, "f.pi", f.pi, (f.nsuper + 1) * integer_size_bytes);
+    detail::encode_array(ar, "f.px", f.px, (f.nsuper + 1) * integer_size_bytes);
+    detail::encode_array(ar, "f.s", f.s, f.ssize * integer_size_bytes);
+    if (f.xtype != CHOLMOD_PATTERN) {
+      detail::encode_array(ar, "f.x", f.x, f.xsize * element_size_bytes);
+    }
+  } else {
+    // Simplicial layout.
+    detail::encode_array(ar, "f.p", f.p, (f.n + 1) * integer_size_bytes);
+    if (f.xtype != CHOLMOD_PATTERN) {
+      detail::encode_array(ar, "f.i", f.i, f.nzmax * integer_size_bytes);
+      detail::encode_array(ar, "f.x", f.x, f.nzmax * element_size_bytes);
+      // nz / next / prev only exist for numeric simplicial factors.
+      detail::encode_array(ar, "f.nz", f.nz, f.n * integer_size_bytes);
+      detail::encode_array(ar, "f.next", f.next,
+                           (f.n + 2) * integer_size_bytes);
+      detail::encode_array(ar, "f.prev", f.prev,
+                           (f.n + 2) * integer_size_bytes);
+    }
+  }
+}
+
+template <class Archive>
+inline void load(Archive &ar, cholmod_factor &f,
+                 std::uint32_t version ALBATROSS_UNUSED) {
+  ar(CEREAL_NVP(f.n));
+  ar(CEREAL_NVP(f.minor));
+  ar(CEREAL_NVP(f.nzmax));
+  ar(CEREAL_NVP(f.nsuper));
+  ar(CEREAL_NVP(f.ssize));
+  ar(CEREAL_NVP(f.xsize));
+  ar(CEREAL_NVP(f.maxcsize));
+  ar(CEREAL_NVP(f.maxesize));
+  ar(CEREAL_NVP(f.ordering));
+  ar(CEREAL_NVP(f.is_ll));
+  ar(CEREAL_NVP(f.is_super));
+  ar(CEREAL_NVP(f.is_monotonic));
+  ar(CEREAL_NVP(f.itype));
+  ar(CEREAL_NVP(f.xtype));
+  ar(CEREAL_NVP(f.dtype));
+  ar(CEREAL_NVP(f.useGPU));
+
+  assert((f.itype == CHOLMOD_INT || f.itype == CHOLMOD_LONG) &&
+         "we only support int and long indices");
+  ALBATROSS_ASSERT(f.xtype != CHOLMOD_COMPLEX &&
+                   "complex factors are not supported");
+
+  const std::size_t integer_size_bytes = get_integer_size_bytes(f);
+  const std::size_t element_size_bytes = get_element_size_bytes(f);
+
+  detail::suitesparse_cereal_realloc(&f.Perm, f.n, integer_size_bytes);
+  detail::decode_array(ar, "f.Perm", f.Perm, f.n * integer_size_bytes);
+  detail::suitesparse_cereal_realloc(&f.ColCount, f.n, integer_size_bytes);
+  detail::decode_array(ar, "f.ColCount", f.ColCount, f.n * integer_size_bytes);
+
+  bool have_iperm = false;
+  ar(CEREAL_NVP(have_iperm));
+  if (have_iperm) {
+    detail::suitesparse_cereal_realloc(&f.IPerm, f.n, integer_size_bytes);
+    detail::decode_array(ar, "f.IPerm", f.IPerm, f.n * integer_size_bytes);
+  } else {
+    if (f.IPerm != nullptr) {
+      free(f.IPerm);
+      f.IPerm = nullptr;
+    }
+  }
+
+  if (f.is_super) {
+    detail::suitesparse_cereal_realloc(&f.super, f.nsuper + 1,
+                                       integer_size_bytes);
+    detail::decode_array(ar, "f.super", f.super,
+                         (f.nsuper + 1) * integer_size_bytes);
+    detail::suitesparse_cereal_realloc(&f.pi, f.nsuper + 1, integer_size_bytes);
+    detail::decode_array(ar, "f.pi", f.pi, (f.nsuper + 1) * integer_size_bytes);
+    detail::suitesparse_cereal_realloc(&f.px, f.nsuper + 1, integer_size_bytes);
+    detail::decode_array(ar, "f.px", f.px, (f.nsuper + 1) * integer_size_bytes);
+    detail::suitesparse_cereal_realloc(&f.s, f.ssize, integer_size_bytes);
+    detail::decode_array(ar, "f.s", f.s, f.ssize * integer_size_bytes);
+    if (f.xtype != CHOLMOD_PATTERN) {
+      detail::suitesparse_cereal_realloc(&f.x, f.xsize, element_size_bytes);
+      detail::decode_array(ar, "f.x", f.x, f.xsize * element_size_bytes);
+    }
+  } else {
+    detail::suitesparse_cereal_realloc(&f.p, f.n + 1, integer_size_bytes);
+    detail::decode_array(ar, "f.p", f.p, (f.n + 1) * integer_size_bytes);
+    if (f.xtype != CHOLMOD_PATTERN) {
+      detail::suitesparse_cereal_realloc(&f.i, f.nzmax, integer_size_bytes);
+      detail::decode_array(ar, "f.i", f.i, f.nzmax * integer_size_bytes);
+      detail::suitesparse_cereal_realloc(&f.x, f.nzmax, element_size_bytes);
+      detail::decode_array(ar, "f.x", f.x, f.nzmax * element_size_bytes);
+      detail::suitesparse_cereal_realloc(&f.nz, f.n, integer_size_bytes);
+      detail::decode_array(ar, "f.nz", f.nz, f.n * integer_size_bytes);
+      detail::suitesparse_cereal_realloc(&f.next, f.n + 2, integer_size_bytes);
+      detail::decode_array(ar, "f.next", f.next,
+                           (f.n + 2) * integer_size_bytes);
+      detail::suitesparse_cereal_realloc(&f.prev, f.n + 2, integer_size_bytes);
+      detail::decode_array(ar, "f.prev", f.prev,
+                           (f.n + 2) * integer_size_bytes);
+    }
+  }
 }
 
 } // namespace cereal

--- a/include/albatross/src/covariance_functions/cholmod_representation.hpp
+++ b/include/albatross/src/covariance_functions/cholmod_representation.hpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2026 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_COVARIANCE_FUNCTION_CHOLMOD_REPRESENTATION_HPP_
+#define ALBATROSS_COVARIANCE_FUNCTION_CHOLMOD_REPRESENTATION_HPP_
+
+namespace albatross {
+
+/*
+ * CholmodCovariance is a sparse-Cholesky-backed CovarianceRepresentation
+ * (see gp.hpp:42-77). Templated on one of the serializable CHOLMOD solver
+ * wrappers (SerializableCholmodSupernodalLLT, SerializableCholmodSimplicialLLT,
+ * SerializableCholmodSimplicialLDLT). Retains the input matrix as a
+ * SparseMatrix<double>; all operations (solve, sqrt_solve, inverse_diagonal,
+ * inverse_blocks, log_determinant) route through CHOLMOD and stay
+ * sparsity-aware in the factor.
+ *
+ * The MatrixXd constructor goes through Eigen::sparseView(): dense inputs
+ * with many exact zeros (e.g. compactly-supported kernels) produce a truly
+ * sparse factor and realise the expected speedup over dense LDLT. Fully
+ * dense inputs will produce a fully dense factor, at which point the
+ * sparse backend is not expected to be faster than the dense path -- but
+ * predictions and derived quantities still match the dense reference.
+ */
+template <typename Solver> struct CholmodCovariance {
+  using Scalar = double;
+  using SparseMatrixType = Eigen::SparseMatrix<double>;
+
+  CholmodCovariance() = default;
+
+  // unique_ptr gives us move semantics without making the CHOLMOD solver
+  // itself movable -- Eigen's CholmodBase destructor frees the factor, so
+  // its implicit copy/move are deleted. Fit<GPFit<...>>::Fit(..., MatrixXd)
+  // (gp.hpp:61) move-assigns from a temporary, which requires the
+  // representation to be movable.
+  explicit CholmodCovariance(
+      const Eigen::MatrixXd &cov, double prune_reference = 1.0,
+      double prune_epsilon = Eigen::NumTraits<double>::dummy_precision())
+      : sparse_A_(cov.sparseView(prune_reference, prune_epsilon)),
+        solver_(std::make_unique<Solver>()) {
+    sparse_A_.makeCompressed();
+    solver_->compute(sparse_A_);
+    ALBATROSS_ASSERT(solver_->info() == Eigen::Success);
+  }
+
+  explicit CholmodCovariance(SparseMatrixType A)
+      : sparse_A_(std::move(A)), solver_(std::make_unique<Solver>()) {
+    sparse_A_.makeCompressed();
+    solver_->compute(sparse_A_);
+    ALBATROSS_ASSERT(solver_->info() == Eigen::Success);
+  }
+
+  // Value semantics: CholmodCovariance is a "solved covariance matrix"
+  // and should behave like one.  Eigen's CholmodBase is non-copyable
+  // (its destructor frees the factor), but sparse_A_ retains everything
+  // needed to reproduce the factor -- so on copy we allocate a fresh
+  // Solver and re-run compute().  This is O(factorization) per copy but
+  // keeps the representation usable in frameworks that store Fit in a
+  // variant / container requiring copyability (e.g. Ransac's FitModel
+  // slot).
+  CholmodCovariance(const CholmodCovariance &other)
+      : sparse_A_(other.sparse_A_), solver_() {
+    if (other.solver_) {
+      solver_ = std::make_unique<Solver>();
+      solver_->compute(sparse_A_);
+      ALBATROSS_ASSERT(solver_->info() == Eigen::Success);
+    }
+  }
+
+  CholmodCovariance &operator=(const CholmodCovariance &other) {
+    if (this != &other) {
+      sparse_A_ = other.sparse_A_;
+      if (other.solver_) {
+        solver_ = std::make_unique<Solver>();
+        solver_->compute(sparse_A_);
+        ALBATROSS_ASSERT(solver_->info() == Eigen::Success);
+      } else {
+        solver_.reset();
+      }
+    }
+    return *this;
+  }
+
+  CholmodCovariance(CholmodCovariance &&) noexcept = default;
+  CholmodCovariance &operator=(CholmodCovariance &&) noexcept = default;
+
+  // ---- CovarianceRepresentation (duck-typed) interface ----
+
+  Eigen::MatrixXd solve(const Eigen::MatrixXd &rhs) const {
+    return solver_->solve(rhs);
+  }
+
+  Eigen::Index rows() const { return solver_ ? solver_->rows() : 0; }
+  Eigen::Index cols() const { return solver_ ? solver_->cols() : 0; }
+
+  bool operator==(const CholmodCovariance &rhs) const {
+    if (rows() != rhs.rows() || cols() != rhs.cols()) {
+      return false;
+    }
+    if (rows() == 0) {
+      return true;
+    }
+    // Functional equivalence: the factor storage for supernodal LLT is not
+    // byte-stable (alignment / padding), so compare via solve on a
+    // deterministic RHS. Matches how LDLT is compared in test_serialize.cc.
+    const Eigen::VectorXd probe = Eigen::VectorXd::Ones(rows());
+    return solver_->solve(probe) == rhs.solver_->solve(probe);
+  }
+
+  // ---- Extended interface matching SerializableLDLT ----
+
+  double log_determinant() const { return solver_->logDeterminant(); }
+
+  bool is_positive_definite() const {
+    return solver_ && solver_->info() == Eigen::Success;
+  }
+
+  // D^{-1/2} L^{-1} P * rhs -- matches SerializableLDLT::sqrt_solve
+  // (see eigen/serializable_ldlt.hpp:100-104). For LLT factors D=I is
+  // implicit so the D-scale step is skipped.
+  template <class Rhs> Eigen::MatrixXd sqrt_solve(const Rhs &rhs) const {
+    Eigen::MatrixXd y = solve_with_sys(CHOLMOD_P, Eigen::MatrixXd(rhs));
+    y = solve_with_sys(CHOLMOD_L, y);
+    if (!solver_->factorPtr()->is_ll) {
+      y = factor_D_inv_sqrt().asDiagonal() * y;
+    }
+    return y;
+  }
+
+  // P^T L^{-T} D^{-1/2} * rhs -- matches
+  // SerializableLDLT::sqrt_transpose_solve
+  // (eigen/serializable_ldlt.hpp:116-121).
+  template <class Rhs>
+  Eigen::MatrixXd sqrt_transpose_solve(const Rhs &rhs) const {
+    Eigen::MatrixXd y = Eigen::MatrixXd(rhs);
+    if (!solver_->factorPtr()->is_ll) {
+      y = factor_D_inv_sqrt().asDiagonal() * y;
+    }
+    y = solve_with_sys(CHOLMOD_Lt, y);
+    y = solve_with_sys(CHOLMOD_Pt, y);
+    return y;
+  }
+
+  // Diagonal of A^{-1} by n column solves. Each solve is O(nnz_L) when the
+  // factor is sparse, so this costs O(n * nnz_L) rather than O(n^3) -- a
+  // real win for sparse problems. For a fully-dense factor this is
+  // comparable to the dense LDLT path.
+  Eigen::VectorXd inverse_diagonal(ThreadPool * /* pool */ = nullptr) const {
+    const Eigen::Index n = rows();
+    Eigen::VectorXd diag(n);
+    // CHOLMOD workspace lives on m_cholmod and is not thread-safe; run
+    // this serially regardless of the pool argument.
+    for (Eigen::Index i = 0; i < n; ++i) {
+      Eigen::VectorXd e_i = Eigen::VectorXd::Zero(n);
+      e_i(i) = 1.0;
+      const Eigen::VectorXd y = solver_->solve(e_i);
+      diag(i) = y(i);
+    }
+    return diag;
+  }
+
+  // Dense (A^{-1})_{B,B} blocks, built per-block via sparse-aware solves.
+  // Matches the signature of SerializableLDLT::inverse_blocks
+  // (eigen/serializable_ldlt.hpp:132-170).
+  std::vector<Eigen::MatrixXd>
+  inverse_blocks(const std::vector<std::vector<std::size_t>> &blocks,
+                 ThreadPool * /* pool */ = nullptr) const {
+    const Eigen::Index n = rows();
+    // CHOLMOD workspace is not thread-safe; run serially.
+    return albatross::apply(
+        blocks,
+        [this, n](const std::vector<std::size_t> &idx) -> Eigen::MatrixXd {
+          const Eigen::Index b = cast::to_index(idx.size());
+          Eigen::MatrixXd E = Eigen::MatrixXd::Zero(n, b);
+          for (Eigen::Index j = 0; j < b; ++j) {
+            E(cast::to_index(idx[cast::to_size(j)]), j) = 1.0;
+          }
+          const Eigen::MatrixXd Y = solver_->solve(E);
+          Eigen::MatrixXd out(b, b);
+          for (Eigen::Index i = 0; i < b; ++i) {
+            const Eigen::Index row_i = cast::to_index(idx[cast::to_size(i)]);
+            for (Eigen::Index j = 0; j < b; ++j) {
+              out(i, j) = Y(row_i, j);
+            }
+          }
+          return out;
+        });
+  }
+
+  SparseMatrixType sparse_A_;
+  std::unique_ptr<Solver> solver_;
+
+private:
+  // Thin wrapper around cholmod_solve for a specific sys code. Makes a
+  // mutable copy of the RHS since viewAsCholmod requires non-const data.
+  Eigen::MatrixXd solve_with_sys(int sys, const Eigen::MatrixXd &rhs) const {
+    Eigen::MatrixXd b_copy = rhs;
+    cholmod_dense b_cd = Eigen::viewAsCholmod(b_copy);
+    cholmod_common *cc = solver_->cholmodCommonPtr();
+    cholmod_factor *L = solver_->factorPtr();
+    cholmod_dense *x_cd = cholmod_solve(sys, L, &b_cd, cc);
+    ALBATROSS_ASSERT(x_cd != nullptr);
+    Eigen::MatrixXd out = Eigen::Map<Eigen::MatrixXd>(
+        reinterpret_cast<double *>(x_cd->x), cast::to_index(x_cd->nrow),
+        cast::to_index(x_cd->ncol));
+    cholmod_free_dense(&x_cd, cc);
+    return out;
+  }
+
+  // Read D^{-1/2} out of a simplicial LDLT factor. For a simplicial LDL'
+  // stored in CSC form, CHOLMOD puts D on the diagonal of the factor
+  // array, so D[k] = x[p[k]] -- the same walk Eigen uses in
+  // CholmodSupport.h's logDeterminant simplicial branch (lines 388-391).
+  // Only valid for LDLT; LLT callers must not hit this path.
+  Eigen::VectorXd factor_D_inv_sqrt() const {
+    const cholmod_factor *L = solver_->factorPtr();
+    ALBATROSS_ASSERT(!L->is_ll && "factor_D_inv_sqrt is for LDLT only");
+    ALBATROSS_ASSERT(!L->is_super && "LDLT factors are always simplicial");
+    ALBATROSS_ASSERT(L->itype == CHOLMOD_INT);
+    const int *p = static_cast<const int *>(L->p);
+    const double *x = static_cast<const double *>(L->x);
+    const Eigen::Index n = cast::to_index(L->n);
+    Eigen::VectorXd dinv(n);
+    for (Eigen::Index k = 0; k < n; ++k) {
+      const double d = x[p[k]];
+      dinv(k) = d > 0. ? 1. / std::sqrt(d) : 0.;
+    }
+    return dinv;
+  }
+};
+
+} // namespace albatross
+
+#endif /* ALBATROSS_COVARIANCE_FUNCTION_CHOLMOD_REPRESENTATION_HPP_ */

--- a/include/albatross/src/eigen/serializable_cholmod.hpp
+++ b/include/albatross/src/eigen/serializable_cholmod.hpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#ifndef ALBATROSS_EIGEN_SERIALIZABLE_CHOLMOD_H
+#define ALBATROSS_EIGEN_SERIALIZABLE_CHOLMOD_H
+
+namespace Eigen {
+
+template <typename _MatrixType, int _UpLo = Lower>
+class SerializableCholmodSupernodalLLT
+    : public CholmodSupernodalLLT<_MatrixType, _UpLo> {
+  using Base = CholmodSupernodalLLT<_MatrixType, _UpLo>;
+
+public:
+  using Base::cols;
+  using Base::rows;
+  using MatrixType = _MatrixType;
+  using StorageIndex = typename MatrixType::StorageIndex;
+  using SolverBase = CholmodBase<_MatrixType, _UpLo, Base>;
+  enum { UpLo = _UpLo };
+
+  SerializableCholmodSupernodalLLT() : Base() {}
+
+  // Public access to otherwise protected CHOLMOD state, for downstream
+  // code (e.g. CholmodCovariance) that needs to call `cholmod_solve`,
+  // `cholmod_spsolve`, or inspect the factor directly.  `m_cholmod` is
+  // declared mutable in CholmodBase; Eigen's derived classes re-import
+  // it into their private section with `using Base::m_cholmod`, so we
+  // reach it through explicit CholmodBase qualification.  The const
+  // accessors yield non-const pointers because CHOLMOD's solve API takes
+  // non-const pointers but treats the factor / common as state, and
+  // `m_cholmod` is mutable anyway.
+  cholmod_factor *factorPtr() const {
+    return this->SolverBase::m_cholmodFactor;
+  }
+  cholmod_common *cholmodCommonPtr() const {
+    return &this->SolverBase::m_cholmod;
+  }
+
+  template <class Archive>
+  void save(Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) const;
+
+  template <class Archive>
+  void load(Archive &ar, const std::uint32_t version ALBATROSS_UNUSED);
+};
+
+template <typename _MatrixType, int _UpLo = Lower>
+class SerializableCholmodSimplicialLLT
+    : public CholmodSimplicialLLT<_MatrixType, _UpLo> {
+  using Base = CholmodSimplicialLLT<_MatrixType, _UpLo>;
+
+public:
+  using Base::cols;
+  using Base::rows;
+  using MatrixType = _MatrixType;
+  using StorageIndex = typename MatrixType::StorageIndex;
+  using SolverBase = CholmodBase<_MatrixType, _UpLo, Base>;
+  enum { UpLo = _UpLo };
+
+  SerializableCholmodSimplicialLLT() : Base() {}
+
+  cholmod_factor *factorPtr() const {
+    return this->SolverBase::m_cholmodFactor;
+  }
+  cholmod_common *cholmodCommonPtr() const {
+    return &this->SolverBase::m_cholmod;
+  }
+
+  template <class Archive>
+  void save(Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) const;
+
+  template <class Archive>
+  void load(Archive &ar, const std::uint32_t version ALBATROSS_UNUSED);
+};
+
+template <typename _MatrixType, int _UpLo = Lower>
+class SerializableCholmodSimplicialLDLT
+    : public CholmodSimplicialLDLT<_MatrixType, _UpLo> {
+  using Base = CholmodSimplicialLDLT<_MatrixType, _UpLo>;
+
+public:
+  using Base::cols;
+  using Base::rows;
+  using MatrixType = _MatrixType;
+  using StorageIndex = typename MatrixType::StorageIndex;
+  using SolverBase = CholmodBase<_MatrixType, _UpLo, Base>;
+  enum { UpLo = _UpLo };
+
+  SerializableCholmodSimplicialLDLT() : Base() {}
+
+  cholmod_factor *factorPtr() const {
+    return this->SolverBase::m_cholmodFactor;
+  }
+  cholmod_common *cholmodCommonPtr() const {
+    return &this->SolverBase::m_cholmod;
+  }
+
+  template <class Archive>
+  void save(Archive &ar, const std::uint32_t version ALBATROSS_UNUSED) const;
+
+  template <class Archive>
+  void load(Archive &ar, const std::uint32_t version ALBATROSS_UNUSED);
+};
+
+} // namespace Eigen
+
+#endif // ALBATROSS_EIGEN_SERIALIZABLE_CHOLMOD_H

--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -129,12 +129,17 @@ cross_validated_scores(const PredictionMetric<Eigen::VectorXd> &metric,
   return cross_validated_scores(metric, folds, predictions.apply(get_mean));
 }
 
-inline Eigen::VectorXd leave_one_out_conditional_variance(
-    const Eigen::SerializableLDLT &covariance_ldlt) {
+// Templated on the CovarianceRepresentation so that dense
+// Eigen::SerializableLDLT, CholmodCovariance<...>, and any future
+// representation that exposes `.inverse_diagonal()` all flow through the
+// same code path.
+template <typename CovarianceRepresentation>
+inline Eigen::VectorXd
+leave_one_out_conditional_variance(const CovarianceRepresentation &covariance) {
   // The leave one out variance will be the inverse of the diagonal of the
   // inverse of covariance (that's a mouthful!) For details see Equation 5.12 of
   // Gaussian Processes for Machine Learning
-  return covariance_ldlt.inverse_diagonal().array().inverse();
+  return covariance.inverse_diagonal().array().inverse();
 }
 
 inline Eigen::VectorXd
@@ -194,9 +199,10 @@ held_out_prediction(const Eigen::MatrixXd &inverse_block,
   return JointDistribution(mean, A_inv);
 }
 
-template <typename GroupKey, typename PredictType>
+template <typename CovarianceRepresentation, typename GroupKey,
+          typename PredictType>
 inline std::map<GroupKey, PredictType>
-held_out_predictions(const Eigen::SerializableLDLT &covariance,
+held_out_predictions(const CovarianceRepresentation &covariance,
                      const Eigen::VectorXd &target_mean,
                      const Eigen::VectorXd &information,
                      const GroupIndexer<GroupKey> &group_indexer,
@@ -238,8 +244,8 @@ leave_one_group_out_conditional(const JointDistribution &prior,
   Eigen::SerializableLDLT ldlt(covariance);
   const Eigen::VectorXd deviation = truth.mean - prior.mean;
   const Eigen::VectorXd information = ldlt.solve(deviation);
-  return held_out_predictions(covariance, truth.mean, information,
-                              group_indexer, predict_type, pool);
+  return held_out_predictions(ldlt, truth.mean, information, group_indexer,
+                              predict_type, pool);
 }
 
 } // namespace details

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ albatross_add_test(albatross_unit_tests
   test_block_utils.cc
   test_call_trace.cc
   test_callers.cc
+  test_cholmod_representation.cc
   test_compression.cc
   test_conditional_gaussian.cc
   test_concatenate.cc

--- a/tests/test_cholmod_representation.cc
+++ b/tests/test_cholmod_representation.cc
@@ -1,0 +1,406 @@
+/*
+ * Copyright (C) 2026 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/CholmodSupport>
+#include <albatross/Indexing>
+#include <albatross/Ransac>
+#include <albatross/serialize/GP>
+#include <albatross/utils/RandomUtils>
+
+#include <gtest/gtest.h>
+
+#include "test_models.h"
+#include "test_utils.h"
+
+namespace albatross {
+
+using SparseDouble = Eigen::SparseMatrix<double>;
+using SupernodalLLT = Eigen::SerializableCholmodSupernodalLLT<SparseDouble>;
+using SimplicialLLT = Eigen::SerializableCholmodSimplicialLLT<SparseDouble>;
+using SimplicialLDLT = Eigen::SerializableCholmodSimplicialLDLT<SparseDouble>;
+
+template <typename Solver>
+class CholmodCovarianceTest : public ::testing::Test {
+public:
+  CholmodCovarianceTest() : cov(), rhs() {
+    const Eigen::Index n = 8;
+    std::default_random_engine gen(1234);
+    cov = random_covariance_matrix(n, gen);
+    rhs = Eigen::MatrixXd::Random(n, 3);
+  }
+  Eigen::MatrixXd cov;
+  Eigen::MatrixXd rhs;
+};
+
+using CholmodSolvers =
+    ::testing::Types<SupernodalLLT, SimplicialLLT, SimplicialLDLT>;
+TYPED_TEST_SUITE(CholmodCovarianceTest, CholmodSolvers);
+
+TYPED_TEST(CholmodCovarianceTest, test_solve_matches_dense) {
+  const CholmodCovariance<TypeParam> rep(this->cov);
+  const Eigen::SerializableLDLT dense(this->cov);
+  EXPECT_LE((rep.solve(this->rhs) - dense.solve(this->rhs)).norm(), 1e-10);
+}
+
+TYPED_TEST(CholmodCovarianceTest, test_log_determinant_matches_dense) {
+  const CholmodCovariance<TypeParam> rep(this->cov);
+  const Eigen::SerializableLDLT dense(this->cov);
+  EXPECT_NEAR(rep.log_determinant(), dense.log_determinant(), 1e-10);
+}
+
+// The square root A^{1/2} is not unique (orthogonal rotation ambiguity), so
+// compare via the quadratic form b^T A^{-1} b which IS unique.
+TYPED_TEST(CholmodCovarianceTest, test_sqrt_solve_quadratic_form) {
+  const CholmodCovariance<TypeParam> rep(this->cov);
+  const Eigen::MatrixXd sqrt_b = rep.sqrt_solve(this->rhs);
+  const Eigen::MatrixXd quad_sqrt = sqrt_b.transpose() * sqrt_b;
+  const Eigen::MatrixXd quad_direct =
+      this->rhs.transpose() * rep.solve(this->rhs);
+  EXPECT_LE((quad_sqrt - quad_direct).norm(), 1e-10);
+}
+
+// With the SerializableLDLT convention S = D^{-1/2} L^{-1} P, sqrt_solve
+// applies S and sqrt_transpose_solve applies S^T, with S^T S = A^{-1}.
+// Composing in order -- first sqrt_solve, then sqrt_transpose_solve --
+// yields exactly A^{-1} b.  (The other order gives S S^T, which is NOT
+// A^{-1}.)
+TYPED_TEST(CholmodCovarianceTest, test_sqrt_transpose_solve_composes) {
+  const CholmodCovariance<TypeParam> rep(this->cov);
+  const Eigen::MatrixXd sqrt_b = rep.sqrt_solve(this->rhs);
+  const Eigen::MatrixXd composed = rep.sqrt_transpose_solve(sqrt_b);
+  const Eigen::MatrixXd direct = rep.solve(this->rhs);
+  EXPECT_LE((composed - direct).norm(), 1e-10);
+}
+
+// sqrt_solve and sqrt_transpose_solve are dual decompositions of A^{-1},
+// so sqrt_transpose_solve(sqrt_solve(x)^T)^T should reconstruct A^{-1} x
+// only up to the A^{1/2} ambiguity -- but the composition
+// sqrt_solve(A) -> then take (sqrt_solve)^T * (sqrt_solve) must equal
+// A^{-1}.  Validate that on a random full matrix.
+TYPED_TEST(CholmodCovarianceTest, test_sqrt_solve_reconstructs_inverse) {
+  const CholmodCovariance<TypeParam> rep(this->cov);
+  const Eigen::MatrixXd n_by_n =
+      Eigen::MatrixXd::Identity(this->cov.rows(), this->cov.cols());
+  const Eigen::MatrixXd sqrt_I = rep.sqrt_solve(n_by_n);
+  const Eigen::MatrixXd A_inv_reconstructed = sqrt_I.transpose() * sqrt_I;
+  const Eigen::MatrixXd A_inv_direct =
+      rep.solve(Eigen::MatrixXd::Identity(this->cov.rows(), this->cov.cols()));
+  EXPECT_LE((A_inv_reconstructed - A_inv_direct).norm(), 1e-8);
+}
+
+TYPED_TEST(CholmodCovarianceTest, test_inverse_diagonal_matches_dense) {
+  const CholmodCovariance<TypeParam> rep(this->cov);
+  const Eigen::SerializableLDLT dense(this->cov);
+  const Eigen::VectorXd cholmod_diag = rep.inverse_diagonal();
+  const Eigen::VectorXd dense_diag = dense.inverse_diagonal();
+  EXPECT_LE((cholmod_diag - dense_diag).norm(), 1e-10);
+}
+
+TYPED_TEST(CholmodCovarianceTest, test_inverse_blocks_matches_dense) {
+  const CholmodCovariance<TypeParam> rep(this->cov);
+  const Eigen::SerializableLDLT dense(this->cov);
+  // A mix of contiguous, singleton, and multi-index blocks.
+  const std::vector<std::vector<std::size_t>> blocks = {
+      {0, 1}, {2}, {3, 4, 5}, {6, 7}};
+  const auto cholmod_blocks = rep.inverse_blocks(blocks);
+  const auto dense_blocks = dense.inverse_blocks(blocks);
+  ASSERT_EQ(cholmod_blocks.size(), dense_blocks.size());
+  for (std::size_t i = 0; i < blocks.size(); ++i) {
+    EXPECT_LE((cholmod_blocks[i] - dense_blocks[i]).norm(), 1e-10)
+        << "block " << i;
+  }
+}
+
+TYPED_TEST(CholmodCovarianceTest, test_is_positive_definite) {
+  const CholmodCovariance<TypeParam> rep(this->cov);
+  EXPECT_TRUE(rep.is_positive_definite());
+}
+
+TYPED_TEST(CholmodCovarianceTest, test_rows_cols) {
+  const CholmodCovariance<TypeParam> rep(this->cov);
+  EXPECT_EQ(rep.rows(), this->cov.rows());
+  EXPECT_EQ(rep.cols(), this->cov.cols());
+}
+
+// --- Dense-GP prediction parity via manual Fit<GPFit<...>> construction.
+// This exercises the CovarianceRepresentation duck-typed interface through
+// the same gp_marginal_prediction / gp_joint_prediction helpers the dense
+// GP code uses.
+TYPED_TEST(CholmodCovarianceTest, test_gp_marginal_prediction_matches_dense) {
+  const Eigen::Index n_train = this->cov.rows();
+  MarginalDistribution targets(Eigen::VectorXd::Random(n_train));
+  targets.covariance = Eigen::VectorXd::Constant(n_train, 1e-6).asDiagonal();
+
+  std::vector<double> train_features(cast::to_size(n_train));
+  for (Eigen::Index i = 0; i < n_train; ++i) {
+    train_features[cast::to_size(i)] = cast::to_double(i);
+  }
+
+  using CholFit = Fit<GPFit<CholmodCovariance<TypeParam>, double>>;
+  using DenseFit = Fit<GPFit<Eigen::SerializableLDLT, double>>;
+  const CholFit chol_fit(train_features, this->cov, targets);
+  const DenseFit dense_fit(train_features, this->cov, targets);
+
+  // Build a cross-covariance to pretend-predict with.
+  const Eigen::Index n_test = 4;
+  const Eigen::MatrixXd cross = Eigen::MatrixXd::Random(n_train, n_test);
+  const Eigen::VectorXd prior_var = Eigen::VectorXd::Ones(n_test);
+  const Eigen::MatrixXd prior_cov =
+      Eigen::MatrixXd::Identity(n_test, n_test) +
+      Eigen::MatrixXd::Constant(n_test, n_test, 0.1);
+
+  const auto chol_marginal = gp_marginal_prediction(
+      cross, prior_var, chol_fit.information, chol_fit.train_covariance);
+  const auto dense_marginal = gp_marginal_prediction(
+      cross, prior_var, dense_fit.information, dense_fit.train_covariance);
+
+  EXPECT_LE((chol_marginal.mean - dense_marginal.mean).norm(), 1e-10);
+  EXPECT_LE((Eigen::VectorXd(chol_marginal.covariance.diagonal()) -
+             Eigen::VectorXd(dense_marginal.covariance.diagonal()))
+                .norm(),
+            1e-10);
+
+  const auto chol_joint = gp_joint_prediction(
+      cross, prior_cov, chol_fit.information, chol_fit.train_covariance);
+  const auto dense_joint = gp_joint_prediction(
+      cross, prior_cov, dense_fit.information, dense_fit.train_covariance);
+
+  EXPECT_LE((chol_joint.mean - dense_joint.mean).norm(), 1e-10);
+  EXPECT_LE((chol_joint.covariance - dense_joint.covariance).norm(), 1e-8);
+}
+
+// Sparsity smoke test: give the representation a dense MatrixXd that
+// happens to have a tridiagonal structure (many exact zeros) and verify
+// that the kept SparseMatrix<double> has the expected sparsity.  This is
+// the mechanism by which compactly-supported covariance kernels will get
+// real speedups out of the Cholmod backend.
+TEST(CholmodCovarianceSparsity, preserves_exact_zeros) {
+  const Eigen::Index n = 20;
+  Eigen::MatrixXd dense = Eigen::MatrixXd::Zero(n, n);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    dense(i, i) = 4.;
+    if (i > 0) {
+      dense(i, i - 1) = dense(i - 1, i) = 1.;
+    }
+  }
+  // 3n - 2 nonzeros in a tridiagonal n x n matrix.
+  const auto expected_nnz = 3 * n - 2;
+  const CholmodCovariance<SupernodalLLT> rep(dense);
+  EXPECT_EQ(rep.sparse_A_.nonZeros(), expected_nnz);
+  EXPECT_LT(rep.sparse_A_.nonZeros(), n * n);
+}
+
+// End-to-end serialization of a Fit<GPFit<CholmodCovariance<...>, double>>.
+// Round-trips through JSON and PortableBinary and verifies predictions
+// stay identical before and after.
+template <typename Solver>
+class CholmodCovarianceFitSerializeTest : public ::testing::Test {};
+TYPED_TEST_SUITE(CholmodCovarianceFitSerializeTest, CholmodSolvers);
+
+TYPED_TEST(CholmodCovarianceFitSerializeTest, test_fit_roundtrip_json) {
+  const Eigen::Index n = 6;
+  std::default_random_engine gen(9999);
+  const Eigen::MatrixXd cov = random_covariance_matrix(n, gen);
+  MarginalDistribution targets(Eigen::VectorXd::Random(n));
+  targets.covariance = Eigen::VectorXd::Constant(n, 1e-8).asDiagonal();
+  std::vector<double> features(cast::to_size(n));
+  for (Eigen::Index i = 0; i < n; ++i) {
+    features[cast::to_size(i)] = cast::to_double(i);
+  }
+
+  using FitType = Fit<GPFit<CholmodCovariance<TypeParam>, double>>;
+  const FitType fit_in(features, cov, targets);
+
+  std::ostringstream os;
+  {
+    cereal::JSONOutputArchive oarchive(os);
+    oarchive(fit_in);
+  }
+  FitType fit_out;
+  {
+    std::istringstream is(os.str());
+    cereal::JSONInputArchive iarchive(is);
+    iarchive(fit_out);
+  }
+
+  EXPECT_EQ(fit_in.train_features, fit_out.train_features);
+  EXPECT_EQ(fit_in.information, fit_out.information);
+
+  const Eigen::VectorXd probe = Eigen::VectorXd::Ones(n);
+  EXPECT_LE((fit_in.train_covariance.solve(probe) -
+             fit_out.train_covariance.solve(probe))
+                .norm(),
+            1e-12);
+}
+
+// --- CV / RANSAC parity vs the dense SerializableLDLT-backed GP. --------
+//
+// CholmodGaussianProcess mirrors the AdaptedGaussianProcess pattern in
+// test_models.h:186-229: override _fit_impl to return a Fit whose
+// CovarianceRepresentation is CholmodCovariance<Solver>; inherit
+// _predict_impl and route cross_validated_predictions through the generic
+// gp_cross_validated_predictions helper.  Combined with the
+// cross_validation_utils.hpp change that templatizes held_out_predictions
+// on the covariance type, this plugs the Cholmod backend into the
+// public cross_validate() and ransac() APIs.
+template <typename CovFunc, typename Solver>
+class CholmodGaussianProcess
+    : public GaussianProcessBase<CovFunc, ZeroMean,
+                                 CholmodGaussianProcess<CovFunc, Solver>> {
+public:
+  using Base = GaussianProcessBase<CovFunc, ZeroMean,
+                                   CholmodGaussianProcess<CovFunc, Solver>>;
+  using Base::_predict_impl;
+  using Base::Base;
+
+  template <typename FeatureType>
+  auto _fit_impl(const std::vector<FeatureType> &features,
+                 const MarginalDistribution &targets) const {
+    const auto measurement_features = as_measurements(features);
+    Eigen::MatrixXd cov =
+        this->covariance_function_(measurement_features, Base::threads_.get());
+    MarginalDistribution zero_mean_targets(targets);
+    this->mean_function_.remove_from(measurement_features,
+                                     &zero_mean_targets.mean);
+    using FitType = Fit<GPFit<CholmodCovariance<Solver>, FeatureType>>;
+    return FitType(features, cov, zero_mean_targets);
+  }
+
+  template <typename FeatureType, typename PredictType, typename GroupKey>
+  std::map<GroupKey, PredictType>
+  cross_validated_predictions(const RegressionDataset<FeatureType> &dataset,
+                              const GroupIndexer<GroupKey> &group_indexer,
+                              PredictTypeIdentity<PredictType> identity) const {
+    return gp_cross_validated_predictions(dataset, group_indexer, *this,
+                                          identity);
+  }
+};
+
+template <typename Solver, typename CovFunc>
+auto cholmod_gp_from_covariance(CovFunc &&covariance) {
+  return CholmodGaussianProcess<std::decay_t<CovFunc>, Solver>(
+      std::forward<CovFunc>(covariance));
+}
+
+// Typed test fixture: one instantiation per Cholmod solver variant.
+template <typename Solver>
+class CholmodCVRansacTest : public ::testing::Test {};
+TYPED_TEST_SUITE(CholmodCVRansacTest, CholmodSolvers);
+
+namespace {
+
+// Tight tolerance on the means; slightly looser on the marginal
+// variances / covariances because they involve an additional solve on
+// the group-block level.  For the identical dense inputs and solves we
+// hit ~1e-10 comfortably.
+constexpr double kCVMeanTol = 1e-10;
+constexpr double kCVVarianceTol = 1e-10;
+
+template <typename Pred1, typename Pred2>
+void expect_groupwise_marginal_match(const Pred1 &a, const Pred2 &b,
+                                     double mean_tol, double var_tol) {
+  ASSERT_EQ(a.size(), b.size());
+  for (const auto &[key, a_pred] : a) {
+    const auto it = b.find(key);
+    ASSERT_TRUE(it != b.end()) << "missing group key in second prediction";
+    const auto &b_pred = it->second;
+    EXPECT_LE((a_pred.mean - b_pred.mean).norm(), mean_tol) << "group " << key;
+    EXPECT_LE((Eigen::VectorXd(a_pred.covariance.diagonal()) -
+               Eigen::VectorXd(b_pred.covariance.diagonal()))
+                  .norm(),
+              var_tol)
+        << "group " << key;
+  }
+}
+
+} // namespace
+
+TYPED_TEST(CholmodCVRansacTest, test_loo_cv_matches_dense) {
+  const auto dataset = make_toy_linear_data();
+  const auto covariance = make_simple_covariance_function();
+
+  const auto dense_gp = gp_from_covariance(covariance);
+  const auto cholmod_gp = cholmod_gp_from_covariance<TypeParam>(covariance);
+
+  LeaveOneOutGrouper loo;
+  const auto dense_cv =
+      dense_gp.cross_validate().predict(dataset, loo).marginals();
+  const auto cholmod_cv =
+      cholmod_gp.cross_validate().predict(dataset, loo).marginals();
+
+  expect_groupwise_marginal_match(dense_cv, cholmod_cv, kCVMeanTol,
+                                  kCVVarianceTol);
+}
+
+TYPED_TEST(CholmodCVRansacTest, test_logo_cv_matches_dense) {
+  const auto dataset = make_toy_linear_data();
+  const auto covariance = make_simple_covariance_function();
+
+  const auto dense_gp = gp_from_covariance(covariance);
+  const auto cholmod_gp = cholmod_gp_from_covariance<TypeParam>(covariance);
+
+  // Two-groups: even- vs odd-indexed feature values.  Plenty for LOGO to
+  // exercise the inverse_blocks path.
+  const auto grouper = [](const double &x) { return static_cast<int>(x) % 2; };
+
+  const auto dense_cv =
+      dense_gp.cross_validate().predict(dataset, grouper).marginals();
+  const auto cholmod_cv =
+      cholmod_gp.cross_validate().predict(dataset, grouper).marginals();
+
+  expect_groupwise_marginal_match(dense_cv, cholmod_cv, kCVMeanTol,
+                                  kCVVarianceTol);
+}
+
+TYPED_TEST(CholmodCVRansacTest, test_ransac_matches_dense) {
+  // Inject two outliers (matching test_ransac.cc:59-109's pattern) so
+  // RANSAC has something to reject.
+  auto dataset = make_toy_linear_data();
+  const std::vector<std::size_t> bad_inds = {3, 5};
+  for (const auto &i : bad_inds) {
+    dataset.targets.mean[cast::to_index(i)] = std::pow(-1, i) * 400.;
+  }
+
+  const auto covariance = make_simple_covariance_function();
+
+  RansacConfig config;
+  config.inlier_threshold = 1.;
+  config.random_sample_size = 3;
+  config.min_consensus_size = 3;
+  config.max_iterations = 20;
+  config.max_failed_candidates = 20;
+
+  DefaultGPRansacStrategy ransac_strategy;
+
+  // Same random seed consumed by both RANSACs: they'll sample the same
+  // candidates and converge on the same consensus set, so the resulting
+  // fits are on identical inlier subsets and their predictions should
+  // agree to within the dense/cholmod solve tolerance.
+  const auto dense_ransac =
+      gp_from_covariance(covariance).ransac(ransac_strategy, config);
+  const auto cholmod_ransac = cholmod_gp_from_covariance<TypeParam>(covariance)
+                                  .ransac(ransac_strategy, config);
+
+  const auto dense_fit = dense_ransac.fit(dataset);
+  const auto cholmod_fit = cholmod_ransac.fit(dataset);
+
+  const auto dense_pred = dense_fit.predict(dataset.features).marginal();
+  const auto cholmod_pred = cholmod_fit.predict(dataset.features).marginal();
+
+  EXPECT_LE((dense_pred.mean - cholmod_pred.mean).norm(), 1e-8);
+  EXPECT_LE((Eigen::VectorXd(dense_pred.covariance.diagonal()) -
+             Eigen::VectorXd(cholmod_pred.covariance.diagonal()))
+                .norm(),
+            1e-8);
+}
+
+} // namespace albatross

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -276,6 +276,15 @@ struct LinearCombo : public SerializableType<LinearCombination<double>> {
   }
 };
 
+// Note: Eigen's Cholmod wrapper classes (and therefore CholmodCovariance) are
+// non-copyable and non-movable -- their user-defined destructor frees the
+// cholmod_factor, which suppresses implicit copy/move generation. They
+// can't plug into the generic SerializableType typed-test harness (whose
+// base virtual `create()` returns the representation by value). Raw
+// round-trip tests for the Cholmod wrappers live in namespace `other`
+// below, and end-to-end Fit<GPFit<CholmodCovariance<...>, ...>> round-trip
+// coverage lives in tests/test_cholmod_representation.cc.
+
 REGISTER_TYPED_TEST_SUITE_P(SerializeTest, test_roundtrip_serialize_json,
                             test_roundtrip_serialize_binary,
                             test_roundtrip_serialize_portable_binary);
@@ -557,6 +566,107 @@ TEST(test_serialize, serialize_spqr_simple) {
   }
   const auto x_out = spqr_out.solve(b);
   EXPECT_EQ(x, x_out);
+}
+
+// --- Raw CHOLMOD LLT/LDLT round-trip tests (parallels the SPQR ones). ---
+
+template <typename CholmodSolver> void expect_cholmod_roundtrip_simple() {
+  Eigen::MatrixXd Adense(3, 3);
+  // clang-format off
+  Adense <<
+     4,  1,  0,
+     1,  3,  1,
+     0,  1,  2;
+  // clang-format on
+  Eigen::VectorXd b(3);
+  b << 2, 4, 99;
+
+  CholmodSolver solver;
+  solver.compute(Adense.sparseView());
+  EXPECT_EQ(solver.info(), Eigen::Success);
+  const Eigen::VectorXd x = solver.solve(b);
+
+  std::ostringstream os;
+  {
+    cereal::JSONOutputArchive oarchive(os);
+    solver.save(oarchive, 0);
+  }
+  CholmodSolver solver_out;
+  {
+    std::istringstream is(os.str());
+    cereal::JSONInputArchive iarchive(is);
+    solver_out.load(iarchive, 0);
+  }
+  const Eigen::VectorXd x_out = solver_out.solve(b);
+  EXPECT_EQ(x, x_out);
+}
+
+TEST(test_serialize, serialize_cholmod_supernodal_llt_simple) {
+  expect_cholmod_roundtrip_simple<
+      Eigen::SerializableCholmodSupernodalLLT<Eigen::SparseMatrix<double>>>();
+}
+
+TEST(test_serialize, serialize_cholmod_simplicial_llt_simple) {
+  expect_cholmod_roundtrip_simple<
+      Eigen::SerializableCholmodSimplicialLLT<Eigen::SparseMatrix<double>>>();
+}
+
+TEST(test_serialize, serialize_cholmod_simplicial_ldlt_simple) {
+  expect_cholmod_roundtrip_simple<
+      Eigen::SerializableCholmodSimplicialLDLT<Eigen::SparseMatrix<double>>>();
+}
+
+template <typename CholmodSolver> void expect_cholmod_roundtrip_random() {
+  // Smaller than the SPQR version: SPD factorization is more expensive per
+  // matrix, and the point here is coverage across sizes / sparsity, not
+  // stress.
+  constexpr Eigen::Index kMeanSize = 20;
+  constexpr std::size_t kNumIters = 50;
+  std::seed_seq seed{17};
+  std::default_random_engine gen{seed};
+  const auto gen_size = [&gen]() {
+    std::poisson_distribution<Eigen::Index> size_dist{kMeanSize};
+    return std::max(Eigen::Index{2}, size_dist(gen));
+  };
+  CholmodSolver solver_out;
+  for (std::size_t iter = 0; iter < kNumIters; ++iter) {
+    const auto n = gen_size();
+    const Eigen::MatrixXd A = albatross::random_covariance_matrix(n, gen);
+    const Eigen::VectorXd B = Eigen::VectorXd::Random(n);
+
+    CholmodSolver solver;
+    solver.compute(A.sparseView());
+    EXPECT_EQ(solver.info(), Eigen::Success);
+    const Eigen::VectorXd x = solver.solve(B);
+
+    std::ostringstream os;
+    {
+      cereal::JSONOutputArchive oarchive(os);
+      solver.save(oarchive, 0);
+    }
+    {
+      std::istringstream is(os.str());
+      cereal::JSONInputArchive iarchive(is);
+      solver_out.load(iarchive, 0);
+    }
+    const Eigen::VectorXd x_out = solver_out.solve(B);
+    EXPECT_EQ(x, x_out);
+  }
+}
+
+TEST(test_serialize, serialize_cholmod_supernodal_llt_random) {
+  expect_cholmod_roundtrip_random<
+      Eigen::SerializableCholmodSupernodalLLT<Eigen::SparseMatrix<double>>>();
+}
+
+TEST(test_serialize, serialize_cholmod_simplicial_llt_random) {
+  expect_cholmod_roundtrip_random<
+      Eigen::SerializableCholmodSimplicialLLT<Eigen::SparseMatrix<double>>>();
+}
+
+TEST(test_serialize, serialize_cholmod_simplicial_ldlt_random) {
+  expect_cholmod_roundtrip_random<
+      Eigen::SerializableCholmodSimplicialLDLT<Eigen::SparseMatrix<double>>>();
 }
 
 TEST(test_serialize, serialize_spqr_random) {


### PR DESCRIPTION
Previously we offered only Eigen's dense LDLT decomposition as a backend for vanilla GP models.  In the case of compact spatial kernels or other structured effects, the prior covariance may be sparse.  To improve fitting performance on such problems, this commit introduces

 1) support for direct CHOLMOD solvers

 2) a CovarianceRepresentation based on CHOLMOD decompositions

This patch is going to fail CI until the bazel registry is updated.