### PR TITLE
Remove orion_model_reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    reviewers:
-      - swift-nav/orion_model_reviewers
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
-    reviewers:
-      - swift-nav/orion_model_reviewers


### PR DESCRIPTION
@swift-nav/orion_model_reviewers membership has dwindled. Let's just remove it from the Dependabot PRs as we've got a better mechanism for notification from Dependabot now.