### PR TITLE
Basic training feature pruning support

### DIFF
--- a/include/albatross/src/cereal/gp.hpp
+++ b/include/albatross/src/cereal/gp.hpp
@@ -16,6 +16,7 @@
 using albatross::Fit;
 using albatross::GaussianProcessBase;
 using albatross::GPFit;
+using albatross::GPRemoveCache;
 using albatross::LinearCombination;
 using albatross::SparseGPFit;
 
@@ -25,6 +26,23 @@ using albatross::SparseGPFit;
 
 namespace cereal {
 
+// All four fields are serialized: the cached matrices are
+// deterministic functions of `indices` plus the fit's
+// covariance/information, so we could rebuild them on load, but
+// doing so would require re-running a solve against the full
+// training covariance.  Persisting them directly keeps deserialized
+// fits equivalent to their originals without extra setup.
+template <typename Archive>
+inline void serialize(Archive &archive, GPRemoveCache &removed,
+                      const std::uint32_t) {
+  archive(cereal::make_nvp("indices", removed.indices));
+  archive(cereal::make_nvp("precision_train_removed",
+                           removed.precision_train_removed));
+  archive(cereal::make_nvp("conditional_cov_removed",
+                           removed.conditional_cov_removed));
+  archive(cereal::make_nvp("delta_removed", removed.delta_removed));
+}
+
 template <typename Archive, typename CovarianceRepresentation,
           typename FeatureType>
 inline void serialize(Archive &archive,
@@ -33,6 +51,7 @@ inline void serialize(Archive &archive,
   archive(cereal::make_nvp("information", fit.information));
   archive(cereal::make_nvp("train_ldlt", fit.train_covariance));
   archive(cereal::make_nvp("train_features", fit.train_features));
+  archive(cereal::make_nvp("removed", fit.removed));
 }
 
 template <typename Archive, typename FeatureType>

--- a/include/albatross/src/core/fit_model.hpp
+++ b/include/albatross/src/core/fit_model.hpp
@@ -94,6 +94,22 @@ public:
     update_in_place(dataset.features, dataset.targets);
   }
 
+  template <typename M = ModelType,
+            typename std::enable_if<has_valid_prune<M, Fit>::value, int>::type =
+                0>
+  auto prune(const std::vector<std::size_t> &indices) const {
+    auto pruned_fit = model_._prune_impl(Fit(fit_), indices);
+    return FitModel<ModelType, decltype(pruned_fit)>(model_,
+                                                     std::move(pruned_fit));
+  }
+
+  template <typename M = ModelType,
+            typename std::enable_if<can_prune_in_place<M, Fit>::value,
+                                    int>::type = 0>
+  void prune_in_place(const std::vector<std::size_t> &indices) {
+    fit_ = model_._prune_impl(fit_, indices);
+  }
+
   Fit get_fit() const { return fit_; }
 
   Fit &get_fit() { return fit_; }
@@ -115,6 +131,12 @@ template <typename ModelType, typename FitType, typename FeatureType>
 auto update(const FitModel<ModelType, FitType> &fit_model,
             const RegressionDataset<FeatureType> &dataset) {
   return fit_model.update(dataset);
+}
+
+template <typename ModelType, typename FitType>
+auto prune(const FitModel<ModelType, FitType> &fit_model,
+           const std::vector<std::size_t> &indices) {
+  return fit_model.prune(indices);
 }
 
 } // namespace albatross

--- a/include/albatross/src/core/traits.hpp
+++ b/include/albatross/src/core/traits.hpp
@@ -265,6 +265,52 @@ public:
   typedef FitModel<ModelType, UpdatedFitType> type;
 };
 
+// Prune traits
+
+template <typename T, typename ExistingFitType> class fit_model_prune_traits {
+
+  template <typename C,
+            typename FitType = decltype(std::declval<const C>()._prune_impl(
+                std::declval<const ExistingFitType &>(),
+                std::declval<const std::vector<std::size_t> &>()))>
+  static FitType test(C *);
+  template <typename> static void test(...);
+
+public:
+  using PruneFitType = decltype(test<T>(0));
+  static constexpr bool has_valid_prune =
+      is_valid_fit_type<PruneFitType>::value;
+  static constexpr bool can_prune_in_place =
+      std::is_same<PruneFitType, ExistingFitType>::value;
+};
+
+template <typename T, typename ExistingFitType> struct has_valid_prune {
+  static constexpr bool value =
+      fit_model_prune_traits<T, ExistingFitType>::has_valid_prune;
+};
+
+template <typename T, typename ExistingFitType> struct can_prune_in_place {
+  static constexpr bool value =
+      fit_model_prune_traits<T, ExistingFitType>::can_prune_in_place;
+};
+
+/*
+ * Determines the type of pruned_fit in a call along the lines of :
+ *
+ *   auto fit_model = model.fit(dataset);
+ *   auto pruned_fit_model = fit_model.prune(indices_to_remove);
+ */
+template <typename T> class pruned_fit_model_type {
+
+  using ModelType = typename T::model_type;
+  using FitType = typename T::fit_type;
+  using PrunedFitType =
+      typename fit_model_prune_traits<ModelType, FitType>::PruneFitType;
+
+public:
+  typedef FitModel<ModelType, PrunedFitType> type;
+};
+
 } // namespace albatross
 
 #endif

--- a/include/albatross/src/linalg/block_symmetric.hpp
+++ b/include/albatross/src/linalg/block_symmetric.hpp
@@ -84,6 +84,13 @@ inline Eigen::Matrix<_Scalar, _Rows, _Cols> BlockSymmetric<Solver>::solve(
   Eigen::Index n = A.rows() + S.rows();
   ALBATROSS_ASSERT(rhs.rows() == n);
 
+  // With an empty bottom block the block-matrix inversion reduces to
+  // solving A directly; short-circuit to avoid invoking an
+  // uninitialized LDLT on the empty S.
+  if (S.rows() == 0) {
+    return A.solve(rhs);
+  }
+
   const Eigen::MatrixXd rhs_a = rhs.topRows(A.rows());
   const Eigen::MatrixXd rhs_b = rhs.bottomRows(S.rows());
 

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -18,6 +18,115 @@ namespace albatross {
 template <typename CovarianceRepresentation, typename FeatureType>
 struct GPFit {};
 
+inline Eigen::MatrixXd selector_matrix(Eigen::Index n_train,
+                                       std::vector<std::size_t> indices) {
+  Eigen::Index n_cols = albatross::cast::to_index(indices.size());
+  Eigen::MatrixXd E{Eigen::MatrixXd::Zero(n_train, n_cols)};
+  for (Eigen::Index col = 0; col < n_cols; ++col) {
+    const std::size_t idx = albatross::cast::to_size(col);
+    E(indices[idx], col) = 1.0;
+  }
+  return E;
+}
+
+// Precomputed data for making corrections to predictive
+// distributions, so that we can remove observations after we have
+// done the big expensive fit.
+struct GPRemoveCache {
+  // {z}
+  std::vector<std::size_t> indices;
+  // K^{-1}[x, z]
+  Eigen::MatrixXd precision_train_removed;
+  // K_{zz}
+  //
+  // TODO(@peddie): perhaps better to store this as a Cholesky factor,
+  // because after precomputation, we may get more stable products if
+  // we do a quadratic form rather than solving to one side.
+  Eigen::MatrixXd conditional_cov_removed;
+  // conditional_cov_removed * information_removed
+  Eigen::VectorXd delta_removed;
+
+  [[nodiscard]] inline operator bool() const { return !indices.empty(); }
+
+  [[nodiscard]] inline bool operator==(const GPRemoveCache &other) const {
+    // Deep-compare every field so a serialization round-trip that
+    // silently drops a cached matrix fails equality; the matrix
+    // fields are deterministic functions of indices + the fit's
+    // covariance/information, so this stays consistent with the
+    // fast-path "same indices ⟹ same cache" invariant.
+    return indices == other.indices &&
+           precision_train_removed == other.precision_train_removed &&
+           conditional_cov_removed == other.conditional_cov_removed &&
+           delta_removed == other.delta_removed;
+  }
+
+  GPRemoveCache() = default;
+
+  template <typename CovarianceRepresentation>
+  GPRemoveCache(const std::vector<std::size_t> &z,
+                const CovarianceRepresentation &train_covariance,
+                const Eigen::VectorXd &train_information)
+      : indices{z} {
+    if (!(*this)) {
+      return;
+    }
+    const Eigen::Index n_train{train_covariance.rows()};
+    const Eigen::Index n_removed{albatross::cast::to_index(indices.size())};
+
+    const Eigen::MatrixXd E_removed{selector_matrix(n_train, indices)};
+
+    precision_train_removed = train_covariance.solve(E_removed);
+
+    Eigen::MatrixXd precision_removed =
+        albatross::subset_rows(precision_train_removed, indices);
+    Eigen::SerializableLDLT P_zz_ldlt(precision_removed);
+    conditional_cov_removed =
+        P_zz_ldlt.solve(Eigen::MatrixXd::Identity(n_removed, n_removed));
+
+    Eigen::VectorXd v_removed = albatross::subset(train_information, indices);
+
+    delta_removed = conditional_cov_removed * v_removed;
+  }
+
+  [[nodiscard]] inline Eigen::MatrixXd
+  compute_W(const Eigen::MatrixXd &cross) const {
+    ALBATROSS_ASSERT(*this &&
+                     "Cannot compute W with no removed training data.");
+    return cross.transpose() * precision_train_removed;
+  }
+
+  // Corrections are to be added to the full term.
+  //
+  // The only thing we need is W, which depends on the
+  // cross-covariance matrix.  You can either compute it with
+  // `compute_W()` directly, or use a subset of the `explained()`
+  // matrix if you are computing explained uncertainty already.
+
+  [[nodiscard]] inline Eigen::VectorXd
+  mean_correction(const Eigen::MatrixXd &W) const {
+    ALBATROSS_ASSERT(
+        *this &&
+        "Cannot compute mean correction with no removed training data.");
+    return -W * delta_removed;
+  }
+
+  [[nodiscard]] inline Eigen::VectorXd
+  marginal_correction(const Eigen::MatrixXd &W) const {
+    ALBATROSS_ASSERT(
+        *this &&
+        "Cannot compute mean correction with no removed training data.");
+    return (W * conditional_cov_removed).cwiseProduct(W).rowwise().sum();
+  }
+
+  [[nodiscard]] inline Eigen::MatrixXd
+  joint_correction(const Eigen::MatrixXd &W) const {
+    ALBATROSS_ASSERT(
+        *this &&
+        "Cannot compute mean correction with no removed training data.");
+    return W * conditional_cov_removed * W.transpose();
+  }
+};
+
 /*
  * The Gaussian Process needs to store the training data and the
  * prior covariance for those data points.  One way to do that would
@@ -49,32 +158,118 @@ struct Fit<GPFit<CovarianceRepresentation, FeatureType>> {
   std::vector<FeatureType> train_features;
   CovarianceRepresentation train_covariance;
   Eigen::VectorXd information;
+  GPRemoveCache removed;
 
   Fit() {}
 
   Fit(const std::vector<FeatureType> &features_,
       const CovarianceRepresentation &train_covariance_,
-      const Eigen::VectorXd &information_)
+      const Eigen::VectorXd &information_,
+      const std::vector<std::size_t> remove_indices_ =
+          std::vector<std::size_t>{})
       : train_features(features_), train_covariance(train_covariance_),
-        information(information_) {}
+        information(information_),
+        removed(remove_indices_, train_covariance, information) {}
 
   Fit(const std::vector<FeatureType> &features,
-      const Eigen::MatrixXd &train_cov, const MarginalDistribution &targets) {
+      const Eigen::MatrixXd &train_cov, const MarginalDistribution &targets,
+      const std::vector<std::size_t> remove_indices_ =
+          std::vector<std::size_t>{}) {
     train_features = features;
     Eigen::MatrixXd cov(train_cov);
     cov += targets.covariance;
     ALBATROSS_ASSERT(!cov.hasNaN());
     train_covariance = CovarianceRepresentation(cov);
     information = train_covariance.solve(targets.mean);
+    removed = GPRemoveCache(remove_indices_, train_covariance, information);
   }
 
   bool operator==(
       const Fit<GPFit<CovarianceRepresentation, FeatureType>> &other) const {
     return (train_features == other.train_features &&
             train_covariance == other.train_covariance &&
-            information == other.information);
+            information == other.information && removed == other.removed);
   }
 };
+
+template <typename X>
+std::vector<std::size_t> match_features(const std::vector<X> &train_data,
+                                        const std::vector<X> &remove) {
+  std::vector<std::size_t> remove_indices;
+  for (std::size_t i = 0; i < train_data.size(); ++i) {
+    if (std::find(remove.begin(), remove.end(), train_data[i]) !=
+        remove.end()) {
+      remove_indices.push_back(i);
+    }
+  }
+  return remove_indices;
+}
+
+struct UpdateOverlapPartition {
+  // The remove-set indices that survive the partition.  Entries of
+  // `remove_indices` that matched an incoming update feature are
+  // "resurrected" and dropped here.
+  std::vector<std::size_t> reduced_remove_indices;
+  // Positions in the incoming update vector for features that do NOT
+  // match a currently-removed training row.  These are the features
+  // that still need to be folded into the fit.
+  std::vector<std::size_t> truly_new_update_indices;
+};
+
+// Partition an incoming update feature list against an existing
+// remove-cache.  When the update feature type matches the training
+// feature type, features that coincide with a currently-removed
+// training row are treated as resurrects (removed from the cache,
+// not appended); everything else is truly new.  When the types
+// differ there can be no overlap by construction, so every incoming
+// feature is truly new.
+template <typename TrainFeatureType, typename UpdateFeatureType>
+UpdateOverlapPartition partition_update_against_removed(
+    const std::vector<TrainFeatureType> &train_features,
+    const std::vector<std::size_t> &remove_indices,
+    const std::vector<UpdateFeatureType> &update_features) {
+  UpdateOverlapPartition out;
+  out.reduced_remove_indices = remove_indices;
+  out.truly_new_update_indices.reserve(update_features.size());
+  if constexpr (std::is_same<TrainFeatureType, UpdateFeatureType>::value) {
+    for (std::size_t ui = 0; ui < update_features.size(); ++ui) {
+      const auto it =
+          std::find_if(out.reduced_remove_indices.begin(),
+                       out.reduced_remove_indices.end(), [&](std::size_t ri) {
+                         return train_features[ri] == update_features[ui];
+                       });
+      if (it != out.reduced_remove_indices.end()) {
+        out.reduced_remove_indices.erase(it);
+      } else {
+        out.truly_new_update_indices.push_back(ui);
+      }
+    }
+  } else {
+    out.truly_new_update_indices.resize(update_features.size());
+    std::iota(out.truly_new_update_indices.begin(),
+              out.truly_new_update_indices.end(), std::size_t{0});
+  }
+  return out;
+}
+
+// Build a no-op `Fit<GPFit<BlockSymmetric<Solver>, ...>>` that wraps
+// an existing fit's covariance, information and features and carries
+// the given (possibly-reduced) remove indices.  Used when an update
+// consists entirely of resurrected features: the block-symmetric
+// return type must still match the general update path, but there is
+// no new data to fold in so the bottom block is empty.
+template <typename Solver, typename FeatureType>
+Fit<GPFit<BlockSymmetric<Solver>, FeatureType>> trivial_update_shortcut_fit(
+    const Fit<GPFit<Solver, FeatureType>> &fit,
+    const std::vector<std::size_t> &reduced_remove_indices) {
+  const Eigen::Index n_train = fit.train_covariance.rows();
+  BlockSymmetric<Solver> trivial_covariance(fit.train_covariance,
+                                            Eigen::MatrixXd::Zero(n_train, 0),
+                                            Eigen::SerializableLDLT());
+  return Fit<GPFit<BlockSymmetric<Solver>, FeatureType>>(
+      fit.train_features, trivial_covariance, fit.information,
+      reduced_remove_indices);
+}
 
 /*
  * Gaussian Process Helper Functions.
@@ -84,19 +279,38 @@ inline Eigen::VectorXd gp_mean_prediction(const Eigen::MatrixXd &cross_cov,
   return cross_cov.transpose() * information;
 }
 
+inline Eigen::VectorXd gp_mean_prediction(const Eigen::MatrixXd &cross_cov,
+                                          const Eigen::VectorXd &information,
+                                          const GPRemoveCache &removed) {
+  Eigen::VectorXd full_mean = gp_mean_prediction(cross_cov, information);
+  if (removed) {
+    full_mean += removed.mean_correction(removed.compute_W(cross_cov));
+  }
+  return full_mean;
+}
+
 template <typename CovarianceRepresentation>
 inline MarginalDistribution
 gp_marginal_prediction(const Eigen::MatrixXd &cross_cov,
                        const Eigen::VectorXd &prior_variance,
                        const Eigen::VectorXd &information,
-                       const CovarianceRepresentation &train_covariance) {
-  const Eigen::VectorXd pred = gp_mean_prediction(cross_cov, information);
+                       const CovarianceRepresentation &train_covariance,
+                       const GPRemoveCache &removed = {}) {
+  Eigen::MatrixXd explained = train_covariance.solve(cross_cov);
+
   // Here we efficiently only compute the diagonal of the posterior
   // covariance matrix.
-  Eigen::MatrixXd explained = train_covariance.solve(cross_cov);
   Eigen::VectorXd explained_variance =
       explained.cwiseProduct(cross_cov).array().colwise().sum();
   Eigen::VectorXd marginal_variance = prior_variance - explained_variance;
+  Eigen::VectorXd pred = gp_mean_prediction(cross_cov, information);
+
+  if (removed) {
+    Eigen::MatrixXd W = subset_rows(explained, removed.indices).transpose();
+    pred += removed.mean_correction(W);
+    marginal_variance += removed.marginal_correction(W);
+  }
+
   return MarginalDistribution(pred, marginal_variance);
 }
 
@@ -105,11 +319,42 @@ inline JointDistribution
 gp_joint_prediction(const Eigen::MatrixXd &cross_cov,
                     const Eigen::MatrixXd &prior_cov,
                     const Eigen::VectorXd &information,
-                    const CovarianceRepresentation &train_covariance) {
-  const Eigen::VectorXd pred = gp_mean_prediction(cross_cov, information);
-  Eigen::MatrixXd explained_cov =
-      cross_cov.transpose() * train_covariance.solve(cross_cov);
+                    const CovarianceRepresentation &train_covariance,
+                    const GPRemoveCache &removed = {}) {
+  Eigen::VectorXd pred = gp_mean_prediction(cross_cov, information);
+  Eigen::MatrixXd explained = train_covariance.solve(cross_cov);
+  Eigen::MatrixXd explained_cov = cross_cov.transpose() * explained;
+
+  if (removed) {
+    Eigen::MatrixXd W = subset_rows(explained, removed.indices).transpose();
+    pred += removed.mean_correction(W);
+    // Subtract here because we are going to then subtract the
+    // explained covariance from the prior.
+    explained_cov -= removed.joint_correction(W);
+  }
+
   return JointDistribution(pred, prior_cov - explained_cov);
+}
+
+// Joint prediction at `features` for a Gaussian Process fit, with an
+// explicit remove cache decoupled from whatever cache the fit is
+// carrying.  `_predict_impl` delegates here with `gp_fit.removed`;
+// `_update_impl` borrows the same helper with an empty cache so it
+// can use the full-fit prediction when computing delta without
+// having to copy the fit just to swap out the cache.
+template <typename CovFunc, typename MeanFunc, typename FeatureType,
+          typename FitFeatureType, typename CovarianceRepresentation>
+inline JointDistribution gp_joint_prediction_with_removed(
+    const CovFunc &covariance_function, const MeanFunc &mean_function,
+    const std::vector<FeatureType> &features,
+    const Fit<GPFit<CovarianceRepresentation, FitFeatureType>> &gp_fit,
+    const GPRemoveCache &removed) {
+  const auto cross_cov = covariance_function(gp_fit.train_features, features);
+  Eigen::MatrixXd prior_cov = covariance_function(features);
+  auto pred = gp_joint_prediction(cross_cov, prior_cov, gp_fit.information,
+                                  gp_fit.train_covariance, removed);
+  mean_function.add_to(features, &pred.mean);
+  return pred;
 }
 
 /*
@@ -311,13 +556,8 @@ public:
               const std::vector<FeatureType> &features,
               const GPFitType<CovarianceRepresentation, FitFeaturetype> &gp_fit,
               PredictTypeIdentity<JointDistribution> &&) const {
-    const auto cross_cov =
-        covariance_function_(gp_fit.train_features, features);
-    Eigen::MatrixXd prior_cov = covariance_function_(features);
-    auto pred = gp_joint_prediction(cross_cov, prior_cov, gp_fit.information,
-                                    gp_fit.train_covariance);
-    mean_function_.add_to(features, &pred.mean);
-    return pred;
+    return gp_joint_prediction_with_removed(
+        covariance_function_, mean_function_, features, gp_fit, gp_fit.removed);
   }
 
   template <
@@ -338,8 +578,9 @@ public:
       prior_variance[i] = covariance_function_(features[cast::to_size(i)],
                                                features[cast::to_size(i)]);
     }
-    auto pred = gp_marginal_prediction(
-        cross_cov, prior_variance, gp_fit.information, gp_fit.train_covariance);
+    auto pred =
+        gp_marginal_prediction(cross_cov, prior_variance, gp_fit.information,
+                               gp_fit.train_covariance, gp_fit.removed);
     mean_function_.add_to(features, &pred.mean);
     return pred;
   }
@@ -357,7 +598,8 @@ public:
       PredictTypeIdentity<Eigen::VectorXd> &&) const {
     const auto cross_cov =
         covariance_function_(gp_fit.train_features, features);
-    auto pred = gp_mean_prediction(cross_cov, gp_fit.information);
+    auto pred =
+        gp_mean_prediction(cross_cov, gp_fit.information, gp_fit.removed);
     mean_function_.add_to(features, &pred);
     return pred;
   }
@@ -383,17 +625,52 @@ public:
           auto _update_impl(const Fit<GPFit<Solver, FeatureType>> &fit_,
                             const std::vector<UpdateFeatureType> &features,
                             const MarginalDistribution &targets) const {
-    const auto new_features = concatenate(fit_.train_features, features);
+    // Partition the update set against the remove-cache.  Matching
+    // features are resurrected (dropped from the remove-cache, not
+    // appended); everything else is folded into the fit via the
+    // usual block-symmetric update.
+    const auto partition = partition_update_against_removed(
+        fit_.train_features, fit_.removed.indices, features);
 
-    auto pred = this->_predict_impl(features, fit_,
-                                    PredictTypeIdentity<JointDistribution>());
+    std::vector<UpdateFeatureType> new_features_to_add =
+        albatross::subset(features, partition.truly_new_update_indices);
 
-    Eigen::VectorXd delta = targets.mean - pred.mean;
-    pred.covariance += targets.covariance;
+    // Shortcut: every incoming feature resurrected a removed row, so
+    // there is no new data to fold in.  Return a no-op
+    // block-symmetric wrap carrying the reduced remove-cache.  This
+    // branch compiles only for matching feature types, since the
+    // partition can only resurrect when types match.
+    if constexpr (std::is_same<FeatureType, UpdateFeatureType>::value) {
+      if (new_features_to_add.empty()) {
+        return trivial_update_shortcut_fit(fit_,
+                                           partition.reduced_remove_indices);
+      }
+    }
+
+    const auto new_features =
+        concatenate(fit_.train_features, new_features_to_add);
+
+    const MarginalDistribution filtered_targets =
+        targets.subset(partition.truly_new_update_indices);
+
+    // The block-symmetric update derives the new information vector
+    // assuming delta = targets - full-fit-prediction (no removal
+    // correction).  Routing through `_predict_impl` would apply the
+    // existing remove cache to the prediction, producing a biased
+    // delta whenever the fit carries a non-empty cache.  Use the
+    // explicit-cache free helper with an empty cache so the math
+    // stays correct regardless of the cache state going in; the
+    // reduced cache is attached to the output fit below.
+    auto pred = gp_joint_prediction_with_removed(
+        covariance_function_, mean_function_, new_features_to_add, fit_,
+        GPRemoveCache());
+
+    Eigen::VectorXd delta = filtered_targets.mean - pred.mean;
+    pred.covariance += filtered_targets.covariance;
     const auto S_ldlt = pred.covariance.ldlt();
 
     const Eigen::MatrixXd cross =
-        covariance_function_(fit_.train_features, features);
+        covariance_function_(fit_.train_features, new_features_to_add);
 
     const auto new_covariance =
         build_block_symmetric(fit_.train_covariance, cross, S_ldlt);
@@ -407,7 +684,25 @@ public:
 
     using NewFeatureType = typename decltype(new_features)::value_type;
     using NewFitType = Fit<GPFit<BlockSymmetric<Solver>, NewFeatureType>>;
-    return NewFitType(new_features, new_covariance, new_information);
+    return NewFitType(new_features, new_covariance, new_information,
+                      partition.reduced_remove_indices);
+  }
+
+  // Observation removal for dense GPs is implemented via a small
+  // correction applied after the full prediction is made.  This
+  // allows us to avoid modifying the (potentially large) sequential
+  // covariance decomposition, but it also assumes that the number of
+  // removed features is small relative to the number of training
+  // features.  If you try to remove a lot of features, performance
+  // may suffer.
+  template <typename Solver, typename FeatureType>
+  auto _prune_impl(const Fit<GPFit<Solver, FeatureType>> &fit_,
+                   const std::vector<std::size_t> &remove_indices) const {
+    // Just record the indices; the remove-cache build happens inside
+    // the Fit<GPFit<...>> constructor.
+    return Fit<GPFit<Solver, FeatureType>>(fit_.train_features,
+                                           fit_.train_covariance,
+                                           fit_.information, remove_indices);
   }
 
   CovFunc get_covariance() const { return covariance_function_; }
@@ -476,6 +771,100 @@ gp_cross_validated_predictions(const RegressionDataset<FeatureType> &dataset,
   return details::held_out_predictions(
       gp_fit.train_covariance, dataset.targets.mean, gp_fit.information,
       group_indexer, predict_type, model.threads_.get());
+}
+
+// Subset a held-out-prediction result down to a list of positions
+// within the augmented group.  One overload per PredictType so the
+// fit-driven CV below can stay generic.
+inline Eigen::VectorXd
+subset_prediction(const Eigen::VectorXd &v,
+                  const std::vector<std::size_t> &positions) {
+  return subset(v, positions);
+}
+
+inline MarginalDistribution
+subset_prediction(const MarginalDistribution &d,
+                  const std::vector<std::size_t> &positions) {
+  return d.subset(positions);
+}
+
+inline JointDistribution
+subset_prediction(const JointDistribution &d,
+                  const std::vector<std::size_t> &positions) {
+  return JointDistribution(subset(d.mean, positions),
+                           symmetric_subset(d.covariance, positions));
+}
+
+// Fit-driven dense-GP cross-validation.  Takes an already-fitted
+// model so the caller can pass in a fit carrying a non-empty
+// GPRemoveCache; the sibling above refits from the dataset every
+// call, so that path never sees a cache.
+//
+// For each CV group, the group's indices are unioned with the fit's
+// remove-cache indices before invoking the standard block-inverse
+// machinery, and the resulting prediction is subset back down to the
+// original group.  The LOO closed form generalises to any leave-out
+// set S: mean_S = y_S - (K^{-1}[S,S])^{-1} v[S], cov = (K^{-1}[S,S])^{-1}.
+// Setting S = R u z_g and restricting the result to z_g's positions
+// gives "fit on X \ R, leave z_g out".  When the cache is empty the
+// augmented indexer equals the original and this reduces exactly to
+// the standard path.
+//
+// Targets come in separately: Fit<GPFit<...>> drops raw y after
+// forming information = K^{-1} y, and the mean-prediction formula
+// genuinely needs y, so it has to be supplied by the caller.
+template <typename GPType, typename CovarianceRepresentation,
+          typename FitFeatureType, typename GroupKey, typename PredictType>
+inline std::map<GroupKey, PredictType> gp_cross_validated_predictions(
+    const FitModel<GPType, Fit<GPFit<CovarianceRepresentation, FitFeatureType>>>
+        &fit_model,
+    const MarginalDistribution &targets,
+    const GroupIndexer<GroupKey> &group_indexer,
+    PredictTypeIdentity<PredictType> predict_type) {
+  const auto &gp_fit = fit_model.get_fit();
+  auto *pool = fit_model.get_model().threads_.get();
+
+  if (!gp_fit.removed) {
+    return details::held_out_predictions(gp_fit.train_covariance, targets.mean,
+                                         gp_fit.information, group_indexer,
+                                         predict_type, pool);
+  }
+
+  // Build an augmented indexer: each group's indices union-ed with
+  // the fit's remove-cache indices.  std::set_union requires sorted
+  // inputs; the cache indices are stored in construction order (sorted)
+  // but the group indices may not be, so defensively sort a copy.
+  GroupIndexer<GroupKey> augmented_indexer;
+  for (const auto &kv : group_indexer) {
+    std::vector<std::size_t> sorted_group = kv.second;
+    std::sort(sorted_group.begin(), sorted_group.end());
+    std::vector<std::size_t> merged;
+    merged.reserve(sorted_group.size() + gp_fit.removed.indices.size());
+    std::set_union(sorted_group.begin(), sorted_group.end(),
+                   gp_fit.removed.indices.begin(), gp_fit.removed.indices.end(),
+                   std::back_inserter(merged));
+    augmented_indexer.emplace(kv.first, std::move(merged));
+  }
+
+  const auto augmented_predictions = details::held_out_predictions(
+      gp_fit.train_covariance, targets.mean, gp_fit.information,
+      augmented_indexer, predict_type, pool);
+
+  std::map<GroupKey, PredictType> out;
+  for (const auto &kv : augmented_predictions) {
+    const auto &orig = group_indexer.at(kv.first);
+    const auto &aug = augmented_indexer.at(kv.first);
+    std::vector<std::size_t> positions;
+    positions.reserve(orig.size());
+    for (const auto i : orig) {
+      const auto it = std::find(aug.begin(), aug.end(), i);
+      ALBATROSS_ASSERT(it != aug.end());
+      positions.push_back(
+          static_cast<std::size_t>(std::distance(aug.begin(), it)));
+    }
+    out.emplace(kv.first, subset_prediction(kv.second, positions));
+  }
+  return out;
 }
 
 /*

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -262,6 +262,153 @@ TEST(test_crossvalidation, test_leave_one_out_equivalences) {
   }
 }
 
+// When the fit carries an empty GPRemoveCache, the fit-driven
+// cross-validation entry point must reduce exactly to the stock
+// model-driven closed form so no caller ends up with different
+// numerics depending on which entry they reached through.
+TEST(test_crossvalidation, test_fit_cv_empty_cache_matches_model_driven) {
+  const auto dataset = make_toy_linear_data();
+  auto model = MakeGaussianProcess().get_model();
+  const auto fit_model = model.fit(dataset);
+  ASSERT_FALSE(fit_model.get_fit().removed);
+
+  const auto indexer = dataset.group_by(group_by_interval<double>).indexers();
+
+  const auto fit_means =
+      gp_cross_validated_predictions(fit_model, dataset.targets, indexer,
+                                     PredictTypeIdentity<Eigen::VectorXd>());
+  const auto fit_marginals = gp_cross_validated_predictions(
+      fit_model, dataset.targets, indexer,
+      PredictTypeIdentity<MarginalDistribution>());
+  const auto fit_joints =
+      gp_cross_validated_predictions(fit_model, dataset.targets, indexer,
+                                     PredictTypeIdentity<JointDistribution>());
+
+  const auto cv_means = model.cross_validate()
+                            .predict(dataset, group_by_interval<double>)
+                            .means();
+  const auto cv_marginals = model.cross_validate()
+                                .predict(dataset, group_by_interval<double>)
+                                .marginals();
+  const auto cv_joints = model.cross_validate()
+                             .predict(dataset, group_by_interval<double>)
+                             .joints();
+
+  for (const auto &kv : cv_joints) {
+    const auto &key = kv.first;
+    EXPECT_EQ(fit_means.at(key), cv_means.at(key));
+    EXPECT_EQ(fit_marginals.at(key).mean, cv_marginals.at(key).mean);
+    EXPECT_EQ(fit_marginals.at(key).covariance.diagonal(),
+              cv_marginals.at(key).covariance.diagonal());
+    EXPECT_EQ(fit_joints.at(key).mean, cv_joints.at(key).mean);
+    EXPECT_EQ(fit_joints.at(key).covariance, cv_joints.at(key).covariance);
+  }
+}
+
+// Fit-driven CV on a pruned fit must match a from-scratch refit on
+// the complement of (removed-set ∪ held-out-group) for every group,
+// covering both disjoint groups and groups that overlap the removed
+// set.  LOO grouping gives us single-index groups which cleanly
+// exercises both: indices in R overlap the cache, indices outside
+// don't.
+TEST(test_crossvalidation, test_fit_cv_with_remove_cache_matches_refit) {
+  const auto dataset = make_toy_linear_data();
+  auto model = MakeGaussianProcess().get_model();
+
+  // Prune three rows; the rest are expected to match vanilla LOO, the
+  // pruned ones must match "refit without the prune set" predictions.
+  const std::vector<std::size_t> prune_inds = {1, 4, 7};
+  const auto full_fit = model.fit(dataset);
+  const auto pruned = albatross::prune(full_fit, prune_inds);
+  ASSERT_EQ(pruned.get_fit().removed.indices, prune_inds);
+
+  LeaveOneOutGrouper loo;
+  const auto indexer = dataset.group_by(loo).indexers();
+
+  const auto fit_means = gp_cross_validated_predictions(
+      pruned, dataset.targets, indexer, PredictTypeIdentity<Eigen::VectorXd>());
+  const auto fit_marginals = gp_cross_validated_predictions(
+      pruned, dataset.targets, indexer,
+      PredictTypeIdentity<MarginalDistribution>());
+  const auto fit_joints =
+      gp_cross_validated_predictions(pruned, dataset.targets, indexer,
+                                     PredictTypeIdentity<JointDistribution>());
+
+  // The block-inverse LOO closed form returns a posterior that still
+  // carries the per-observation measurement noise (it inverts
+  // K + noise). Wrap the brute-force prediction in
+  // Measurement<...> so its covariance matches.
+  const auto brute_force = [&](const std::vector<std::size_t> &group_inds) {
+    std::vector<std::size_t> leave_out;
+    leave_out.reserve(group_inds.size() + prune_inds.size());
+    std::set_union(group_inds.begin(), group_inds.end(), prune_inds.begin(),
+                   prune_inds.end(), std::back_inserter(leave_out));
+    const auto train_inds =
+        indices_complement(leave_out, dataset.features.size());
+    const auto train_subset = albatross::subset(dataset, train_inds);
+    const auto test_features = albatross::subset(dataset.features, group_inds);
+    return model.fit(train_subset)
+        .predict_with_measurement_noise(test_features)
+        .joint();
+  };
+
+  for (const auto &kv : indexer) {
+    const auto &key = kv.first;
+    const auto expected = brute_force(kv.second);
+
+    EXPECT_LE((fit_means.at(key) - expected.mean).norm(), 1e-6);
+    EXPECT_LE((fit_marginals.at(key).mean - expected.mean).norm(), 1e-6);
+    EXPECT_LE((fit_marginals.at(key).covariance.diagonal() -
+               expected.covariance.diagonal())
+                  .norm(),
+              1e-6);
+    EXPECT_LE((fit_joints.at(key).mean - expected.mean).norm(), 1e-6);
+    EXPECT_LE((fit_joints.at(key).covariance - expected.covariance).norm(),
+              1e-6);
+  }
+}
+
+// With group_by_interval each group straddles the remove set, so
+// every group hits the overlap branch ("some of z_g is already in R").
+// The union-and-subset machinery is supposed to turn this into "leave
+// R ∪ z_g out of X, predict at z_g" regardless of the overlap -- this
+// test pins that down against a from-scratch refit.
+TEST(test_crossvalidation, test_fit_cv_group_overlapping_cache_matches_refit) {
+  const auto dataset = make_toy_linear_data();
+  auto model = MakeGaussianProcess().get_model();
+
+  // One prune index per group_by_interval bucket to guarantee overlap.
+  const std::vector<std::size_t> prune_inds = {2, 5, 8};
+  const auto full_fit = model.fit(dataset);
+  const auto pruned = albatross::prune(full_fit, prune_inds);
+
+  const auto indexer = dataset.group_by(group_by_interval<double>).indexers();
+
+  const auto fit_joints =
+      gp_cross_validated_predictions(pruned, dataset.targets, indexer,
+                                     PredictTypeIdentity<JointDistribution>());
+
+  for (const auto &kv : indexer) {
+    std::vector<std::size_t> group_sorted = kv.second;
+    std::sort(group_sorted.begin(), group_sorted.end());
+    std::vector<std::size_t> leave_out;
+    std::set_union(group_sorted.begin(), group_sorted.end(), prune_inds.begin(),
+                   prune_inds.end(), std::back_inserter(leave_out));
+    const auto train_inds =
+        indices_complement(leave_out, dataset.features.size());
+    const auto train_subset = albatross::subset(dataset, train_inds);
+    const auto test_features = albatross::subset(dataset.features, kv.second);
+    // Match the CV formula's noise-inclusive posterior.
+    const auto expected = model.fit(train_subset)
+                              .predict_with_measurement_noise(test_features)
+                              .joint();
+
+    EXPECT_LE((fit_joints.at(kv.first).mean - expected.mean).norm(), 1e-6);
+    EXPECT_LE((fit_joints.at(kv.first).covariance - expected.covariance).norm(),
+              1e-6);
+  }
+}
+
 class MakeLargeGaussianProcess {
 public:
   auto get_model() const {

--- a/tests/test_gp.cc
+++ b/tests/test_gp.cc
@@ -218,6 +218,259 @@ TEST(test_gp, test_update_model_same_types) {
   EXPECT_GE((split_pred.covariance - first_pred.covariance).norm(), 1e-6);
 }
 
+TEST(test_gp, test_update_then_prune_same_as_first) {
+  const auto dataset = test_unobservable_dataset();
+
+  // Deliberately pick |test|=3, |train|=7, |first|=5, |second|=2 so every
+  // size is distinct.  A bug in the post-prune correction path that
+  // silently transposes the (|test| x |second|) matrix - or
+  // mis-parenthesizes a cwiseProduct against the (|second| x |second|)
+  // conditional covariance - would only compile when those dimensions
+  // coincide, so keeping them apart turns the bug into a build-time or
+  // assertion failure instead of wrong numerics.
+  std::vector<std::size_t> train_inds = {0, 1, 3, 4, 6, 7, 9};
+  std::vector<std::size_t> test_inds = {2, 5, 8};
+
+  const auto train = albatross::subset(dataset, train_inds);
+  const auto test = albatross::subset(dataset, test_inds);
+
+  std::vector<std::size_t> first_inds = {0, 2, 4, 5, 6};
+  std::vector<std::size_t> second_inds = {1, 3};
+  const auto first = albatross::subset(train, first_inds);
+  const auto second = albatross::subset(train, second_inds);
+
+  const auto model = test_unobservable_model();
+
+  const auto first_model = model.fit(first);
+  const auto first_pred = first_model.predict(test.features).joint();
+
+  const auto updated = update(first_model, second);
+  // After an update, `second` lives at the tail of the concatenated
+  // training features; demonstrate composing match_features with the
+  // index-based prune instead of open-coding the positions.
+  const auto round_tripped = prune(
+      updated, match_features(updated.get_fit().train_features, second.features));
+  const auto round_tripped_pred = round_tripped.predict(test.features).joint();
+
+  EXPECT_TRUE(round_tripped_pred.mean.isApprox(first_pred.mean));
+  EXPECT_LE((round_tripped_pred.covariance - first_pred.covariance).norm(),
+            1e-6);
+}
+
+TEST(test_gp, test_prune_then_update_same_as_full) {
+  const auto dataset = test_unobservable_dataset();
+
+  std::vector<std::size_t> train_inds = {0, 1, 3, 4, 6, 7, 9};
+  std::vector<std::size_t> test_inds = {2, 5, 8};
+
+  const auto train = albatross::subset(dataset, train_inds);
+  const auto test = albatross::subset(dataset, test_inds);
+
+  std::vector<std::size_t> second_inds = {1, 3};
+  const auto second = albatross::subset(train, second_inds);
+
+  const auto model = test_unobservable_model();
+
+  const auto full_model = model.fit(train);
+  const auto full_pred = full_model.predict(test.features).joint();
+
+  const auto pruned = prune(full_model, second_inds);
+  const auto round_tripped = update(pruned, second);
+  const auto round_tripped_pred = round_tripped.predict(test.features).joint();
+
+  EXPECT_TRUE(round_tripped_pred.mean.isApprox(full_pred.mean));
+  EXPECT_LE((round_tripped_pred.covariance - full_pred.covariance).norm(),
+            1e-6);
+}
+
+TEST(test_gp, test_partition_update_against_removed_no_cache) {
+  const std::vector<double> train = {0.0, 1.0, 2.0, 3.0};
+  const std::vector<std::size_t> remove = {};
+  const std::vector<double> update = {1.0, 4.0};
+
+  const auto p = partition_update_against_removed(train, remove, update);
+  EXPECT_TRUE(p.reduced_remove_indices.empty());
+  EXPECT_EQ(p.truly_new_update_indices, (std::vector<std::size_t>{0, 1}));
+}
+
+TEST(test_gp, test_partition_update_against_removed_full_overlap) {
+  const std::vector<double> train = {0.0, 1.0, 2.0, 3.0};
+  const std::vector<std::size_t> remove = {1, 3};
+  const std::vector<double> update = {1.0, 3.0};
+
+  const auto p = partition_update_against_removed(train, remove, update);
+  EXPECT_TRUE(p.reduced_remove_indices.empty());
+  EXPECT_TRUE(p.truly_new_update_indices.empty());
+}
+
+TEST(test_gp, test_partition_update_against_removed_partial_overlap) {
+  const std::vector<double> train = {0.0, 1.0, 2.0, 3.0};
+  const std::vector<std::size_t> remove = {1, 3};
+  const std::vector<double> update = {1.0, 4.0, 5.0};
+
+  const auto p = partition_update_against_removed(train, remove, update);
+  EXPECT_EQ(p.reduced_remove_indices, (std::vector<std::size_t>{3}));
+  EXPECT_EQ(p.truly_new_update_indices, (std::vector<std::size_t>{1, 2}));
+}
+
+TEST(test_gp, test_partition_update_against_removed_different_types) {
+  const std::vector<double> train = {0.0, 1.0, 2.0, 3.0};
+  const std::vector<std::size_t> remove = {1, 3};
+  const std::vector<int> update = {1, 4, 5};
+
+  const auto p = partition_update_against_removed(train, remove, update);
+  EXPECT_EQ(p.reduced_remove_indices, remove);
+  EXPECT_EQ(p.truly_new_update_indices, (std::vector<std::size_t>{0, 1, 2}));
+}
+
+// Round-trip test for a genuine partial-overlap update: some incoming
+// features resurrect previously-pruned rows while others are truly new
+// and must be folded into the fit.  The post-round-trip predictions
+// must match a fresh fit whose training set is exactly
+// (original_train \ still_pruned) ∪ truly_new.
+TEST(test_gp, test_update_partial_overlap_matches_expected_fit) {
+  const auto dataset = test_unobservable_dataset();
+
+  // |train| = 7, |test| = 3.
+  const std::vector<std::size_t> train_inds = {0, 1, 3, 4, 6, 7, 9};
+  const std::vector<std::size_t> test_inds = {2, 5, 8};
+
+  const auto train = albatross::subset(dataset, train_inds);
+  const auto test = albatross::subset(dataset, test_inds);
+
+  // Prune two rows from train.  These are positions 1 and 3 within
+  // train, i.e. dataset indices {1, 4}.
+  const std::vector<std::size_t> prune_positions = {1, 3};
+
+  // Update with 3 features: dataset[1] overlaps the remove-cache and
+  // should be resurrected; dataset[5] and dataset[8] are outside
+  // train and need to be folded in.
+  const std::vector<std::size_t> update_inds = {1, 5, 8};
+  const auto update_data = albatross::subset(dataset, update_inds);
+
+  const auto model = test_unobservable_model();
+
+  const auto trained = model.fit(train);
+  const auto pruned_fit = prune(trained, prune_positions);
+  const auto round_tripped = update(pruned_fit, update_data);
+  const auto round_tripped_pred = round_tripped.predict(test.features).joint();
+
+  // Expected: fit on (train \ {dataset[4]}) ∪ {dataset[5], dataset[8]}
+  // = dataset rows {0, 1, 3, 5, 6, 7, 8, 9}.
+  const std::vector<std::size_t> expected_inds = {0, 1, 3, 5, 6, 7, 8, 9};
+  const auto expected_data = albatross::subset(dataset, expected_inds);
+  const auto expected_fit = model.fit(expected_data);
+  const auto expected_pred = expected_fit.predict(test.features).joint();
+
+  EXPECT_TRUE(round_tripped_pred.mean.isApprox(expected_pred.mean));
+  EXPECT_LE((round_tripped_pred.covariance - expected_pred.covariance).norm(),
+            1e-6);
+}
+
+// Each of mean / marginal / joint prediction must apply the
+// removal correction.  Compare the pruned fit's predictions against
+// a fresh fit on the kept subset of the training data.  Sizes are
+// intentionally distinct (|test|=3, |train|=7, |second|=2) so that
+// any transpose / cwiseProduct shape bug in the correction path
+// manifests as an assertion rather than garbage numerics.
+namespace {
+struct PrunedPredictionFixture {
+  RegressionDataset<double> train;
+  RegressionDataset<double> test;
+  RegressionDataset<double> kept;
+  std::vector<std::size_t> second_inds;
+};
+
+PrunedPredictionFixture make_pruned_prediction_fixture() {
+  const auto dataset = test_unobservable_dataset();
+  const std::vector<std::size_t> train_inds = {0, 1, 3, 4, 6, 7, 9};
+  const std::vector<std::size_t> test_inds = {2, 5, 8};
+  const auto train = albatross::subset(dataset, train_inds);
+  const auto test = albatross::subset(dataset, test_inds);
+  const std::vector<std::size_t> second_inds = {1, 3};
+  const std::vector<std::size_t> kept_positions = {0, 2, 4, 5, 6};
+  const auto kept = albatross::subset(train, kept_positions);
+  return {train, test, kept, second_inds};
+}
+} // namespace
+
+TEST(test_gp, test_pruned_mean_matches_refit) {
+  const auto f = make_pruned_prediction_fixture();
+  const auto model = test_unobservable_model();
+  const auto pruned_fit = prune(model.fit(f.train), f.second_inds);
+  const auto kept_fit = model.fit(f.kept);
+
+  const Eigen::VectorXd pruned_mean =
+      pruned_fit.predict(f.test.features).mean();
+  const Eigen::VectorXd kept_mean = kept_fit.predict(f.test.features).mean();
+
+  EXPECT_TRUE(pruned_mean.isApprox(kept_mean));
+}
+
+TEST(test_gp, test_pruned_marginal_matches_refit) {
+  const auto f = make_pruned_prediction_fixture();
+  const auto model = test_unobservable_model();
+  const auto pruned_fit = prune(model.fit(f.train), f.second_inds);
+  const auto kept_fit = model.fit(f.kept);
+
+  const auto pruned_marg = pruned_fit.predict(f.test.features).marginal();
+  const auto kept_marg = kept_fit.predict(f.test.features).marginal();
+
+  EXPECT_TRUE(pruned_marg.mean.isApprox(kept_marg.mean));
+  EXPECT_LE(
+      (pruned_marg.covariance.diagonal() - kept_marg.covariance.diagonal())
+          .norm(),
+      1e-6);
+}
+
+TEST(test_gp, test_pruned_joint_matches_refit) {
+  const auto f = make_pruned_prediction_fixture();
+  const auto model = test_unobservable_model();
+  const auto pruned_fit = prune(model.fit(f.train), f.second_inds);
+  const auto kept_fit = model.fit(f.kept);
+
+  const auto pruned_joint = pruned_fit.predict(f.test.features).joint();
+  const auto kept_joint = kept_fit.predict(f.test.features).joint();
+
+  EXPECT_TRUE(pruned_joint.mean.isApprox(kept_joint.mean));
+  EXPECT_LE((pruned_joint.covariance - kept_joint.covariance).norm(), 1e-6);
+}
+
+// Pruning every training feature should leave the posterior equal
+// to the GP's prior at the query locations: the correction exactly
+// cancels the "explained" components of mean and covariance, so the
+// mean drops to mean_function_(test) (zero here) and the covariance
+// reduces to covariance_function_(test).  Covers mean / marginal /
+// joint predictions.
+TEST(test_gp, test_prune_all_features_gives_prior) {
+  const auto dataset = test_unobservable_dataset();
+  const std::vector<double> test_features = {0.15, 0.9, 1.65, 2.4};
+
+  const auto model = test_unobservable_model();
+  const auto full_fit = model.fit(dataset);
+  std::vector<std::size_t> all_inds(dataset.features.size());
+  std::iota(all_inds.begin(), all_inds.end(), std::size_t{0});
+  const auto all_pruned = prune(full_fit, all_inds);
+  ASSERT_EQ(all_pruned.get_fit().removed.indices.size(),
+            dataset.features.size());
+
+  // The mean function is ZeroMean, so the expected posterior mean
+  // is exactly zero; use an absolute tolerance since isApprox's
+  // relative tolerance degenerates when the reference is zero.
+  const Eigen::MatrixXd expected_cov = model.compute_covariance(test_features);
+
+  const auto joint = all_pruned.predict(test_features).joint();
+  EXPECT_TRUE(joint.mean.isZero(1e-8));
+  EXPECT_TRUE(joint.covariance.isApprox(expected_cov));
+
+  const auto marginal = all_pruned.predict(test_features).marginal();
+  EXPECT_TRUE(marginal.mean.isZero(1e-8));
+  EXPECT_TRUE(marginal.covariance.diagonal().isApprox(expected_cov.diagonal()));
+
+  const Eigen::VectorXd mean_pred = all_pruned.predict(test_features).mean();
+  EXPECT_TRUE(mean_pred.isZero(1e-8));
+}
+
 TEST(test_gp, test_update_model_different_types) {
   const auto dataset = test_unobservable_dataset();
 

--- a/tests/test_serialize.cc
+++ b/tests/test_serialize.cc
@@ -453,6 +453,114 @@ TEST(test_serialize, test_gp_serialize_version) {
   EXPECT_EQ(actual_version, expected_version);
 }
 
+template <typename InputArchiveType, typename OutputArchiveType, typename T>
+T roundtrip_archive(const T &original) {
+  std::ostringstream os;
+  {
+    OutputArchiveType oarchive(os);
+    oarchive(original);
+  }
+  T out;
+  {
+    std::istringstream is(os.str());
+    InputArchiveType iarchive(is);
+    iarchive(out);
+  }
+  return out;
+}
+
+TEST(test_serialize, test_gp_remove_cache_roundtrip_json) {
+  MakeGaussianProcess test_case;
+  auto dataset = test_case.get_dataset();
+  auto fit = test_case.get_model().fit(dataset);
+
+  const std::vector<std::size_t> prune_positions = {2, 5};
+  const auto pruned = albatross::prune(fit, prune_positions);
+  ASSERT_EQ(pruned.get_fit().removed.indices, prune_positions);
+
+  const auto &original_cache = pruned.get_fit().removed;
+  const auto cache_out =
+      roundtrip_archive<cereal::JSONInputArchive, cereal::JSONOutputArchive>(
+          original_cache);
+
+  EXPECT_EQ(cache_out, original_cache);
+}
+
+// End-to-end round-trip of a FitModel carrying a non-empty remove
+// cache. Compares equality via operator==, reserializes to check for
+// byte stability, and verifies that every prediction type produces
+// the same output off the deserialized fit as off the original.
+template <typename InputArchiveType, typename OutputArchiveType>
+void expect_pruned_fit_model_roundtrip() {
+  MakeGaussianProcess test_case;
+  auto dataset = test_case.get_dataset();
+  auto fit = test_case.get_model().fit(dataset);
+
+  const std::vector<std::size_t> prune_positions = {1, 4, 7};
+  const auto pruned = albatross::prune(fit, prune_positions);
+  ASSERT_EQ(pruned.get_fit().removed.indices, prune_positions);
+
+  std::ostringstream os;
+  {
+    OutputArchiveType oarchive(os);
+    oarchive(pruned);
+  }
+
+  using FitModelType = std::decay_t<decltype(pruned)>;
+  FitModelType deserialized;
+  {
+    std::istringstream is(os.str());
+    InputArchiveType iarchive(is);
+    iarchive(deserialized);
+  }
+
+  EXPECT_TRUE(deserialized == pruned);
+  EXPECT_FALSE(deserialized.get_fit().removed.indices.empty());
+
+  std::ostringstream os_again;
+  {
+    OutputArchiveType oarchive(os_again);
+    oarchive(deserialized);
+  }
+  EXPECT_EQ(os_again.str(), os.str());
+
+  // Predictions must survive the round-trip for all three output
+  // types; if the cache had silently dropped its cached matrices
+  // during serialization these would diverge from the pre-serialize
+  // predictions.
+  const std::vector<double> test_features = {0.5, 2.5, 5.5, 8.5};
+
+  const Eigen::VectorXd pre_mean = pruned.predict(test_features).mean();
+  const Eigen::VectorXd post_mean = deserialized.predict(test_features).mean();
+  EXPECT_TRUE(pre_mean.isApprox(post_mean));
+
+  const auto pre_marginal = pruned.predict(test_features).marginal();
+  const auto post_marginal = deserialized.predict(test_features).marginal();
+  EXPECT_TRUE(pre_marginal.mean.isApprox(post_marginal.mean));
+  EXPECT_TRUE(pre_marginal.covariance.diagonal().isApprox(
+      post_marginal.covariance.diagonal()));
+
+  const auto pre_joint = pruned.predict(test_features).joint();
+  const auto post_joint = deserialized.predict(test_features).joint();
+  EXPECT_TRUE(pre_joint.mean.isApprox(post_joint.mean));
+  EXPECT_TRUE(pre_joint.covariance.isApprox(post_joint.covariance));
+}
+
+TEST(test_serialize, test_pruned_fit_model_roundtrip_json) {
+  expect_pruned_fit_model_roundtrip<cereal::JSONInputArchive,
+                                    cereal::JSONOutputArchive>();
+}
+
+TEST(test_serialize, test_pruned_fit_model_roundtrip_binary) {
+  expect_pruned_fit_model_roundtrip<cereal::BinaryInputArchive,
+                                    cereal::BinaryOutputArchive>();
+}
+
+TEST(test_serialize, test_pruned_fit_model_roundtrip_portable_binary) {
+  expect_pruned_fit_model_roundtrip<cereal::PortableBinaryInputArchive,
+                                    cereal::PortableBinaryOutputArchive>();
+}
+
 } // namespace albatross
 
 namespace other {

--- a/tests/test_traits_core.cc
+++ b/tests/test_traits_core.cc
@@ -386,4 +386,52 @@ TEST(test_traits_core, update_traits) {
                               X>::can_update_in_place));
 }
 
+class HasValidPruneImpl : public ModelBase<HasValidPruneImpl> {
+public:
+  Fit<HasValidPruneImpl>
+  _prune_impl(const Fit<HasValidPruneImpl> &,
+              const std::vector<std::size_t> &) const {
+    return {};
+  };
+};
+
+class HasInValidPruneImpl : public ModelBase<HasValidPruneImpl> {
+public:
+  double _prune_impl(const Fit<HasValidPruneImpl> &,
+                     const std::vector<std::size_t> &) const {
+    return 0.;
+  };
+};
+
+class HasModifiedPruneImpl : public ModelBase<HasValidPruneImpl> {
+public:
+  Fit<X> _prune_impl(const Fit<HasModifiedPruneImpl> &,
+                     const std::vector<std::size_t> &) const {
+    return {};
+  };
+};
+
+TEST(test_traits_core, prune_traits) {
+  EXPECT_TRUE(bool(
+      fit_model_prune_traits<HasValidPruneImpl,
+                             Fit<HasValidPruneImpl>>::has_valid_prune));
+  EXPECT_TRUE(bool(
+      fit_model_prune_traits<HasValidPruneImpl,
+                             Fit<HasValidPruneImpl>>::can_prune_in_place));
+
+  EXPECT_FALSE(bool(
+      fit_model_prune_traits<HasInValidPruneImpl,
+                             Fit<HasValidPruneImpl>>::has_valid_prune));
+  EXPECT_FALSE(bool(
+      fit_model_prune_traits<HasInValidPruneImpl,
+                             Fit<HasValidPruneImpl>>::can_prune_in_place));
+
+  EXPECT_TRUE(bool(
+      fit_model_prune_traits<HasModifiedPruneImpl,
+                             Fit<HasModifiedPruneImpl>>::has_valid_prune));
+  EXPECT_FALSE(bool(
+      fit_model_prune_traits<HasModifiedPruneImpl,
+                             Fit<HasModifiedPruneImpl>>::can_prune_in_place));
+}
+
 } // namespace albatross


### PR DESCRIPTION
This adds the ability to the dense GP model to remove some of the training data after the fit is complete.  If the subset to be removed is small compared to the size of the training data, this may be much faster than re-fitting.