### PR TITLE
Revert "Use symmetric rank updates for structurally symmetric Gram products" (#595)

### DIFF
--- a/include/albatross/src/covariance_functions/traits.hpp
+++ b/include/albatross/src/covariance_functions/traits.hpp
@@ -83,8 +83,6 @@ public:
 
 DEFINE_CLASS_METHOD_TRAITS(solve);
 
-DEFINE_CLASS_METHOD_TRAITS(sqrt_solve);
-
 DEFINE_CLASS_METHOD_TRAITS(_ssr_impl);
 
 template <typename T, typename FeatureType> class has_valid_ssr_impl {

--- a/include/albatross/src/models/gp.hpp
+++ b/include/albatross/src/models/gp.hpp
@@ -100,45 +100,6 @@ gp_marginal_prediction(const Eigen::MatrixXd &cross_cov,
   return MarginalDistribution(pred, marginal_variance);
 }
 
-/*
- * Computes X^T X exploiting symmetry: a BLAS style rank update fills
- * the lower triangle with half the flops of a general matrix product,
- * after which the full symmetric matrix is materialized.
- */
-inline Eigen::MatrixXd symmetric_transpose_product(const Eigen::MatrixXd &X) {
-  Eigen::MatrixXd product = Eigen::MatrixXd::Zero(X.cols(), X.cols());
-  product.selfadjointView<Eigen::Lower>().rankUpdate(X.transpose());
-  return Eigen::MatrixXd(product.selfadjointView<Eigen::Lower>());
-}
-
-/*
- * The explained covariance, cross_cov^T K^-1 cross_cov, is symmetric.
- * When the covariance representation provides a matrix square root
- * solve we can form S = K^-1/2 cross_cov and compute S^T S with a
- * symmetric rank update (one triangular solve and half the product
- * flops); otherwise fall back to the generic solve based product.
- */
-template <typename CovarianceRepresentation,
-          std::enable_if_t<
-              has_sqrt_solve<CovarianceRepresentation, Eigen::MatrixXd>::value,
-              int> = 0>
-inline Eigen::MatrixXd
-gp_explained_covariance(const Eigen::MatrixXd &cross_cov,
-                        const CovarianceRepresentation &train_covariance) {
-  const Eigen::MatrixXd sqrt = train_covariance.sqrt_solve(cross_cov);
-  return symmetric_transpose_product(sqrt);
-}
-
-template <typename CovarianceRepresentation,
-          std::enable_if_t<
-              !has_sqrt_solve<CovarianceRepresentation, Eigen::MatrixXd>::value,
-              int> = 0>
-inline Eigen::MatrixXd
-gp_explained_covariance(const Eigen::MatrixXd &cross_cov,
-                        const CovarianceRepresentation &train_covariance) {
-  return cross_cov.transpose() * train_covariance.solve(cross_cov);
-}
-
 template <typename CovarianceRepresentation>
 inline JointDistribution
 gp_joint_prediction(const Eigen::MatrixXd &cross_cov,
@@ -146,8 +107,8 @@ gp_joint_prediction(const Eigen::MatrixXd &cross_cov,
                     const Eigen::VectorXd &information,
                     const CovarianceRepresentation &train_covariance) {
   const Eigen::VectorXd pred = gp_mean_prediction(cross_cov, information);
-  const Eigen::MatrixXd explained_cov =
-      gp_explained_covariance(cross_cov, train_covariance);
+  Eigen::MatrixXd explained_cov =
+      cross_cov.transpose() * train_covariance.solve(cross_cov);
   return JointDistribution(pred, prior_cov - explained_cov);
 }
 
@@ -353,10 +314,9 @@ public:
               const std::vector<FeatureType> &features,
               const GPFitType<CovarianceRepresentation, FitFeaturetype> &gp_fit,
               PredictTypeIdentity<JointDistribution> &&) const {
-    const auto cross_cov = covariance_function_(gp_fit.train_features, features,
-                                                Base::threads_.get());
-    Eigen::MatrixXd prior_cov =
-        covariance_function_(features, Base::threads_.get());
+    const auto cross_cov =
+        covariance_function_(gp_fit.train_features, features);
+    Eigen::MatrixXd prior_cov = covariance_function_(features);
     auto pred = gp_joint_prediction(cross_cov, prior_cov, gp_fit.information,
                                     gp_fit.train_covariance);
     mean_function_.add_to(features, &pred.mean);
@@ -374,10 +334,8 @@ public:
       const std::vector<FeatureType> &features,
       const GPFitType<CovarianceRepresentation, FitFeaturetype> &gp_fit,
       PredictTypeIdentity<MarginalDistribution> &&) const {
-    const auto cross_cov = covariance_function_(gp_fit.train_features, features,
-                                                Base::threads_.get());
-    // Note: the scalar prior variance calls below intentionally stay
-    // serial; they are cheap relative to the cross covariance.
+    const auto cross_cov =
+        covariance_function_(gp_fit.train_features, features);
     Eigen::VectorXd prior_variance(cast::to_index(features.size()));
     for (Eigen::Index i = 0; i < prior_variance.size(); ++i) {
       prior_variance[i] = covariance_function_(features[cast::to_size(i)],
@@ -400,8 +358,8 @@ public:
       const std::vector<FeatureType> &features,
       const GPFitType<CovarianceRepresentation, FitFeaturetype> &gp_fit,
       PredictTypeIdentity<Eigen::VectorXd> &&) const {
-    const auto cross_cov = covariance_function_(gp_fit.train_features, features,
-                                                Base::threads_.get());
+    const auto cross_cov =
+        covariance_function_(gp_fit.train_features, features);
     auto pred = gp_mean_prediction(cross_cov, gp_fit.information);
     mean_function_.add_to(features, &pred);
     return pred;
@@ -462,15 +420,14 @@ public:
   template <typename FeatureType>
   JointDistribution prior(const std::vector<FeatureType> &features) const {
     const auto measurement_features = as_measurements(features);
-    return JointDistribution(
-        mean_function_(measurement_features),
-        covariance_function_(measurement_features, Base::threads_.get()));
+    return JointDistribution(mean_function_(measurement_features),
+                             covariance_function_(measurement_features));
   }
 
   template <typename FeatureType>
   Eigen::MatrixXd
   compute_covariance(const std::vector<FeatureType> &features) const {
-    return covariance_function_(features, Base::threads_.get());
+    return covariance_function_(features);
   }
 
   template <typename FeatureType,
@@ -487,8 +444,7 @@ public:
     Eigen::VectorXd zero_mean(dataset.targets.mean);
     const auto measurement_features = as_measurements(dataset.features);
     mean_function_.remove_from(measurement_features, &zero_mean);
-    const Eigen::MatrixXd cov =
-        covariance_function_(measurement_features, Base::threads_.get());
+    const Eigen::MatrixXd cov = covariance_function_(measurement_features);
     double ll = -negative_log_likelihood(zero_mean, cov);
     ll += this->prior_log_likelihood();
     return ll;

--- a/include/albatross/src/models/sparse_gp.hpp
+++ b/include/albatross/src/models/sparse_gp.hpp
@@ -469,8 +469,8 @@ public:
   _predict_impl(const std::vector<FeatureType> &features,
                 const Fit<SparseGPFit<FitFeaturetype>> &sparse_gp_fit,
                 PredictTypeIdentity<Eigen::VectorXd> &&) const {
-    const auto cross_cov = this->covariance_function_(
-        sparse_gp_fit.train_features, features, Base::threads_.get());
+    const auto cross_cov =
+        this->covariance_function_(sparse_gp_fit.train_features, features);
     Eigen::VectorXd mean =
         gp_mean_prediction(cross_cov, sparse_gp_fit.information);
     this->mean_function_.add_to(features, &mean);
@@ -482,14 +482,12 @@ public:
   _predict_impl(const std::vector<FeatureType> &features,
                 const Fit<SparseGPFit<FitFeaturetype>> &sparse_gp_fit,
                 PredictTypeIdentity<MarginalDistribution> &&) const {
-    const auto cross_cov = this->covariance_function_(
-        sparse_gp_fit.train_features, features, Base::threads_.get());
+    const auto cross_cov =
+        this->covariance_function_(sparse_gp_fit.train_features, features);
     Eigen::VectorXd mean =
         gp_mean_prediction(cross_cov, sparse_gp_fit.information);
     this->mean_function_.add_to(features, &mean);
 
-    // Note: the scalar prior variance calls below intentionally stay
-    // serial; they are cheap relative to the cross covariance.
     Eigen::VectorXd marginal_variance(cast::to_index(features.size()));
     for (Eigen::Index i = 0; i < marginal_variance.size(); ++i) {
       marginal_variance[i] = this->covariance_function_(
@@ -516,10 +514,9 @@ public:
   _predict_impl(const std::vector<FeatureType> &features,
                 const Fit<SparseGPFit<FitFeaturetype>> &sparse_gp_fit,
                 PredictTypeIdentity<JointDistribution> &&) const {
-    const auto cross_cov = this->covariance_function_(
-        sparse_gp_fit.train_features, features, Base::threads_.get());
-    const Eigen::MatrixXd prior_cov =
-        this->covariance_function_(features, Base::threads_.get());
+    const auto cross_cov =
+        this->covariance_function_(sparse_gp_fit.train_features, features);
+    const Eigen::MatrixXd prior_cov = this->covariance_function_(features);
 
     const Eigen::MatrixXd S_sqrt =
         sqrt_solve(sparse_gp_fit.R, sparse_gp_fit.P, cross_cov);
@@ -527,18 +524,9 @@ public:
     const Eigen::MatrixXd Q_sqrt =
         sparse_gp_fit.train_covariance.sqrt_solve(cross_cov);
 
-    // Both corrections are symmetric Gram products, so accumulate
-    // S_sqrt^T S_sqrt - Q_sqrt^T Q_sqrt in the lower triangle with
-    // rank updates (half the flops, one accumulator, no temporaries
-    // for the two full products).
-    Eigen::MatrixXd correction =
-        Eigen::MatrixXd::Zero(prior_cov.rows(), prior_cov.cols());
-    correction.selfadjointView<Eigen::Lower>().rankUpdate(S_sqrt.transpose(),
-                                                          1.);
-    correction.selfadjointView<Eigen::Lower>().rankUpdate(Q_sqrt.transpose(),
-                                                          -1.);
-    Eigen::MatrixXd covariance = prior_cov;
-    covariance += Eigen::MatrixXd(correction.selfadjointView<Eigen::Lower>());
+    const Eigen::MatrixXd max_explained = Q_sqrt.transpose() * Q_sqrt;
+    const Eigen::MatrixXd unexplained = S_sqrt.transpose() * S_sqrt;
+    const Eigen::MatrixXd covariance = prior_cov - max_explained + unexplained;
 
     JointDistribution pred(cross_cov.transpose() * sparse_gp_fit.information,
                            covariance);
@@ -701,11 +689,7 @@ private:
     for (const auto &pair : indexer) {
       Eigen::Index cols = cast::to_index(pair.second.size());
       auto P_cols = P.block(0, i, P.rows(), cols);
-      // P_cols^T P_cols is symmetric; use a rank update on the lower
-      // triangle and materialize the full block.
-      Eigen::MatrixXd block = Eigen::MatrixXd::Zero(cols, cols);
-      block.selfadjointView<Eigen::Lower>().rankUpdate(P_cols.transpose());
-      Q_ff_diag.blocks.emplace_back(block.selfadjointView<Eigen::Lower>());
+      Q_ff_diag.blocks.emplace_back(P_cols.transpose() * P_cols);
       i += cols;
     }
     auto A = K_ff - Q_ff_diag;


### PR DESCRIPTION
## Summary

Reverts #595 (dd2166c), slows down some useful sparse gp problems.

A likely mechanism is that Eigen's `selfadjointView::rankUpdate` (SYRK-style) kernel is considerably less optimized than its GEMM path, so halving the flops does not translate into a speedup in practice.