### PR TITLE
Compute inverse_diagonal directly from the inverse Cholesky factor

### DIFF
--- a/include/albatross/src/eigen/serializable_ldlt.hpp
+++ b/include/albatross/src/eigen/serializable_ldlt.hpp
@@ -175,27 +175,27 @@ public:
   }
 
   /*
-   * The diagonal of the inverse of the matrix this LDLT
-   * decomposition represents in O(n^2) operations.
+   * The diagonal of the inverse of the matrix this LDLT decomposition
+   * represents.  The triangular solve against the identity makes this
+   * O(n^3) flops (the same as inverse_blocks), but the diagonal is
+   * then read off directly as column squared norms, with no per-entry
+   * index vectors, column subsets or 1x1 block allocations.
    */
   Eigen::VectorXd inverse_diagonal() const {
     Eigen::Index n = this->rows();
 
-    const auto size_n = albatross::cast::to_size(n);
-    std::vector<std::vector<std::size_t>> block_indices(size_n);
-    for (std::size_t i = 0; i < size_n; i++) {
-      block_indices[i] = {i};
-    }
+    // As in inverse_blocks:
+    //   A = P^T L D L^T P  =>  A^-1 = R^-T R^-1 with R^-1 = D^-1/2 L^-1 P
+    // so diag(A^-1)_i is the squared norm of column i of R^-1.
+    Eigen::MatrixXd inverse_cholesky =
+        this->transpositionsP() * Eigen::MatrixXd::Identity(n, n);
+    this->matrixL().solveInPlace(inverse_cholesky);
+    inverse_cholesky.array().colwise() *=
+        diagonal_sqrt_inverse().diagonal().array();
 
-    Eigen::VectorXd inv_diag(n);
-    const auto blocks = inverse_blocks(block_indices);
-    for (std::size_t i = 0; i < size_n; i++) {
-      ALBATROSS_ASSERT(blocks[i].rows() == 1);
-      ALBATROSS_ASSERT(blocks[i].cols() == 1);
-      inv_diag[albatross::cast::to_index(i)] = blocks[i](0, 0);
-    }
+    ALBATROSS_ASSERT(!inverse_cholesky.hasNaN());
 
-    return inv_diag;
+    return inverse_cholesky.colwise().squaredNorm().transpose();
   }
 
   bool operator==(const SerializableLDLT &rhs) const {

--- a/tests/test_serializable_ldlt.cc
+++ b/tests/test_serializable_ldlt.cc
@@ -45,6 +45,25 @@ TEST_F(SerializableLDLTTest, test_inverse_diagonal) {
   EXPECT_LE(fabs((Eigen::VectorXd(inverse.diagonal()) - diag).norm()), 1e-8);
 }
 
+TEST_F(SerializableLDLTTest, test_inverse_diagonal_matches_inverse_blocks) {
+  const auto serializable_ldlt = Eigen::SerializableLDLT(cov.ldlt());
+
+  const auto n = albatross::cast::to_size(cov.rows());
+  std::vector<std::vector<std::size_t>> singletons(n);
+  for (std::size_t i = 0; i < n; i++) {
+    singletons[i] = {i};
+  }
+
+  const auto blocks = serializable_ldlt.inverse_blocks(singletons);
+  const auto diag = serializable_ldlt.inverse_diagonal();
+  ASSERT_EQ(albatross::cast::to_size(diag.size()), n);
+  for (std::size_t i = 0; i < n; i++) {
+    ASSERT_EQ(blocks[i].rows(), 1);
+    ASSERT_EQ(blocks[i].cols(), 1);
+    EXPECT_NEAR(blocks[i](0, 0), diag[albatross::cast::to_index(i)], 1e-12);
+  }
+}
+
 TEST_F(SerializableLDLTTest, test_log_det) {
   auto ldlt = cov.ldlt();
   const auto serializable_ldlt = Eigen::SerializableLDLT(ldlt);


### PR DESCRIPTION
Replaces the n-singleton-block machinery with column squared norms; removes per-element allocations and fixes the incorrect O(n^2) complexity comment. New regression test vs `inverse_blocks`.

## Benchmark results

| benchmark | speedup |
|---|---|
| inverse_diagonal/256 | **1.05x** |
| inverse_diagonal/512 | **1.02x** |
| inverse_diagonal/1024 | **~1.01x** |

Honest assessment: the O(n^3) triangular solve dominates, so the win is small — kept because the code is simpler, allocation-free, and never slower.

Stack 3/5, on #592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)