### PR TITLE
Fix five bugs found during code analysis

### DIFF
--- a/include/albatross/src/covariance_functions/representations.hpp
+++ b/include/albatross/src/covariance_functions/representations.hpp
@@ -70,6 +70,12 @@ struct ExplainedCovariance {
     inner = inner_;
   }
 
+  // Use this constructor if the LDLT of the outer matrix has already
+  // been computed; it avoids re-factorizing the outer matrix.
+  ExplainedCovariance(const Eigen::SerializableLDLT &outer_ldlt_,
+                      const Eigen::MatrixXd &inner_)
+      : outer_ldlt(outer_ldlt_), inner(inner_) {}
+
   /*
    * Returns S^-1 rhs by using S^-1 = A^-1 B A^-1
    */

--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -21,7 +21,7 @@ get_predictions(const ModelType &model,
                 const RegressionFolds<GroupKey, FeatureType> &folds) {
 
   const auto predict_group = [&model](const auto &fold) {
-    return model.fit(fold.train_dataset).predict(fold.train_dataset.features);
+    return model.fit(fold.train_dataset).predict(fold.test_dataset.features);
   };
 
   return folds.apply(predict_group);

--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -218,8 +218,11 @@ held_out_predictions(const Eigen::SerializableLDLT &covariance,
   return apply(
              group_indexer,
              [&](const auto &key, const auto &indices) {
+               // `blocks` is shared across the pool's workers; use the
+               // const `at()` accessor since the non-const `operator[]`
+               // is a data race.
                return held_out_prediction(
-                   blocks[key], subset(target_mean, indices),
+                   blocks.at(key), subset(target_mean, indices),
                    subset(information, indices), predict_type);
              },
              pool)

--- a/include/albatross/src/evaluation/cross_validation_utils.hpp
+++ b/include/albatross/src/evaluation/cross_validation_utils.hpp
@@ -238,8 +238,11 @@ leave_one_group_out_conditional(const JointDistribution &prior,
   Eigen::SerializableLDLT ldlt(covariance);
   const Eigen::VectorXd deviation = truth.mean - prior.mean;
   const Eigen::VectorXd information = ldlt.solve(deviation);
-  return held_out_predictions(covariance, truth.mean, information,
-                              group_indexer, predict_type, pool);
+  // Pass the already computed LDLT here; passing the dense covariance
+  // would silently re-factorize it (an O(n^3) operation) through
+  // Eigen::SerializableLDLT's implicit converting constructor.
+  return held_out_predictions(ldlt, truth.mean, information, group_indexer,
+                              predict_type, pool);
 }
 
 } // namespace details

--- a/include/albatross/src/linalg/spqr_utils.hpp
+++ b/include/albatross/src/linalg/spqr_utils.hpp
@@ -43,8 +43,8 @@ constexpr Eigen::Index kMinSparsePivotSize = 300;
 // SPQR pivot threshold policy.
 constexpr double kSPQRPivotCoefficient = 0.1;
 
-// Set the pivot threshold of the solver based on the problem to be
-// solved.
+// Compute the pivot threshold of the solver based on the problem to
+// be solved.
 //
 // The default SPQR pivot threshold calculation is oriented towards
 // problems considerably larger than your typical Albatross use case.
@@ -52,13 +52,13 @@ constexpr double kSPQRPivotCoefficient = 0.1;
 // function to choose a smaller threshold than the default and trade a
 // minimal speed reduction for accuracy improvements.
 template <typename MatrixType>
-inline void SPQR_set_pivot_threshold(SPQR *spqr, const MatrixType &m,
-                                     Eigen::Index min_sparse_pivot_size,
-                                     double spqr_pivot_coefficient) {
+inline double SPQR_pivot_threshold(const MatrixType &m,
+                                   Eigen::Index min_sparse_pivot_size,
+                                   double spqr_pivot_coefficient) {
   if (m.rows() < min_sparse_pivot_size || m.cols() < min_sparse_pivot_size) {
     // For small matrices, just use a really tight threshold for pivot
     // detection to reduce the inaccuracy of the sparse method.
-    spqr->setPivotThreshold(1e-15);
+    return 1e-15;
   }
   // For larger matrices, use the default SuiteSparseQR policy to
   // choose the pivot threshold, but accept a user-controlled
@@ -70,9 +70,18 @@ inline void SPQR_set_pivot_threshold(SPQR *spqr, const MatrixType &m,
   if (max2Norm == 0.) {
     max2Norm = 1.;
   }
-  spqr->setPivotThreshold(spqr_pivot_coefficient *
-                          cast::to_double(m.rows() + m.cols()) * max2Norm *
-                          Eigen::NumTraits<double>::epsilon());
+  return spqr_pivot_coefficient * cast::to_double(m.rows() + m.cols()) *
+         max2Norm * Eigen::NumTraits<double>::epsilon();
+}
+
+// Set the pivot threshold of the solver based on the problem to be
+// solved (see `SPQR_pivot_threshold` above).
+template <typename MatrixType>
+inline void SPQR_set_pivot_threshold(SPQR *spqr, const MatrixType &m,
+                                     Eigen::Index min_sparse_pivot_size,
+                                     double spqr_pivot_coefficient) {
+  spqr->setPivotThreshold(
+      SPQR_pivot_threshold(m, min_sparse_pivot_size, spqr_pivot_coefficient));
 }
 
 template <typename MatrixType>

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -245,7 +245,7 @@ public:
     using FitType = Fit<GPFit<ExplainedCovariance, FeatureType>>;
     return FitModel<ImplType, FitType>(
         impl(), gp_fit_from_prediction(features, covariance_function_(features),
-                                       prediction));
+                                       zero_mean_prediction));
   }
 
   std::string get_name() const { return model_name_; };

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -143,9 +143,16 @@ gp_fit_from_prediction(const std::vector<FeatureType> &features,
                        const JointDistribution &prediction) {
   Fit<GPFit<ExplainedCovariance, FeatureType>> fit;
   fit.train_features = features;
+  // Factorize the prior once and share the decomposition between the
+  // covariance representation and the information vector.  Passing the
+  // dense `prior` to ExplainedCovariance (or calling `prior.ldlt()`
+  // again below) would trigger a second O(n^3) factorization, possibly
+  // silently through Eigen::SerializableLDLT's implicit converting
+  // constructor.
+  const Eigen::SerializableLDLT prior_ldlt(prior);
   fit.train_covariance =
-      ExplainedCovariance(prior, prior - prediction.covariance);
-  fit.information = prior.ldlt().solve(prediction.mean);
+      ExplainedCovariance(prior_ldlt, prior - prediction.covariance);
+  fit.information = prior_ldlt.solve(prediction.mean);
   return fit;
 }
 

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -144,11 +144,7 @@ gp_fit_from_prediction(const std::vector<FeatureType> &features,
   Fit<GPFit<ExplainedCovariance, FeatureType>> fit;
   fit.train_features = features;
   // Factorize the prior once and share the decomposition between the
-  // covariance representation and the information vector.  Passing the
-  // dense `prior` to ExplainedCovariance (or calling `prior.ldlt()`
-  // again below) would trigger a second O(n^3) factorization, possibly
-  // silently through Eigen::SerializableLDLT's implicit converting
-  // constructor.
+  // covariance representation and the information vector.
   const Eigen::SerializableLDLT prior_ldlt(prior);
   fit.train_covariance =
       ExplainedCovariance(prior_ldlt, prior - prediction.covariance);

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -727,7 +727,7 @@ auto rebase_inducing_points(
 template <typename CovFunc, typename MeanFunc, typename GrouperFunction,
           typename InducingPointStrategy>
 using SparseQRSparseGaussianProcessRegression =
-    SparseGaussianProcessRegression<CovFunc, GrouperFunction,
+    SparseGaussianProcessRegression<CovFunc, MeanFunc, GrouperFunction,
                                     InducingPointStrategy, SPQRImplementation>;
 
 template <typename CovFunc, typename MeanFunc, typename GrouperFunction,

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -262,6 +262,26 @@ TEST(test_crossvalidation, test_leave_one_out_equivalences) {
   }
 }
 
+TEST(test_crossvalidation, test_get_predictions_uses_test_features) {
+  // Regression test: get_predictions must predict each fold's held-out
+  // test features (matching predict_fold), not the training features
+  // it was fit on.
+  const auto dataset = make_toy_linear_data();
+  auto model = MakeGaussianProcess().get_model();
+
+  const auto folds = folds_from_grouper(dataset, group_by_interval<double>);
+  const auto predictions = get_predictions(model, folds);
+
+  for (const auto &pair : folds) {
+    const auto &key = pair.first;
+    const auto &fold = pair.second;
+    const Eigen::VectorXd actual = predictions.at(key).mean();
+    ASSERT_EQ(actual.size(), cast::to_index(fold.test_dataset.size()));
+    const Eigen::VectorXd expected = predict_fold(model, fold).mean();
+    EXPECT_LE((actual - expected).norm(), 1e-12);
+  }
+}
+
 TEST(test_crossvalidation, test_leave_one_group_out_conditional_reference) {
   // Regression test: leave_one_group_out_conditional_* must match a
   // manually computed dense-algebra reference.  This pins the behavior

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -352,13 +352,31 @@ TEST(test_crossvalidation, test_leave_one_group_out_conditional_threaded) {
 
   for (const auto &pair : indexers) {
     const auto &key = pair.first;
-    EXPECT_EQ(threaded_means.at(key), serial_means.at(key));
-    EXPECT_EQ(threaded_marginals.at(key).mean, serial_marginals.at(key).mean);
-    EXPECT_EQ(Eigen::MatrixXd(threaded_marginals.at(key).covariance),
-              Eigen::MatrixXd(serial_marginals.at(key).covariance));
-    EXPECT_EQ(threaded_joints.at(key).mean, serial_joints.at(key).mean);
-    EXPECT_EQ(threaded_joints.at(key).covariance,
-              serial_joints.at(key).covariance);
+
+    ASSERT_EQ(threaded_means.at(key).size(), serial_means.at(key).size());
+    for (Eigen::Index i = 0; i < serial_means.at(key).size(); ++i) {
+      EXPECT_DOUBLE_EQ(threaded_means.at(key)[i], serial_means.at(key)[i]);
+    }
+
+    const auto &serial_marginal = serial_marginals.at(key);
+    const auto &threaded_marginal = threaded_marginals.at(key);
+    ASSERT_EQ(threaded_marginal.size(), serial_marginal.size());
+    for (Eigen::Index i = 0; i < cast::to_index(serial_marginal.size()); ++i) {
+      EXPECT_DOUBLE_EQ(threaded_marginal.mean[i], serial_marginal.mean[i]);
+      EXPECT_DOUBLE_EQ(threaded_marginal.get_diagonal(i),
+                       serial_marginal.get_diagonal(i));
+    }
+
+    const auto &serial_joint = serial_joints.at(key);
+    const auto &threaded_joint = threaded_joints.at(key);
+    ASSERT_EQ(threaded_joint.size(), serial_joint.size());
+    for (Eigen::Index i = 0; i < cast::to_index(serial_joint.size()); ++i) {
+      EXPECT_DOUBLE_EQ(threaded_joint.mean[i], serial_joint.mean[i]);
+      for (Eigen::Index j = 0; j < cast::to_index(serial_joint.size()); ++j) {
+        EXPECT_DOUBLE_EQ(threaded_joint.covariance(i, j),
+                         serial_joint.covariance(i, j));
+      }
+    }
   }
 }
 

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -262,6 +262,45 @@ TEST(test_crossvalidation, test_leave_one_out_equivalences) {
   }
 }
 
+TEST(test_crossvalidation, test_leave_one_group_out_conditional_reference) {
+  // Regression test: leave_one_group_out_conditional_* must match a
+  // manually computed dense-algebra reference.  This pins the behavior
+  // of the internal held_out_predictions path (which reuses a single
+  // LDLT of the covariance rather than re-factorizing it).
+  const auto dataset = make_toy_linear_data();
+  auto model = MakeGaussianProcess().get_model();
+
+  const auto indexers = dataset.group_by(group_by_interval<double>).indexers();
+  const auto prior = model.prior(dataset.features);
+
+  const auto loo_joints =
+      leave_one_group_out_conditional_joints(prior, dataset.targets, indexers);
+
+  const Eigen::MatrixXd sigma =
+      prior.covariance + Eigen::MatrixXd(dataset.targets.covariance);
+
+  for (const auto &pair : indexers) {
+    const auto &group_inds = pair.second;
+    const auto other_inds = indices_complement(group_inds, prior.size());
+
+    const Eigen::MatrixXd sigma_gg = symmetric_subset(sigma, group_inds);
+    const Eigen::MatrixXd sigma_go = subset(sigma, group_inds, other_inds);
+    const Eigen::MatrixXd sigma_oo = symmetric_subset(sigma, other_inds);
+    const Eigen::VectorXd deviation_o =
+        subset(Eigen::VectorXd(dataset.targets.mean - prior.mean), other_inds);
+
+    const Eigen::VectorXd expected_mean =
+        subset(prior.mean, group_inds) +
+        sigma_go * sigma_oo.ldlt().solve(deviation_o);
+    const Eigen::MatrixXd expected_cov =
+        sigma_gg - sigma_go * sigma_oo.ldlt().solve(sigma_go.transpose());
+
+    const auto &actual = loo_joints.at(pair.first);
+    EXPECT_LE((actual.mean - expected_mean).norm(), 1e-6);
+    EXPECT_LE((actual.covariance - expected_cov).norm(), 1e-6);
+  }
+}
+
 class MakeLargeGaussianProcess {
 public:
   auto get_model() const {

--- a/tests/test_cross_validation.cc
+++ b/tests/test_cross_validation.cc
@@ -301,6 +301,47 @@ TEST(test_crossvalidation, test_leave_one_group_out_conditional_reference) {
   }
 }
 
+TEST(test_crossvalidation, test_leave_one_group_out_conditional_threaded) {
+  // Regression test: the held-out prediction path must produce the
+  // same results when run on a real thread pool as when run serially.
+  // (The underlying data race on the shared block map is only
+  // detectable under TSan; this pins correctness of the threaded
+  // path.)
+  const auto dataset = make_toy_linear_data();
+  auto model = MakeGaussianProcess().get_model();
+
+  const auto indexers = dataset.group_by(group_by_interval<double>).indexers();
+  const auto prior = model.prior(dataset.features);
+
+  auto pool = make_shared_thread_pool(4);
+
+  const auto serial_means =
+      leave_one_group_out_conditional_means(prior, dataset.targets, indexers);
+  const auto threaded_means = leave_one_group_out_conditional_means(
+      prior, dataset.targets, indexers, pool.get());
+
+  const auto serial_marginals = leave_one_group_out_conditional_marginals(
+      prior, dataset.targets, indexers);
+  const auto threaded_marginals = leave_one_group_out_conditional_marginals(
+      prior, dataset.targets, indexers, pool.get());
+
+  const auto serial_joints =
+      leave_one_group_out_conditional_joints(prior, dataset.targets, indexers);
+  const auto threaded_joints = leave_one_group_out_conditional_joints(
+      prior, dataset.targets, indexers, pool.get());
+
+  for (const auto &pair : indexers) {
+    const auto &key = pair.first;
+    EXPECT_EQ(threaded_means.at(key), serial_means.at(key));
+    EXPECT_EQ(threaded_marginals.at(key).mean, serial_marginals.at(key).mean);
+    EXPECT_EQ(Eigen::MatrixXd(threaded_marginals.at(key).covariance),
+              Eigen::MatrixXd(serial_marginals.at(key).covariance));
+    EXPECT_EQ(threaded_joints.at(key).mean, serial_joints.at(key).mean);
+    EXPECT_EQ(threaded_joints.at(key).covariance,
+              serial_joints.at(key).covariance);
+  }
+}
+
 class MakeLargeGaussianProcess {
 public:
   auto get_model() const {

--- a/tests/test_gp.cc
+++ b/tests/test_gp.cc
@@ -341,6 +341,35 @@ TEST(test_gp, test_model_from_prediction_low_rank) {
       model_pred.covariance, 1e-8));
 }
 
+TEST(test_gp, test_model_from_prediction_with_mean) {
+  // Regression test: fit_from_prediction must remove the mean function
+  // from the prediction before building the new fit.  If the original
+  // (mean-included) prediction is used, the mean function ends up
+  // double counted in subsequent predictions.
+  const double a = 5.;
+  const double b = 1.;
+  const auto dataset = make_toy_linear_data(a, b);
+
+  SquaredExponential<EuclideanDistance> squared_exponential(2., 1.);
+  IndependentNoise<double> noise(0.1);
+  const auto covariance = squared_exponential + measurement_only(noise);
+  LinearMean linear_mean;
+  linear_mean.offset.value = a;
+  linear_mean.slope.value = b;
+  const auto model = gp_from_covariance_and_mean(covariance, linear_mean);
+
+  const auto fit_model = model.fit(dataset);
+
+  const std::vector<double> features = {1.3, 4.2, 7.1};
+  const auto pred = fit_model.predict(features).joint();
+
+  const auto from_prediction = model.fit_from_prediction(features, pred);
+  const auto pred_again = from_prediction.predict(features).joint();
+
+  EXPECT_LE((pred_again.mean - pred.mean).norm(), 1e-6);
+  EXPECT_LE((pred_again.covariance - pred.covariance).norm(), 1e-6);
+}
+
 TEST(test_gp, test_explained_covariance_precomputed_ldlt) {
   // Regression test: constructing an ExplainedCovariance from a
   // precomputed LDLT (which avoids re-factorizing the outer matrix)

--- a/tests/test_gp.cc
+++ b/tests/test_gp.cc
@@ -341,6 +341,25 @@ TEST(test_gp, test_model_from_prediction_low_rank) {
       model_pred.covariance, 1e-8));
 }
 
+TEST(test_gp, test_explained_covariance_precomputed_ldlt) {
+  // Regression test: constructing an ExplainedCovariance from a
+  // precomputed LDLT (which avoids re-factorizing the outer matrix)
+  // must behave identically to constructing it from the dense matrix.
+  const Eigen::Index k = 7;
+  Eigen::MatrixXd outer = Eigen::MatrixXd::Random(k, k);
+  outer = outer * outer.transpose() + Eigen::MatrixXd::Identity(k, k);
+  Eigen::MatrixXd inner = Eigen::MatrixXd::Random(k, k);
+  inner = inner * inner.transpose();
+
+  const ExplainedCovariance from_dense(outer, inner);
+  const ExplainedCovariance from_ldlt(Eigen::SerializableLDLT(outer), inner);
+
+  EXPECT_TRUE(from_dense == from_ldlt);
+
+  const Eigen::MatrixXd rhs = Eigen::MatrixXd::Random(k, 3);
+  EXPECT_EQ(from_dense.solve(rhs), from_ldlt.solve(rhs));
+}
+
 TEST(test_gp, test_unobservablemodel_with_sum_constraint) {
 
   const auto dataset = test_unobservable_dataset();

--- a/tests/test_linalg_utils.cc
+++ b/tests/test_linalg_utils.cc
@@ -31,6 +31,29 @@ TEST(test_linalg_utils, test_qr_sqrt_solve) {
   EXPECT_LT((actual_quad - expected_quad).norm(), 1e-14);
 }
 
+TEST(test_linalg_utils, test_spqr_pivot_threshold_small_matrix) {
+  // Regression test: matrices smaller than the minimum sparse pivot
+  // size must use the tight small-problem threshold (1e-15) instead of
+  // falling through to the large-problem SuiteSparseQR policy.
+  const Eigen::Index small_size = kMinSparsePivotSize - 1;
+  const Eigen::MatrixXd small =
+      Eigen::MatrixXd::Identity(small_size, small_size);
+  EXPECT_EQ(
+      SPQR_pivot_threshold(small, kMinSparsePivotSize, kSPQRPivotCoefficient),
+      1e-15);
+
+  // Large matrices should keep using the (scaled) default policy.
+  const Eigen::Index large_size = kMinSparsePivotSize;
+  const Eigen::MatrixXd large =
+      Eigen::MatrixXd::Identity(large_size, large_size);
+  const double expected_large = kSPQRPivotCoefficient *
+                                cast::to_double(large_size + large_size) *
+                                Eigen::NumTraits<double>::epsilon();
+  EXPECT_DOUBLE_EQ(
+      SPQR_pivot_threshold(large, kMinSparsePivotSize, kSPQRPivotCoefficient),
+      expected_large);
+}
+
 TEST(test_linalg_utils, test_print_eigen_values) {
 
   constexpr Eigen::Index k = 10;

--- a/tests/test_linalg_utils.cc
+++ b/tests/test_linalg_utils.cc
@@ -38,7 +38,7 @@ TEST(test_linalg_utils, test_spqr_pivot_threshold_small_matrix) {
   const Eigen::Index small_size = kMinSparsePivotSize - 1;
   const Eigen::MatrixXd small =
       Eigen::MatrixXd::Identity(small_size, small_size);
-  EXPECT_EQ(
+  EXPECT_DOUBLE_EQ(
       SPQR_pivot_threshold(small, kMinSparsePivotSize, kSPQRPivotCoefficient),
       1e-15);
 

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -267,6 +267,31 @@ TEST(test_sparse_gp_sparse_qr, test_update_exists) {
   EXPECT_TRUE(bool(can_update_in_place<SparseGPR, FitType, double>::value));
 }
 
+TEST(test_sparse_gp_sparse_qr, test_alias_forwards_all_template_params) {
+  // Compile-time regression test: the SparseQRSparseGaussianProcessRegression
+  // alias must forward all four of its template parameters into the
+  // corresponding slots of SparseGaussianProcessRegression and select
+  // SPQRImplementation.  A previous version dropped MeanFunc, shifting
+  // every parameter into the wrong slot and silently falling back to
+  // DenseQRImplementation.
+  using CovFunc = SquaredExponential<EuclideanDistance>;
+  using MeanFunc = ZeroMean;
+  using GrouperFunction = LeaveOneIntervalOut;
+  using InducingPointStrategy = UniformlySpacedInducingPoints;
+
+  using Expected =
+      SparseGaussianProcessRegression<CovFunc, MeanFunc, GrouperFunction,
+                                      InducingPointStrategy,
+                                      SPQRImplementation>;
+  using Actual = SparseQRSparseGaussianProcessRegression<
+      CovFunc, MeanFunc, GrouperFunction, InducingPointStrategy>;
+  static_assert(std::is_same<Actual, Expected>::value,
+                "SparseQRSparseGaussianProcessRegression must forward "
+                "CovFunc, MeanFunc, GrouperFunction and "
+                "InducingPointStrategy and use SPQRImplementation");
+  EXPECT_TRUE(bool(std::is_same<Actual, Expected>::value));
+}
+
 TYPED_TEST(SparseGaussianProcessTest, test_update) {
   auto &grouper_ = this->grouper;
   auto &qr_ = this->qr;

--- a/tests/test_sparse_gp.cc
+++ b/tests/test_sparse_gp.cc
@@ -271,9 +271,7 @@ TEST(test_sparse_gp_sparse_qr, test_alias_forwards_all_template_params) {
   // Compile-time regression test: the SparseQRSparseGaussianProcessRegression
   // alias must forward all four of its template parameters into the
   // corresponding slots of SparseGaussianProcessRegression and select
-  // SPQRImplementation.  A previous version dropped MeanFunc, shifting
-  // every parameter into the wrong slot and silently falling back to
-  // DenseQRImplementation.
+  // SPQRImplementation.
   using CovFunc = SquaredExponential<EuclideanDistance>;
   using MeanFunc = ZeroMean;
   using GrouperFunction = LeaveOneIntervalOut;


### PR DESCRIPTION
One commit per bug, each with a regression test (behavioral ones verified failing pre-fix):

- SPQR pivot-threshold fall-through (small-matrix branch was dead code)
- Duplicate O(n^3) LDLT factorizations in LOGO-CV and `fit_from_prediction`
- `fit_from_prediction` discarded the mean-removed prediction (wrong results with non-zero mean functions)
- Data race: `std::map::operator[]` from thread-pool workers in `held_out_predictions`
- `SparseQRSparseGaussianProcessRegression` alias mis-bound template params; `get_predictions` returned in-sample predictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)