### PR TITLE
Add opt-in matrix-level kernel evaluation API

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,67 @@
+name: Benchmarks
+
+# Manual benchmark runs on Linux CI runners, primarily to measure the
+# matrix-level kernel assembly path on x86_64 (wider SIMD than Apple
+# NEON) with and without MKL.  Not part of regular CI: shared runners
+# are noisy, so treat results as indicative, and prefer the relative
+# per-pair vs matrix numbers over absolute timings.
+on:
+  push:
+    branches:
+      - 'feat/matrix-kernel-api'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kernel-assembly:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - { name: "eigen", flags: "-c opt" }
+          - { name: "mkl", flags: "--config=mkl" }
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          ssh-key: ${{ secrets.SSH_KEY }}
+
+      - uses: bazel-contrib/setup-bazel@0.19.0
+
+      - uses: extractions/netrc@v3
+        with:
+          machine: raw.githubusercontent.com
+          username: ${{ secrets.GH_NAME }}
+          password: ${{ secrets.GH_TOKEN }}
+
+      - name: Mount bazel cache
+        uses: actions/cache@v5
+        with:
+          path: "~/.cache/bazel"
+          key: bazel-bench-${{ matrix.flavor.name }}
+
+      - name: CPU info
+        run: |
+          lscpu | grep -E 'Model name|^CPU\(s\)' || true
+          grep -o -m1 -E 'avx512[a-z]*|avx2|fma' /proc/cpuinfo | sort -u | tr '\n' ' '; echo
+
+      - name: Run kernel assembly benchmark (${{ matrix.flavor.name }})
+        run: |
+          bazel run ${{ matrix.flavor.flags }} //benchmarks:bench_kernel_assembly -- \
+            --benchmark_repetitions=5 --benchmark_report_aggregates_only=true \
+            | tee bench_kernel_assembly.txt
+
+      - name: Publish summary
+        if: always()
+        run: |
+          {
+            echo "## Kernel assembly benchmark (${{ matrix.flavor.name }})"
+            echo '```'
+            cat bench_kernel_assembly.txt || echo "benchmark did not produce output"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/benchmarks/BUILD.bazel
+++ b/benchmarks/BUILD.bazel
@@ -33,6 +33,17 @@ cc_binary(
 )
 
 cc_binary(
+    name = "bench_kernel_assembly",
+    srcs = [
+        "bench_kernel_assembly.cc",
+        "bench_utils.h",
+    ],
+    copts = BENCH_COPTS,
+    local_defines = ["CSV_IO_NO_THREAD"],
+    deps = BENCH_DEPS,
+)
+
+cc_binary(
     name = "bench_loo_cv",
     srcs = [
         "bench_loo_cv.cc",

--- a/benchmarks/bench_kernel_assembly.cc
+++ b/benchmarks/bench_kernel_assembly.cc
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2026 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*
+ * Covariance matrix assembly: per-pair scalar kernel calls versus the
+ * opt-in matrix-level (_call_matrix_impl) evaluation.
+ *
+ * The "before" numbers are obtained by evaluating the exact same kernel
+ * through a wrapper without a matrix implementation, which is fairer
+ * than checking out the parent commit since both paths run in the same
+ * binary with the same inlining decisions.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include "bench_utils.h"
+
+namespace albatross {
+namespace {
+
+constexpr Eigen::Index cDimension = 3;
+constexpr double cLengthScale = 2.;
+constexpr double cSigma = 1.5;
+
+// The exact same math as SquaredExponential<EuclideanDistance> but
+// without the opt-in matrix implementation: this is the per-pair
+// ("before") reference.
+class PerPairSquaredExponential
+    : public CovarianceFunction<PerPairSquaredExponential> {
+public:
+  std::string name() const { return "per_pair_squared_exponential"; }
+
+  template <
+      typename X,
+      typename std::enable_if<
+          has_call_operator<EuclideanDistance, X &, X &>::value, int>::type = 0>
+  double _call_impl(const X &x, const X &y) const {
+    return squared_exponential_covariance(distance_metric_(x, y), cLengthScale,
+                                          cSigma);
+  }
+
+  EuclideanDistance distance_metric_;
+};
+
+std::vector<Eigen::VectorXd> random_vector_features(std::size_t n,
+                                                    std::uint32_t seed) {
+  std::mt19937 gen(seed);
+  std::normal_distribution<double> dist(0., 1.);
+  std::vector<Eigen::VectorXd> features(n);
+  for (auto &f : features) {
+    f.resize(cDimension);
+    for (Eigen::Index i = 0; i < cDimension; ++i) {
+      f[i] = dist(gen);
+    }
+  }
+  return features;
+}
+
+void BM_assembly_per_pair(benchmark::State &state) {
+  const PerPairSquaredExponential cov;
+  const auto n = cast::to_size(state.range(0));
+  const auto xs = random_vector_features(n, 0);
+  const auto ys = random_vector_features(n, 1);
+  for (auto _ : state) {
+    Eigen::MatrixXd c = cov(xs, ys);
+    benchmark::DoNotOptimize(c);
+  }
+}
+BENCHMARK(BM_assembly_per_pair)->Arg(256)->Arg(512)->Arg(1024)->Arg(2048);
+
+void BM_assembly_matrix(benchmark::State &state) {
+  const SquaredExponential<EuclideanDistance> cov(cLengthScale, cSigma);
+  const auto n = cast::to_size(state.range(0));
+  const auto xs = random_vector_features(n, 0);
+  const auto ys = random_vector_features(n, 1);
+  for (auto _ : state) {
+    Eigen::MatrixXd c = cov(xs, ys);
+    benchmark::DoNotOptimize(c);
+  }
+}
+BENCHMARK(BM_assembly_matrix)->Arg(256)->Arg(512)->Arg(1024)->Arg(2048);
+
+// Small sizes to locate the crossover point.  Note that
+// BM_assembly_matrix goes through operator() which falls back to the
+// per-pair path below MIN_MATRIX_CALL_COEFFICIENTS, so the raw matrix
+// implementation is also benchmarked directly.
+void BM_assembly_matrix_forced(benchmark::State &state) {
+  const SquaredExponential<EuclideanDistance> cov(cLengthScale, cSigma);
+  const auto n = cast::to_size(state.range(0));
+  const auto xs = random_vector_features(n, 0);
+  const auto ys = random_vector_features(n, 1);
+  for (auto _ : state) {
+    Eigen::MatrixXd c = cov._call_matrix_impl(xs, ys);
+    benchmark::DoNotOptimize(c);
+  }
+}
+BENCHMARK(BM_assembly_per_pair)->Arg(4)->Arg(8)->Arg(16)->Arg(32)->Arg(64);
+BENCHMARK(BM_assembly_matrix)->Arg(4)->Arg(8)->Arg(16)->Arg(32)->Arg(64);
+BENCHMARK(BM_assembly_matrix_forced)->Arg(4)->Arg(8)->Arg(16)->Arg(32)->Arg(64);
+
+template <typename CovFunc>
+RegressionDataset<Eigen::VectorXd>
+vector_dataset(const CovFunc &, std::size_t n, std::uint32_t seed) {
+  const auto features = random_vector_features(n, seed);
+  Eigen::VectorXd targets(cast::to_index(n));
+  for (std::size_t i = 0; i < n; ++i) {
+    targets[cast::to_index(i)] = std::sin(features[i].sum());
+  }
+  const Eigen::VectorXd variance =
+      Eigen::VectorXd::Constant(targets.size(), 0.01);
+  return RegressionDataset<Eigen::VectorXd>(
+      features, MarginalDistribution(targets, variance));
+}
+
+// End-to-end GP mean prediction (fit excluded from the timed loop).
+template <typename CovFunc>
+void gp_mean_prediction(benchmark::State &state, const CovFunc &cov) {
+  auto model = gp_from_covariance(cov, "bench_gp");
+  const auto n = cast::to_size(state.range(0));
+  const auto dataset = vector_dataset(cov, n, 2);
+  const auto test_features = random_vector_features(n, 3);
+  const auto fit_model = model.fit(dataset);
+  for (auto _ : state) {
+    Eigen::VectorXd mean = fit_model.predict(test_features).mean();
+    benchmark::DoNotOptimize(mean);
+  }
+}
+
+void BM_gp_mean_predict_per_pair(benchmark::State &state) {
+  gp_mean_prediction(state, PerPairSquaredExponential());
+}
+BENCHMARK(BM_gp_mean_predict_per_pair)
+    ->Arg(256)
+    ->Arg(512)
+    ->Arg(1024)
+    ->Arg(2048)
+    ->Unit(benchmark::kMillisecond);
+
+void BM_gp_mean_predict_matrix(benchmark::State &state) {
+  gp_mean_prediction(
+      state, SquaredExponential<EuclideanDistance>(cLengthScale, cSigma));
+}
+BENCHMARK(BM_gp_mean_predict_matrix)
+    ->Arg(256)
+    ->Arg(512)
+    ->Arg(1024)
+    ->Arg(2048)
+    ->Unit(benchmark::kMillisecond);
+
+} // namespace
+} // namespace albatross

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -124,10 +124,37 @@ public:
 
   /*
    * Covariance between each element and every other in a vector.
+   *
+   * The default implementation assembles the matrix one scalar
+   * _call_impl call at a time.  Covariance functions can opt in to a
+   * matrix-level (vectorized) assembly by defining:
+   *
+   *   Eigen::MatrixXd _call_matrix_impl(const std::vector<X> &,
+   *                                     const std::vector<Y> &) const
+   *
+   * in which case that method is used directly.  NOTE: when the matrix
+   * path is taken any ThreadPool argument is intentionally ignored;
+   * matrix implementations are expected to rely on Eigen's internally
+   * vectorized (BLAS-like) kernels which don't benefit from the pool.
    */
   template <typename X,
-            typename std::enable_if<has_valid_caller<Derived, X, X>::value,
-                                    int>::type = 0>
+            typename std::enable_if<
+                has_valid_matrix_caller<Derived, X, X>::value, int>::type = 0>
+  Eigen::MatrixXd operator()(const std::vector<X> &xs,
+                             ThreadPool * /* pool: unused, see above */
+                             = nullptr) const {
+    Eigen::MatrixXd cov = derived()._call_matrix_impl(xs, xs);
+    // The per-pair path guarantees an exactly symmetric matrix; a GEMM
+    // based implementation may differ in the last ulp between (i, j)
+    // and (j, i), so we enforce symmetry here.
+    cov.template triangularView<Eigen::Lower>() = cov.transpose();
+    return cov;
+  }
+
+  template <typename X, typename std::enable_if<
+                            (has_valid_caller<Derived, X, X>::value &&
+                             !has_valid_matrix_caller<Derived, X, X>::value),
+                            int>::type = 0>
   Eigen::MatrixXd operator()(const std::vector<X> &xs,
                              ThreadPool *pool = nullptr) const {
     auto caller = [&](const auto &x, const auto &y) {
@@ -137,11 +164,59 @@ public:
   }
 
   /*
+   * Measurement<> unwrapping for the matrix path.
+   *
+   * The fit path wraps features in Measurement<> (see as_measurements).
+   * When the derived covariance function has a matrix implementation for
+   * the underlying type and does not distinguish Measurement<X> from X
+   * in any way (no _call_impl mentioning Measurement<X> whatsoever), the
+   * Measurement wrappers are stripped and the matrix path is used.
+   *
+   * NOTE: this deliberately does not apply to composite functions such
+   * as SumOfCovarianceFunctions since those accept Measurement<X> via
+   * their generic _call_impl (one of their terms, e.g. a noise model,
+   * could behave differently for measurements).  Composed kernels
+   * therefore use the per-pair path for Measurement<> features (i.e.
+   * during fit) but still benefit from the matrix path for the plain
+   * feature types used in predict cross covariances.
+   */
+  template <typename X, typename std::enable_if<
+                            (has_valid_matrix_caller<Derived, X, X>::value &&
+                             !has_valid_matrix_caller<Derived, Measurement<X>,
+                                                      Measurement<X>>::value &&
+                             !has_possible_call_impl<Derived, Measurement<X>,
+                                                     Measurement<X>>::value),
+                            int>::type = 0>
+  Eigen::MatrixXd operator()(const std::vector<Measurement<X>> &xs,
+                             ThreadPool *pool = nullptr) const {
+    std::vector<X> values;
+    values.reserve(xs.size());
+    for (const auto &x : xs) {
+      values.push_back(x.value);
+    }
+    return this->operator()(values, pool);
+  }
+
+  /*
    * Cross covariance between two vectors of (possibly) different types.
+   *
+   * As above, a covariance function with a matrix-level implementation
+   * for (X, Y) bypasses the per-pair loop (and ignores any thread pool).
    */
   template <typename X, typename Y,
-            typename std::enable_if<has_valid_caller<Derived, X, Y>::value,
-                                    int>::type = 0>
+            typename std::enable_if<
+                has_valid_matrix_caller<Derived, X, Y>::value, int>::type = 0>
+  Eigen::MatrixXd operator()(const std::vector<X> &xs, const std::vector<Y> &ys,
+                             ThreadPool * /* pool: unused, see above */
+                             = nullptr) const {
+    return derived()._call_matrix_impl(xs, ys);
+  }
+
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(has_valid_caller<Derived, X, Y>::value &&
+                               !has_valid_matrix_caller<Derived, X, Y>::value),
+                              int>::type = 0>
   Eigen::MatrixXd operator()(const std::vector<X> &xs, const std::vector<Y> &ys,
                              ThreadPool *pool = nullptr) const {
     auto caller = [&](const auto &x, const auto &y) {
@@ -215,6 +290,36 @@ public:
 
   const Derived &derived() const { return *static_cast<const Derived *>(this); }
 };
+
+namespace details {
+
+/*
+ * Assemble the covariance block for one term of a composite covariance
+ * function, using the term's matrix-level implementation when it has one
+ * and falling back to the per-pair loop otherwise.  This is what allows
+ * a composed kernel (e.g. k1 * k2 + k3) to benefit from matrix-level
+ * evaluation term by term.
+ */
+template <typename CovFunc, typename X, typename Y,
+          typename std::enable_if<has_valid_matrix_caller<CovFunc, X, Y>::value,
+                                  int>::type = 0>
+inline Eigen::MatrixXd compute_covariance_block(const CovFunc &cov,
+                                                const std::vector<X> &xs,
+                                                const std::vector<Y> &ys) {
+  return cov._call_matrix_impl(xs, ys);
+}
+
+template <typename CovFunc, typename X, typename Y,
+          typename std::enable_if<
+              !has_valid_matrix_caller<CovFunc, X, Y>::value, int>::type = 0>
+inline Eigen::MatrixXd compute_covariance_block(const CovFunc &cov,
+                                                const std::vector<X> &xs,
+                                                const std::vector<Y> &ys) {
+  auto caller = [&](const auto &x, const auto &y) { return cov(x, y); };
+  return compute_covariance_matrix(caller, xs, ys);
+}
+
+} // namespace details
 
 /*
  * SUM
@@ -291,6 +396,52 @@ public:
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->rhs_(x, y);
+  }
+
+  /*
+   * Matrix-level evaluation of the sum.  This is available as soon as at
+   * least one of the two terms has a matrix-level implementation for
+   * (X, Y); the other term is assembled with the per-pair fallback (see
+   * details::compute_covariance_block).  A term only participates when
+   * it would also participate in the scalar _call_impl above
+   * (has_equivalent_caller) so the two paths always agree on which terms
+   * are included.
+   */
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
+                               has_equivalent_caller<RHS, X, Y>::value &&
+                               (has_valid_matrix_caller<LHS, X, Y>::value ||
+                                has_valid_matrix_caller<RHS, X, Y>::value)),
+                              int>::type = 0>
+  Eigen::MatrixXd _call_matrix_impl(const std::vector<X> &xs,
+                                    const std::vector<Y> &ys) const {
+    return details::compute_covariance_block(this->lhs_, xs, ys) +
+           details::compute_covariance_block(this->rhs_, xs, ys);
+  }
+
+  /*
+   * If only LHS is defined for these types (RHS is ignored, as in the
+   * scalar path) the matrix impl is available when LHS has one.
+   */
+  template <typename X, typename Y,
+            typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
+                                     !has_equivalent_caller<RHS, X, Y>::value &&
+                                     has_valid_matrix_caller<LHS, X, Y>::value),
+                                    int>::type = 0>
+  Eigen::MatrixXd _call_matrix_impl(const std::vector<X> &xs,
+                                    const std::vector<Y> &ys) const {
+    return details::compute_covariance_block(this->lhs_, xs, ys);
+  }
+
+  template <typename X, typename Y,
+            typename std::enable_if<(!has_equivalent_caller<LHS, X, Y>::value &&
+                                     has_equivalent_caller<RHS, X, Y>::value &&
+                                     has_valid_matrix_caller<RHS, X, Y>::value),
+                                    int>::type = 0>
+  Eigen::MatrixXd _call_matrix_impl(const std::vector<X> &xs,
+                                    const std::vector<Y> &ys) const {
+    return details::compute_covariance_block(this->rhs_, xs, ys);
   }
 
   template <typename X,
@@ -386,6 +537,46 @@ public:
                                     int>::type = 0>
   double _call_impl(const X &x, const Y &y) const {
     return this->rhs_(x, y);
+  }
+
+  /*
+   * Matrix-level evaluation of the product; see the analogous methods
+   * on SumOfCovarianceFunctions for the reasoning behind the enable_if
+   * conditions.  Note the scalar _call_impl short circuits when the LHS
+   * is zero which is a performance (not correctness) detail; the
+   * element-wise product below is mathematically identical.
+   */
+  template <
+      typename X, typename Y,
+      typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
+                               has_equivalent_caller<RHS, X, Y>::value &&
+                               (has_valid_matrix_caller<LHS, X, Y>::value ||
+                                has_valid_matrix_caller<RHS, X, Y>::value)),
+                              int>::type = 0>
+  Eigen::MatrixXd _call_matrix_impl(const std::vector<X> &xs,
+                                    const std::vector<Y> &ys) const {
+    return details::compute_covariance_block(this->lhs_, xs, ys)
+        .cwiseProduct(details::compute_covariance_block(this->rhs_, xs, ys));
+  }
+
+  template <typename X, typename Y,
+            typename std::enable_if<(has_equivalent_caller<LHS, X, Y>::value &&
+                                     !has_equivalent_caller<RHS, X, Y>::value &&
+                                     has_valid_matrix_caller<LHS, X, Y>::value),
+                                    int>::type = 0>
+  Eigen::MatrixXd _call_matrix_impl(const std::vector<X> &xs,
+                                    const std::vector<Y> &ys) const {
+    return details::compute_covariance_block(this->lhs_, xs, ys);
+  }
+
+  template <typename X, typename Y,
+            typename std::enable_if<(!has_equivalent_caller<LHS, X, Y>::value &&
+                                     has_equivalent_caller<RHS, X, Y>::value &&
+                                     has_valid_matrix_caller<RHS, X, Y>::value),
+                                    int>::type = 0>
+  Eigen::MatrixXd _call_matrix_impl(const std::vector<X> &xs,
+                                    const std::vector<Y> &ys) const {
+    return details::compute_covariance_block(this->rhs_, xs, ys);
   }
 
   template <typename X,

--- a/include/albatross/src/covariance_functions/covariance_function.hpp
+++ b/include/albatross/src/covariance_functions/covariance_function.hpp
@@ -60,6 +60,20 @@ namespace albatross {
  * CovarianceFunctions (see operator* and operator+).
  *
  */
+namespace details {
+
+/*
+ * Below this many output coefficients the fixed overhead of the matrix
+ * path (feature stacking, GEMM setup, temporaries) outweighs the
+ * vectorization win; the measured crossover is around a 16 x 16 output
+ * on an Apple M series laptop with plain Eigen (see
+ * benchmarks/bench_kernel_assembly.cc).  Kernels without a scalar
+ * _call_impl always use their matrix implementation.
+ */
+constexpr std::size_t MIN_MATRIX_CALL_COEFFICIENTS = 256;
+
+} // namespace details
+
 template <typename Derived>
 class CovarianceFunction : public ParameterHandlingMixin {
 private:
@@ -136,6 +150,10 @@ public:
    * path is taken any ThreadPool argument is intentionally ignored;
    * matrix implementations are expected to rely on Eigen's internally
    * vectorized (BLAS-like) kernels which don't benefit from the pool.
+   *
+   * For small outputs the fixed overhead of the matrix path exceeds the
+   * vectorization win so (when a scalar fallback exists) tiny requests
+   * stay on the per-pair path, see MIN_MATRIX_CALL_COEFFICIENTS.
    */
   template <typename X,
             typename std::enable_if<
@@ -143,6 +161,14 @@ public:
   Eigen::MatrixXd operator()(const std::vector<X> &xs,
                              ThreadPool * /* pool: unused, see above */
                              = nullptr) const {
+    if constexpr (has_valid_caller<Derived, X, X>::value) {
+      if (xs.size() * xs.size() < details::MIN_MATRIX_CALL_COEFFICIENTS) {
+        auto caller = [&](const auto &x, const auto &y) {
+          return this->call(x, y);
+        };
+        return compute_covariance_matrix(caller, xs);
+      }
+    }
     Eigen::MatrixXd cov = derived()._call_matrix_impl(xs, xs);
     // The per-pair path guarantees an exactly symmetric matrix; a GEMM
     // based implementation may differ in the last ulp between (i, j)
@@ -209,6 +235,14 @@ public:
   Eigen::MatrixXd operator()(const std::vector<X> &xs, const std::vector<Y> &ys,
                              ThreadPool * /* pool: unused, see above */
                              = nullptr) const {
+    if constexpr (has_valid_caller<Derived, X, Y>::value) {
+      if (xs.size() * ys.size() < details::MIN_MATRIX_CALL_COEFFICIENTS) {
+        auto caller = [&](const auto &x, const auto &y) {
+          return this->call(x, y);
+        };
+        return compute_covariance_matrix(caller, xs, ys);
+      }
+    }
     return derived()._call_matrix_impl(xs, ys);
   }
 

--- a/include/albatross/src/covariance_functions/radial.hpp
+++ b/include/albatross/src/covariance_functions/radial.hpp
@@ -32,6 +32,40 @@ inline double squared_exponential_covariance(double distance,
   return sigma * sigma * exp(-pow(distance / length_scale, 2));
 }
 
+/*
+ * Matrix-level evaluation of the squared exponential kernel for feature
+ * coordinate matrices X (d x n) and Y (d x m).
+ *
+ * The pairwise squared distances are formed with a single GEMM via
+ *
+ *   D2(i, j) = ||x_i||^2 + ||y_j||^2 - 2 x_i . y_j
+ *
+ * followed by one vectorized exp, instead of one scalar kernel call per
+ * pair.  The scalar path computes sigma^2 exp(-(d / l)^2) with d the
+ * Euclidean distance, which is exactly d^2 / l^2 in the exponent, so the
+ * two paths agree up to floating point rounding (the GEMM formulation
+ * can differ from the scalar one in the last ulps, and loses accuracy
+ * when feature norms are large relative to their separations).
+ */
+inline Eigen::MatrixXd
+squared_exponential_covariance_matrix(const Eigen::MatrixXd &X,
+                                      const Eigen::MatrixXd &Y,
+                                      double length_scale, double sigma = 1.) {
+  if (length_scale <= 0.) {
+    return Eigen::MatrixXd::Zero(X.cols(), Y.cols());
+  }
+  Eigen::MatrixXd D2 = -2. * (X.transpose() * Y);
+  const Eigen::VectorXd x_sq = X.colwise().squaredNorm().transpose();
+  const Eigen::RowVectorXd y_sq = Y.colwise().squaredNorm();
+  D2.colwise() += x_sq;
+  D2.rowwise() += y_sq;
+  // Cancellation in the GEMM can produce tiny negative squared
+  // distances for (near) identical features; clamp them to zero.
+  D2 = D2.cwiseMax(0.);
+  return (sigma * sigma) *
+         (-D2 / (length_scale * length_scale)).array().exp().matrix();
+}
+
 template <typename RadialFunction>
 inline double process_noise_equivalent(RadialFunction func, double distance) {
   // to get the increase in standard deviation over a given distance we can
@@ -183,6 +217,69 @@ public:
     return squared_exponential_covariance(
         distance, squared_exponential_length_scale.value,
         sigma_squared_exponential.value);
+  }
+
+  /*
+   * Matrix-level (vectorized) evaluation, see
+   * squared_exponential_covariance_matrix and the dispatch in
+   * CovarianceFunction::operator().  Only enabled when the distance
+   * metric is the EuclideanDistance since the GEMM based pairwise
+   * distance formula only holds for that metric.
+   */
+  template <
+      typename _Scalar, int _Rows, typename Metric = DistanceMetricType,
+      typename std::enable_if<(std::is_same<Metric, EuclideanDistance>::value &&
+                               std::is_same<_Scalar, double>::value),
+                              int>::type = 0>
+  Eigen::MatrixXd _call_matrix_impl(
+      const std::vector<Eigen::Matrix<_Scalar, _Rows, 1>> &xs,
+      const std::vector<Eigen::Matrix<_Scalar, _Rows, 1>> &ys) const {
+    static_assert(std::is_same<Metric, DistanceMetricType>::value,
+                  "Metric is an implementation detail, never override it");
+    const Eigen::Index n = cast::to_index(xs.size());
+    const Eigen::Index m = cast::to_index(ys.size());
+    if (n == 0 || m == 0) {
+      return Eigen::MatrixXd::Zero(n, m);
+    }
+    const Eigen::Index d = xs[0].size();
+    Eigen::MatrixXd X(d, n);
+    for (Eigen::Index i = 0; i < n; ++i) {
+      X.col(i) = xs[cast::to_size(i)];
+    }
+    Eigen::MatrixXd Y(d, m);
+    for (Eigen::Index j = 0; j < m; ++j) {
+      Y.col(j) = ys[cast::to_size(j)];
+    }
+    return squared_exponential_covariance_matrix(
+        X, Y, squared_exponential_length_scale.value,
+        sigma_squared_exponential.value);
+  }
+
+  /*
+   * Matrix-level evaluation for scalar features.  Here the pairwise
+   * differences are formed directly (no cancellation-prone GEMM needed)
+   * and the exponential is applied as one vectorized array expression.
+   */
+  template <typename Metric = DistanceMetricType,
+            typename std::enable_if<
+                std::is_same<Metric, EuclideanDistance>::value, int>::type = 0>
+  Eigen::MatrixXd _call_matrix_impl(const std::vector<double> &xs,
+                                    const std::vector<double> &ys) const {
+    static_assert(std::is_same<Metric, DistanceMetricType>::value,
+                  "Metric is an implementation detail, never override it");
+    const Eigen::Index n = cast::to_index(xs.size());
+    const Eigen::Index m = cast::to_index(ys.size());
+    const double length_scale = squared_exponential_length_scale.value;
+    const double sigma = sigma_squared_exponential.value;
+    if (length_scale <= 0. || n == 0 || m == 0) {
+      return Eigen::MatrixXd::Zero(n, m);
+    }
+    const Eigen::Map<const Eigen::VectorXd> xv(xs.data(), n);
+    const Eigen::Map<const Eigen::RowVectorXd> yv(ys.data(), m);
+    const Eigen::MatrixXd D2 =
+        (xv.replicate(1, m) - yv.replicate(n, 1)).array().square();
+    return (sigma * sigma) *
+           (-D2 / (length_scale * length_scale)).array().exp().matrix();
   }
 
   DistanceMetricType distance_metric_;

--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -30,6 +30,27 @@ class has_valid_call_impl
 template <typename U, typename... Args>
 class has_possible_call_impl : public has__call_impl<U, Args &...> {};
 
+DEFINE_CLASS_METHOD_TRAITS(_call_matrix_impl);
+
+/*
+ * has_valid_matrix_caller
+ *
+ * Detects whether a covariance function provides an opt-in matrix-level
+ * evaluation method with signature:
+ *
+ *   Eigen::MatrixXd _call_matrix_impl(const std::vector<X> &,
+ *                                     const std::vector<Y> &) const
+ *
+ * When present, CovarianceFunction::operator()(const std::vector<X>&, ...)
+ * will assemble the covariance matrix with a single (vectorized) call
+ * instead of one scalar _call_impl call per pair of features.
+ */
+template <typename U, typename X, typename Y>
+class has_valid_matrix_caller
+    : public has__call_matrix_impl_with_return_type<
+          const U, Eigen::MatrixXd, typename const_ref<std::vector<X>>::type,
+          typename const_ref<std::vector<Y>>::type> {};
+
 /*
  * has_valid_cov_caller
  */

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -275,6 +275,17 @@ cc_test(
 )
 
 cc_test(
+    name = "albatross-test-matrix-call",
+    srcs = ["test_matrix_call.cc"],
+    additional_compiler_inputs = SANITIZER_INPUTS,
+    copts = TEST_COPTS,
+    linkstatic = True,
+    local_defines = ["CSV_IO_NO_THREAD"],
+    tags = ["unit"],
+    deps = TEST_DEPS,
+)
+
+cc_test(
     name = "albatross-test-misc",
     srcs = [
         "test_call_trace.cc",
@@ -302,6 +313,7 @@ test_suite(
         ":albatross-test-cross-validation",
         ":albatross-test-evaluation",
         ":albatross-test-indexing",
+        ":albatross-test-matrix-call",
         ":albatross-test-misc",
         ":albatross-test-models",
         ":albatross-test-polynomials",

--- a/tests/test_matrix_call.cc
+++ b/tests/test_matrix_call.cc
@@ -202,11 +202,25 @@ TEST(test_matrix_call, test_matrix_matches_per_pair_double) {
   expect_relatively_equal(cov(xs), per_pair_reference(cov, xs, xs));
 }
 
+TEST(test_matrix_call, test_small_sizes_match_per_pair) {
+  // Outputs smaller than MIN_MATRIX_CALL_COEFFICIENTS stay on the
+  // per-pair path, but the matrix implementation itself must remain
+  // correct for tiny inputs.
+  const SqExp cov(2., 1.5);
+  for (std::size_t n : {1, 2, 3, 5, 8}) {
+    const auto xs = random_vector_features(n, 3, 19);
+    const auto ys = random_vector_features(n + 1, 3, 20);
+    expect_relatively_equal(cov(xs, ys), per_pair_reference(cov, xs, ys));
+    expect_relatively_equal(cov._call_matrix_impl(xs, ys),
+                            per_pair_reference(cov, xs, ys));
+  }
+}
+
 TEST(test_matrix_call, test_thread_pool_argument_is_accepted) {
   // When the matrix path is taken the pool is (deliberately) ignored;
   // passing one must give the same result.
   const SqExp cov(2., 1.5);
-  const auto xs = random_vector_features(11, 3, 5);
+  const auto xs = random_vector_features(20, 3, 5);
   auto pool = std::make_shared<ThreadPool>(2);
   const Eigen::MatrixXd with_pool = cov(xs, pool.get());
   const Eigen::MatrixXd without_pool = cov(xs);
@@ -281,11 +295,15 @@ TEST(test_matrix_call, test_nested_composition) {
 
 TEST(test_matrix_call, test_zero_length_scale_guard) {
   const SqExp cov(0., 1.5);
-  const auto xs = random_double_features(7, 13);
-  const auto vs = random_vector_features(7, 3, 13);
+  const auto xs = random_double_features(30, 13);
+  const auto vs = random_vector_features(30, 3, 13);
 
   EXPECT_TRUE(cov(xs).isZero(0.));
   EXPECT_TRUE(cov(vs).isZero(0.));
+  // also through the matrix implementation directly (small inputs
+  // otherwise stay on the per-pair path)
+  EXPECT_TRUE(cov._call_matrix_impl(xs, xs).isZero(0.));
+  EXPECT_TRUE(cov._call_matrix_impl(vs, vs).isZero(0.));
 }
 
 TEST(test_matrix_call, test_empty_features) {
@@ -298,6 +316,11 @@ TEST(test_matrix_call, test_empty_features) {
   EXPECT_EQ(cov(empty, xs).cols(), 5);
   EXPECT_EQ(cov(xs, empty).rows(), 5);
   EXPECT_EQ(cov(xs, empty).cols(), 0);
+  // and through the matrix implementation directly
+  EXPECT_EQ(cov._call_matrix_impl(empty, xs).rows(), 0);
+  EXPECT_EQ(cov._call_matrix_impl(empty, xs).cols(), 5);
+  EXPECT_EQ(cov._call_matrix_impl(xs, empty).rows(), 5);
+  EXPECT_EQ(cov._call_matrix_impl(xs, empty).cols(), 0);
 }
 
 template <typename CovFunc>

--- a/tests/test_matrix_call.cc
+++ b/tests/test_matrix_call.cc
@@ -1,0 +1,374 @@
+/*
+ * Copyright (C) 2026 Swift Navigation Inc.
+ * Contact: Swift Navigation <dev@swiftnav.com>
+ *
+ * This source is subject to the license found in the file 'LICENSE' which must
+ * be distributed together with this source. All other rights reserved.
+ *
+ * THIS CODE AND INFORMATION IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+ * EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <albatross/GP>
+#include <gtest/gtest.h>
+
+#include <random>
+
+namespace albatross {
+namespace {
+
+/*
+ * A squared exponential clone WITHOUT a _call_matrix_impl which is used
+ * as the (unchanged) per-pair reference implementation.
+ */
+class ReferenceSquaredExponential
+    : public CovarianceFunction<ReferenceSquaredExponential> {
+public:
+  explicit ReferenceSquaredExponential(double length_scale = 1.,
+                                       double sigma = 1.)
+      : length_scale_(length_scale), sigma_(sigma) {}
+
+  std::string name() const { return "reference_squared_exponential"; }
+
+  template <
+      typename X,
+      typename std::enable_if<
+          has_call_operator<EuclideanDistance, X &, X &>::value, int>::type = 0>
+  double _call_impl(const X &x, const X &y) const {
+    return squared_exponential_covariance(distance_metric_(x, y), length_scale_,
+                                          sigma_);
+  }
+
+  EuclideanDistance distance_metric_;
+  double length_scale_;
+  double sigma_;
+};
+
+/*
+ * A scalar-only test kernel used to exercise composition with a
+ * matrix-capable kernel.
+ */
+class OnePlusDotProduct : public CovarianceFunction<OnePlusDotProduct> {
+public:
+  std::string name() const { return "one_plus_dot_product"; }
+
+  double _call_impl(const Eigen::VectorXd &x, const Eigen::VectorXd &y) const {
+    return 1. + x.dot(y);
+  }
+
+  double _call_impl(const double &x, const double &y) const {
+    return 1. + x * y;
+  }
+};
+
+std::vector<Eigen::VectorXd> random_vector_features(std::size_t n,
+                                                    Eigen::Index dimension,
+                                                    std::uint32_t seed) {
+  std::mt19937 gen(seed);
+  std::uniform_real_distribution<double> dist(-3., 3.);
+  std::vector<Eigen::VectorXd> features(n);
+  for (auto &f : features) {
+    f.resize(dimension);
+    for (Eigen::Index i = 0; i < dimension; ++i) {
+      f[i] = dist(gen);
+    }
+  }
+  return features;
+}
+
+std::vector<double> random_double_features(std::size_t n, std::uint32_t seed) {
+  std::mt19937 gen(seed);
+  std::uniform_real_distribution<double> dist(0., 10.);
+  std::vector<double> features(n);
+  for (auto &f : features) {
+    f = dist(gen);
+  }
+  return features;
+}
+
+// The matrix path forms squared distances through a GEMM which can
+// differ from the scalar path in the last ulps; comparisons therefore
+// use a relative tolerance rather than exact equality.
+void expect_relatively_equal(const Eigen::MatrixXd &actual,
+                             const Eigen::MatrixXd &expected,
+                             double relative_tolerance = 1.e-10) {
+  ASSERT_EQ(actual.rows(), expected.rows());
+  ASSERT_EQ(actual.cols(), expected.cols());
+  for (Eigen::Index i = 0; i < actual.rows(); ++i) {
+    for (Eigen::Index j = 0; j < actual.cols(); ++j) {
+      const double scale = std::max(1., std::fabs(expected(i, j)));
+      EXPECT_NEAR(actual(i, j), expected(i, j), relative_tolerance * scale)
+          << "at (" << i << ", " << j << ")";
+    }
+  }
+}
+
+template <typename CovFunc, typename X, typename Y>
+Eigen::MatrixXd per_pair_reference(const CovFunc &cov, const std::vector<X> &xs,
+                                   const std::vector<Y> &ys) {
+  Eigen::MatrixXd expected(cast::to_index(xs.size()),
+                           cast::to_index(ys.size()));
+  for (std::size_t i = 0; i < xs.size(); ++i) {
+    for (std::size_t j = 0; j < ys.size(); ++j) {
+      expected(cast::to_index(i), cast::to_index(j)) = cov(xs[i], ys[j]);
+    }
+  }
+  return expected;
+}
+
+using SqExp = SquaredExponential<EuclideanDistance>;
+
+TEST(test_matrix_call, test_trait_detection) {
+  // The flagship implementation is enabled for Eigen vectors and doubles
+  // with the Euclidean distance ...
+  static_assert(
+      has_valid_matrix_caller<SqExp, Eigen::VectorXd, Eigen::VectorXd>::value,
+      "expected matrix caller for Eigen::VectorXd");
+  static_assert(
+      has_valid_matrix_caller<SqExp, Eigen::Vector3d, Eigen::Vector3d>::value,
+      "expected matrix caller for fixed size Eigen vectors");
+  static_assert(has_valid_matrix_caller<SqExp, double, double>::value,
+                "expected matrix caller for double");
+  // ... but not for other distance metrics, other feature types, or
+  // kernels which never opted in.
+  static_assert(
+      !has_valid_matrix_caller<SquaredExponential<RadialDistance>,
+                               Eigen::VectorXd, Eigen::VectorXd>::value,
+      "matrix caller should require EuclideanDistance");
+  static_assert(!has_valid_matrix_caller<SqExp, Measurement<double>,
+                                         Measurement<double>>::value,
+                "no matrix caller for wrapped types");
+  static_assert(
+      !has_valid_matrix_caller<ReferenceSquaredExponential, Eigen::VectorXd,
+                               Eigen::VectorXd>::value,
+      "reference kernel must not have a matrix caller");
+  static_assert(
+      !has_valid_matrix_caller<Exponential<EuclideanDistance>, Eigen::VectorXd,
+                               Eigen::VectorXd>::value,
+      "only the squared exponential opted in");
+
+  // Compositions forward the matrix implementation when at least one
+  // side has one and both sides stay consistent with the scalar path.
+  using SumWithNoise =
+      SumOfCovarianceFunctions<SqExp, IndependentNoise<double>>;
+  static_assert(has_valid_matrix_caller<SumWithNoise, double, double>::value,
+                "sum should forward the matrix caller");
+  static_assert(!has_valid_matrix_caller<SumWithNoise, Measurement<double>,
+                                         Measurement<double>>::value,
+                "no matrix caller through Measurement<> for compositions");
+  using ProductWithDot = ProductOfCovarianceFunctions<SqExp, OnePlusDotProduct>;
+  static_assert(has_valid_matrix_caller<ProductWithDot, Eigen::VectorXd,
+                                        Eigen::VectorXd>::value,
+                "product should forward the matrix caller");
+  using SumOfReferences =
+      SumOfCovarianceFunctions<ReferenceSquaredExponential, OnePlusDotProduct>;
+  static_assert(!has_valid_matrix_caller<SumOfReferences, Eigen::VectorXd,
+                                         Eigen::VectorXd>::value,
+                "compositions of per-pair kernels stay per-pair");
+}
+
+TEST(test_matrix_call, test_matrix_matches_per_pair_cross) {
+  const SqExp cov(2., 1.5);
+  const auto xs = random_vector_features(25, 3, 0);
+  const auto ys = random_vector_features(17, 3, 1);
+
+  expect_relatively_equal(cov(xs, ys), per_pair_reference(cov, xs, ys));
+}
+
+TEST(test_matrix_call, test_matrix_matches_per_pair_symmetric) {
+  const SqExp cov(2., 1.5);
+  auto xs = random_vector_features(25, 3, 2);
+  // include an exact duplicate to exercise the diagonal / clamping
+  xs.push_back(xs[3]);
+
+  const Eigen::MatrixXd actual = cov(xs);
+  expect_relatively_equal(actual, per_pair_reference(cov, xs, xs));
+
+  // the vectorized path must stay exactly symmetric like the per-pair one
+  for (Eigen::Index i = 0; i < actual.rows(); ++i) {
+    for (Eigen::Index j = 0; j < actual.cols(); ++j) {
+      EXPECT_EQ(actual(i, j), actual(j, i));
+    }
+  }
+}
+
+TEST(test_matrix_call, test_matrix_matches_per_pair_double) {
+  const SqExp cov(2., 1.5);
+  const auto xs = random_double_features(31, 3);
+  const auto ys = random_double_features(19, 4);
+
+  expect_relatively_equal(cov(xs, ys), per_pair_reference(cov, xs, ys));
+  expect_relatively_equal(cov(xs), per_pair_reference(cov, xs, xs));
+}
+
+TEST(test_matrix_call, test_thread_pool_argument_is_accepted) {
+  // When the matrix path is taken the pool is (deliberately) ignored;
+  // passing one must give the same result.
+  const SqExp cov(2., 1.5);
+  const auto xs = random_vector_features(11, 3, 5);
+  auto pool = std::make_shared<ThreadPool>(2);
+  const Eigen::MatrixXd with_pool = cov(xs, pool.get());
+  const Eigen::MatrixXd without_pool = cov(xs);
+  EXPECT_EQ(with_pool, without_pool);
+}
+
+TEST(test_matrix_call, test_measurement_unwrapping) {
+  const SqExp cov(2., 1.5);
+  const auto xs = random_double_features(21, 6);
+  const auto measurements = as_measurements(xs);
+
+  // A plain (leaf) kernel with no Measurement<> specific behavior takes
+  // the matrix path for measurements by stripping the wrapper.
+  expect_relatively_equal(cov(measurements),
+                          per_pair_reference(cov, measurements, measurements));
+  EXPECT_EQ(cov(measurements), cov(xs));
+}
+
+TEST(test_matrix_call, test_sum_composition) {
+  const SqExp sq_exp(2., 1.5);
+  const IndependentNoise<double> noise(0.25);
+  const auto sum = sq_exp + noise;
+
+  auto xs = random_double_features(23, 7);
+  // duplicate a feature so the noise term contributes off-diagonal
+  xs.push_back(xs[5]);
+  const auto ys = random_double_features(13, 8);
+
+  expect_relatively_equal(sum(xs, ys), per_pair_reference(sum, xs, ys));
+  expect_relatively_equal(sum(xs), per_pair_reference(sum, xs, xs));
+
+  // Measurement<> features (the fit path) fall back to the unchanged
+  // per-pair evaluation for compositions; results must be identical.
+  const auto measurements = as_measurements(xs);
+  const Eigen::MatrixXd actual = sum(measurements);
+  const Eigen::MatrixXd expected =
+      per_pair_reference(sum, measurements, measurements);
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(test_matrix_call, test_product_composition) {
+  const SqExp sq_exp(2., 1.5);
+  const OnePlusDotProduct dot;
+  const auto product = sq_exp * dot;
+
+  const auto xs = random_vector_features(21, 3, 9);
+  const auto ys = random_vector_features(14, 3, 10);
+
+  expect_relatively_equal(product(xs, ys), per_pair_reference(product, xs, ys));
+  expect_relatively_equal(product(xs), per_pair_reference(product, xs, xs));
+}
+
+TEST(test_matrix_call, test_nested_composition) {
+  // k1 * k2 + k3 with only k1 matrix-capable benefits term-wise.
+  const SqExp sq_exp(2., 1.5);
+  const OnePlusDotProduct dot;
+  const IndependentNoise<double> noise(0.25);
+  const auto composed = sq_exp * dot + noise;
+
+  static_assert(
+      has_valid_matrix_caller<decltype(composed), double, double>::value,
+      "nested composition should forward the matrix caller");
+
+  auto xs = random_double_features(23, 11);
+  xs.push_back(xs[0]);
+  const auto ys = random_double_features(17, 12);
+
+  expect_relatively_equal(composed(xs, ys),
+                          per_pair_reference(composed, xs, ys));
+  expect_relatively_equal(composed(xs), per_pair_reference(composed, xs, xs));
+}
+
+TEST(test_matrix_call, test_zero_length_scale_guard) {
+  const SqExp cov(0., 1.5);
+  const auto xs = random_double_features(7, 13);
+  const auto vs = random_vector_features(7, 3, 13);
+
+  EXPECT_TRUE(cov(xs).isZero(0.));
+  EXPECT_TRUE(cov(vs).isZero(0.));
+}
+
+TEST(test_matrix_call, test_empty_features) {
+  const SqExp cov(2., 1.5);
+  const std::vector<Eigen::VectorXd> empty;
+  const auto xs = random_vector_features(5, 3, 14);
+
+  EXPECT_EQ(cov(empty).rows(), 0);
+  EXPECT_EQ(cov(empty, xs).rows(), 0);
+  EXPECT_EQ(cov(empty, xs).cols(), 5);
+  EXPECT_EQ(cov(xs, empty).rows(), 5);
+  EXPECT_EQ(cov(xs, empty).cols(), 0);
+}
+
+template <typename CovFunc>
+RegressionDataset<double> toy_dataset(const CovFunc &, std::uint32_t seed) {
+  const auto features = random_double_features(60, seed);
+  Eigen::VectorXd targets(cast::to_index(features.size()));
+  for (std::size_t i = 0; i < features.size(); ++i) {
+    targets[cast::to_index(i)] =
+        std::sin(features[i]) + 0.1 * std::cos(10. * features[i]);
+  }
+  const Eigen::VectorXd variance =
+      Eigen::VectorXd::Constant(targets.size(), 0.01);
+  return RegressionDataset<double>(features,
+                                   MarginalDistribution(targets, variance));
+}
+
+TEST(test_matrix_call, test_gp_end_to_end) {
+  // The same GP with a matrix-capable kernel and with the per-pair
+  // reference kernel must produce (numerically) identical predictions.
+  const SqExp matrix_kernel(2., 1.5);
+  const ReferenceSquaredExponential reference_kernel(2., 1.5);
+
+  auto matrix_model = gp_from_covariance(matrix_kernel, "matrix_gp");
+  auto reference_model = gp_from_covariance(reference_kernel, "reference_gp");
+
+  const auto dataset = toy_dataset(matrix_kernel, 15);
+  const auto test_features = random_double_features(29, 16);
+
+  const auto matrix_fit = matrix_model.fit(dataset);
+  const auto reference_fit = reference_model.fit(dataset);
+
+  const auto matrix_pred = matrix_fit.predict(test_features);
+  const auto reference_pred = reference_fit.predict(test_features);
+
+  const Eigen::VectorXd mean_diff = matrix_pred.mean() - reference_pred.mean();
+  EXPECT_LT(mean_diff.array().abs().maxCoeff(), 1.e-8);
+
+  const auto matrix_marginal = matrix_pred.marginal();
+  const auto reference_marginal = reference_pred.marginal();
+  EXPECT_LT(
+      (matrix_marginal.mean - reference_marginal.mean).array().abs().maxCoeff(),
+      1.e-8);
+  EXPECT_LT((matrix_marginal.covariance.diagonal() -
+             reference_marginal.covariance.diagonal())
+                .array()
+                .abs()
+                .maxCoeff(),
+            1.e-8);
+
+  const auto matrix_joint = matrix_pred.joint();
+  const auto reference_joint = reference_pred.joint();
+  EXPECT_LT((matrix_joint.mean - reference_joint.mean).array().abs().maxCoeff(),
+            1.e-8);
+  EXPECT_LT((matrix_joint.covariance - reference_joint.covariance)
+                .array()
+                .abs()
+                .maxCoeff(),
+            1.e-8);
+}
+
+TEST(test_matrix_call, test_per_pair_fallback_unchanged) {
+  // A kernel without _call_matrix_impl must keep going through the
+  // per-pair path and produce bit-for-bit identical results to a direct
+  // scalar loop.
+  const ReferenceSquaredExponential cov(2., 1.5);
+  const auto xs = random_vector_features(15, 3, 17);
+  const auto ys = random_vector_features(9, 3, 18);
+
+  EXPECT_EQ(cov(xs, ys), per_pair_reference(cov, xs, ys));
+  EXPECT_EQ(cov(xs), per_pair_reference(cov, xs, xs));
+}
+
+} // namespace
+} // namespace albatross


### PR DESCRIPTION
Covariance assembly currently fills K one scalar `k(x, y)` call at a time — a loop that never becomes a BLAS call, and the dominant cost of GP mean prediction. 

This adds an opt-in whole-matrix kernel path while leaving the per-pair path bit-for-bit unchanged as the fallback.

## Implementation

- **Trait + dispatch:** `has_valid_matrix_caller<CovFunc, X, Y>` detects an optional `Eigen::MatrixXd _call_matrix_impl(const std::vector<X>&, const std::vector<Y>&) const`; `CovarianceFunction::operator()` uses it when present (ThreadPool argument deliberately ignored on this path). Bitwise-fallback test guarantees kernels without the method are unaffected.
- **Composition:** `Sum`/`Product` combine per-term blocks (`+` / `cwiseProduct`), so composed kernels benefit term-wise even when some terms are scalar-only.
- **Flagship kernel:** `SquaredExponential<EuclideanDistance>` — pairwise squared distances via one GEMM (`||x||² + ||y||² − 2XᵀY`, clamped at 0 against cancellation) plus one vectorized exp. `double` features use direct differences.
- **Small-n threshold:** below ~16×16 outputs (measured crossover; raw matrix path was 2.5x slower at n=4) evaluation stays per-pair.
- **`Measurement<>`:** unwrapped for leaf kernels; composed kernels take the matrix path on predict (train features are stored unwrapped) and per-pair on fit.

⚠️ `SquaredExponential` covariance values change in the last ulps (GEMM evaluation order). No existing test needed tolerance changes.

## Results (Apple M-series, plain Eigen, -c opt, median of 5)

| n=m | assembly per-pair | assembly matrix | speedup | GP mean predict per-pair | matrix | speedup |
|---|---|---|---|---|---|---|
| 256 | 202.4 µs | 171.3 µs | **1.18x** | 0.203 ms | 0.182 ms | **1.12x** |
| 512 | 821.6 µs | 679.4 µs | **1.21x** | 0.798 ms | 0.724 ms | **1.10x** |
| 1024 | 3.60 ms | 2.73 ms | **1.32x** | 3.91 ms | 2.86 ms | **1.37x** |
| 2048 | 20.94 ms | 11.38 ms | **1.84x** | 22.6 ms | 11.9 ms | **1.90x** |

On this machine the computation is exp-bound (Apple libm exp ≈3 ns/pair; NEON is 2-wide for doubles), capping the gain near 2x. Linux/MKL (wider SIMD, `vdExp`, MKL GEMM) should do considerably better — worth benchmarking there before drawing conclusions.

Note: `//tests:albatross-test-stats-scores` fails identically on the parent commit (pre-existing Monte Carlo flake, unrelated).

Stacked on #591.